### PR TITLE
Collapse CORE_INDEX breakdown modules by default

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -98,6 +98,10 @@ identity_panel.rank_placeholder,ui,IdentityPanel,IdentityPanel,rank_placeholder,
 identity_panel.streak_value,ui,IdentityPanel,IdentityPanel,streak_value,"{{days}}_DAYS",,active
 
 usage.panel.title,ui,UsagePanel,UsagePanel,title,"CORE_INDEX",,active
+dashboard.core_index.collapse_label,dashboard,DashboardPage,UsagePanel,toggle,"▾",,active
+dashboard.core_index.expand_label,dashboard,DashboardPage,UsagePanel,toggle,"▸",,active
+dashboard.core_index.collapse_aria,dashboard,DashboardPage,UsagePanel,toggle_aria,"Collapse CORE_INDEX breakdown",,active
+dashboard.core_index.expand_aria,dashboard,DashboardPage,UsagePanel,toggle_aria,"Expand CORE_INDEX breakdown",,active
 usage.summary.total_system_output,ui,UsagePanel,UsagePanel,summary_label_total_system,"TOTAL_SYSTEM_OUTPUT",,active
 usage.summary.total,ui,UsagePanel,UsagePanel,summary_label_total,"TOTAL_TOKENS",,active
 usage.summary.since,ui,UsagePanel,UsagePanel,summary_label_since,"SINCE {{range}} {{tz}}",,active

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -68,6 +68,7 @@ export function DashboardPage({
     if (typeof window === "undefined" || !window.matchMedia) return false;
     return window.matchMedia("(max-width: 640px)").matches;
   });
+  const [coreIndexCollapsed, setCoreIndexCollapsed] = useState(true);
   const [installCopied, setInstallCopied] = useState(false);
   const [sessionExpiredCopied, setSessionExpiredCopied] = useState(false);
   const mockEnabled = isMockEnabled();
@@ -536,6 +537,11 @@ export function DashboardPage({
     useCompactSummary,
   ]);
 
