### PR TITLE
chore(release): 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-12-26
+### Fixed
+- Preserve per-model half-hour buckets (avoid collapsing multi-model hours into `unknown`).
+
 ## [0.1.0] - 2025-12-26
 ### Added
 - Gemini CLI session parsing from `~/.gemini/tmp/**/chats/session-*.json` with UTC half-hour aggregation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibescore/tracker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibescore/tracker",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@insforge/sdk": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibescore/tracker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Codex CLI token usage tracker (macOS-first, notify-driven).",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump CLI version to 0.1.1
- Add CHANGELOG entry for per-model bucket fix

## Test Plan
- [x] npm test
- [x] node scripts/acceptance/npm-install-smoke.cjs
- [ ] npm publish --access public (blocked: requires OTP)
