### PR TITLE
chore: ignore local env and vercel artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ pnpm-debug.log*
 /copy2.jsx
 
 # Local-only docs
+.vercel
+.env*.local

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local


### PR DESCRIPTION
## Goal
Ignore local env and Vercel artifacts.

## Key Changes
- Add `.env*.local` and `.vercel` ignores at repo root
- Add `dashboard/.gitignore` for same

## Verification
- git status --short

## Regression Gate
- Most likely break: none (no runtime logic)
- Verified: git status clean
- Not verified: n/a