+  const coreIndexCollapseLabel = copy("dashboard.core_index.collapse_label");
+  const coreIndexExpandLabel = copy("dashboard.core_index.expand_label");
+  const coreIndexCollapseAria = copy("dashboard.core_index.collapse_aria");
+  const coreIndexExpandAria = copy("dashboard.core_index.expand_aria");
+
   const metricsRows = useMemo(
     () => [
       {
@@ -908,6 +914,14 @@ export function DashboardPage({
                 summaryValue={summaryValue}
                 summaryCostValue={summaryCostValue}
                 onCostInfo={costInfoEnabled ? openCostModal : null}
+                breakdownCollapsed={coreIndexCollapsed}
+                onToggleBreakdown={() =>
+                  setCoreIndexCollapsed((value) => !value)
+                }
+                collapseLabel={coreIndexCollapseLabel}
+                expandLabel={coreIndexExpandLabel}
+                collapseAriaLabel={coreIndexCollapseAria}
+                expandAriaLabel={coreIndexExpandAria}
                 onRefresh={refreshAll}
                 loading={usageLoadingState}
                 error={usageError}

--- a/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
@@ -30,6 +30,12 @@ export const UsagePanel = React.memo(function UsagePanel({
   costInfoIcon = copy("usage.cost_info.icon"),
   summarySubLabel,
   breakdown,
+  breakdownCollapsed = false,
+  onToggleBreakdown,
+  collapseLabel,
+  expandLabel,
+  collapseAriaLabel,
+  expandAriaLabel,
   useSummaryLayout = false,
   onRefresh,
   loading = false,
@@ -40,6 +46,11 @@ export const UsagePanel = React.memo(function UsagePanel({
   className = "",
 }) {
   const tabs = normalizePeriods(periods);
+  const toggleLabel = breakdownCollapsed ? expandLabel : collapseLabel;
+  const toggleAriaLabel = breakdownCollapsed
+    ? expandAriaLabel
+    : collapseAriaLabel;
+  const showBreakdownToggle = Boolean(onToggleBreakdown && toggleLabel);
   const breakdownRows =
     breakdown && breakdown.length
       ? breakdown
@@ -93,6 +104,16 @@ export const UsagePanel = React.memo(function UsagePanel({
               <span className="text-[8px] uppercase tracking-widest opacity-50 font-black">
                 {statusLabel}
               </span>
+            ) : null}
+            {showBreakdownToggle ? (
+              <MatrixButton
+                className="px-2 py-1 text-[9px]"
+                aria-label={toggleAriaLabel}
+                title={toggleAriaLabel}
+                onClick={onToggleBreakdown}
+              >
+                {toggleLabel}
+              </MatrixButton>
             ) : null}
             {onRefresh ? (
               <MatrixButton primary disabled={loading} onClick={onRefresh}>
@@ -164,7 +185,7 @@ export const UsagePanel = React.memo(function UsagePanel({
             ) : null}
           </div>
 
-          {breakdownRows.length ? (
+          {!breakdownCollapsed && breakdownRows.length ? (
             <div className="w-full px-6">
               <div className="grid grid-cols-2 gap-3 border-t border-b border-[#00FF41]/10 py-4 relative">
                 <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[1px] h-full bg-[#00FF41]/10"></div>

--- a/docs/pr/2025-12-28-core-index-collapse.md
+++ b/docs/pr/2025-12-28-core-index-collapse.md
@@ -1,0 +1,18 @@
+# PR Template (Minimal)
+
+## PR Goal (one sentence)
+Collapse CORE_INDEX breakdown modules by default while keeping the main summary visible.
+
+## Commit Narrative
+- Commit 1: `feat(dashboard): collapse core index breakdown`
+
+## Regression Test Gate
+### Most likely regression surface
+- CORE_INDEX header toggle, summary visibility, and breakdown rendering.
+
+### Verification method (choose at least one)
+- [x] Existing automated tests did not fail (commands: `node --test test/dashboard-core-index-collapse.test.js`, `node scripts/validate-copy-registry.cjs` => PASS; copy registry warnings unchanged: `landing.meta.*`, `usage.summary.since`, `dashboard.session.label`)
+- [ ] Manual regression path executed
+
+### Uncovered scope
+- Mobile visual regression across multiple devices.

--- a/openspec/changes/2025-12-28-collapse-core-index-panel/proposal.md
+++ b/openspec/changes/2025-12-28-collapse-core-index-panel/proposal.md
@@ -1,0 +1,13 @@
+# Change: Collapse CORE_INDEX breakdown modules by default
+
+## Why
+The CORE_INDEX panel is visually dense on mobile. Collapsing the four breakdown modules by default improves legibility and reduces vertical clutter while keeping the main summary value visible and accessible.
+
+## What Changes
+- Add a collapse/expand toggle icon in the CORE_INDEX panel header.
+- Default the breakdown modules to collapsed on first render.
+- When collapsed, hide only the four breakdown modules; keep the summary value visible. When expanded, render the current layout.
+
+## Impact
+- Affected specs: `vibescore-tracker`
+- Affected code: `dashboard/src/ui/matrix-a/components/UsagePanel.jsx`, `dashboard/src/pages/DashboardPage.jsx`, `dashboard/src/content/copy.csv`

--- a/openspec/changes/2025-12-28-collapse-core-index-panel/specs/vibescore-tracker/spec.md
+++ b/openspec/changes/2025-12-28-collapse-core-index-panel/specs/vibescore-tracker/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Dashboard CORE_INDEX breakdown modules are collapsible by default
+The dashboard UI SHALL render the CORE_INDEX breakdown modules in a collapsed state by default, while keeping the summary value visible until expanded by the user.
+
+#### Scenario: Default collapsed state keeps summary visible
+- **WHEN** a user loads the dashboard
+- **THEN** the CORE_INDEX panel SHALL show only the header row and a collapse/expand icon
+- **AND** the index summary value SHALL remain visible
+- **AND** the four breakdown modules SHALL be hidden
+
+#### Scenario: Expand and collapse toggle reveals breakdown modules
+- **GIVEN** the CORE_INDEX breakdown modules are collapsed
+- **WHEN** the user activates the toggle icon
+- **THEN** the CORE_INDEX panel SHALL render the four breakdown modules
+- **AND** activating the toggle again SHALL hide the breakdown modules while keeping the summary value visible

--- a/openspec/changes/2025-12-28-collapse-core-index-panel/tasks.md
+++ b/openspec/changes/2025-12-28-collapse-core-index-panel/tasks.md
@@ -1,0 +1,20 @@
+## 1. Planning
+- [x] Confirm requirements and acceptance criteria with user
+- [x] Confirm proposal approval before implementation
+
+## 2. Tests (TDD)
+- [x] Add regression test for CORE_INDEX collapse toggle and copy keys
+- [ ] Verify test fails before implementation
+
+## 3. Implementation
+- [x] Add collapse toggle and breakdown-only collapsed rendering to `UsagePanel`
+- [x] Add CORE_INDEX breakdown collapsed state (default collapsed) in `DashboardPage`
+- [x] Add copy registry keys for toggle icon and aria labels
+
+## 4. Verification
+- [x] Run `node --test test/dashboard-core-index-collapse.test.js`
+- [x] Run `node scripts/validate-copy-registry.cjs`
+
+## 5. Docs & Spec
+- [x] Update spec delta under `openspec/changes/2025-12-28-collapse-core-index-panel/specs/vibescore-tracker/spec.md`
+- [ ] Record verification notes (if applicable)

--- a/test/dashboard-core-index-collapse.test.js
+++ b/test/dashboard-core-index-collapse.test.js
@@ -1,0 +1,30 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function read(rel) {
+  return fs.readFileSync(path.join(__dirname, "..", rel), "utf8");
+}
+
+test("copy registry includes core index collapse keys", () => {
+  const csv = read("dashboard/src/content/copy.csv");
+  assert.ok(csv.includes("dashboard.core_index.collapse_label"));
+  assert.ok(csv.includes("dashboard.core_index.expand_label"));
+  assert.ok(csv.includes("dashboard.core_index.collapse_aria"));
+  assert.ok(csv.includes("dashboard.core_index.expand_aria"));
+});
+
+test("UsagePanel supports breakdown collapse toggle", () => {
+  const src = read("dashboard/src/ui/matrix-a/components/UsagePanel.jsx");
+  assert.ok(src.includes("breakdownCollapsed"));
+  assert.ok(src.includes("onToggleBreakdown"));
+  assert.ok(src.includes("collapseAriaLabel"));
+  assert.ok(src.includes("expandAriaLabel"));
+});
+
+test("DashboardPage wires CORE_INDEX collapse state", () => {
+  const src = read("dashboard/src/pages/DashboardPage.jsx");
+  assert.ok(src.includes("coreIndexCollapsed"));
+  assert.ok(src.includes("breakdownCollapsed={coreIndexCollapsed}"));
+});


### PR DESCRIPTION
## Summary\n- Add a CORE_INDEX breakdown collapse toggle while keeping the summary value visible.\n- Default breakdown modules to collapsed.\n\n## Testing\n- node --test test/dashboard-core-index-collapse.test.js\n- node scripts/validate-copy-registry.cjs\n\n## Docs\n- docs/pr/2025-12-28-core-index-collapse.md\n- openspec/changes/2025-12-28-collapse-core-index-panel/