### PR TITLE
fix(edge): exchange link codes via records api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Dashboard install panel temporarily hides the copy button and link code fetch flow.
 
+### Fixed
+- Link code exchange uses records API to avoid RPC gateway 404s.
+
 ## [0.2.0] - 2025-12-28
 ### Added
 - One-login link code install flow (Dashboard copy + CLI `init --link-code`).

--- a/docs/deployment/freeze.md
+++ b/docs/deployment/freeze.md
@@ -29,3 +29,9 @@
 - Change ID: `fix-link-code-exchange-rpc-path` (bug fix; no OpenSpec change)
 - Freeze artifact: `insforge-functions/vibescore-link-code-exchange.js` (built via `npm run build:insforge`)
 - Cold regression step: `node scripts/acceptance/link-code-exchange.cjs`
+
+## 2025-12-29-link-code-exchange-records
+- Scope: link code exchange uses records API (no RPC dependency)
+- Change ID: `fix-link-code-exchange-records` (bug fix; no OpenSpec change)
+- Freeze artifact: `insforge-functions/vibescore-link-code-exchange.js` (built via `npm run build:insforge`)
+- Cold regression step: `node scripts/acceptance/link-code-exchange.cjs`

--- a/docs/pr/2025-12-29-link-code-exchange-records.md
+++ b/docs/pr/2025-12-29-link-code-exchange-records.md
@@ -1,0 +1,32 @@
+# PR Template (Minimal)
+
+## PR Goal (one sentence)
+Replace link code exchange RPC calls with direct records API operations to avoid 404s on the InsForge gateway.
+
+## Commit Narrative
+- Commit 1: `fix(edge): implement link code exchange via records api`
+
+## Rollback Semantics
+- Reverting this PR restores the RPC path, which is not exposed on the current gateway and will break link code exchange.
+
+## Hidden Context
+- InsForge gateway does not expose `/rpc` or `/api/database/rpc` for this function.
+- Exchange now performs best-effort idempotency with compensation deletes when race conditions occur.
+
+## Regression Test Gate
+### Most likely regression surface
+- Link code exchange -> device token issuance; CLI `init --link-code`.
+
+### Verification method (choose at least one)
+- [x] Existing automated tests did not fail (command: `node --test test/edge-functions.test.js` => PASS)
+- [x] New minimal test added and executed (command: `node scripts/acceptance/link-code-exchange.cjs` => PASS)
+- [ ] Manual regression path executed (steps + expected result)
+
+### Uncovered scope
+- Live exchange against a deployed backend using a real link code.
+
+## Fast-Track (only if applicable)
+- Statement: N/A.
+
+## Notes
+- High-risk modules touched: auth flow, device token issuance, database writes.

--- a/insforge-functions/vibescore-link-code-exchange.js
+++ b/insforge-functions/vibescore-link-code-exchange.js
@@ -66,13 +66,13 @@ var require_env = __commonJS({
     function getServiceRoleKey2() {
       return Deno.env.get("INSFORGE_SERVICE_ROLE_KEY") || Deno.env.get("SERVICE_ROLE_KEY") || Deno.env.get("INSFORGE_API_KEY") || Deno.env.get("API_KEY") || null;
     }
-    function getAnonKey() {
+    function getAnonKey2() {
       return Deno.env.get("ANON_KEY") || Deno.env.get("INSFORGE_ANON_KEY") || null;
     }
     module2.exports = {
       getBaseUrl: getBaseUrl2,
       getServiceRoleKey: getServiceRoleKey2,
-      getAnonKey
+      getAnonKey: getAnonKey2
     };
   }
 });
@@ -171,10 +171,13 @@ var require_logging = __commonJS({
 
 // insforge-src/functions/vibescore-link-code-exchange.js
 var { handleOptions, json, requireMethod, readJson } = require_http();
-var { getBaseUrl, getServiceRoleKey } = require_env();
+var { getAnonKey, getBaseUrl, getServiceRoleKey } = require_env();
 var { sha256Hex } = require_crypto();
 var { withRequestLogging } = require_logging();
-module.exports = withRequestLogging("vibescore-link-code-exchange", async function(request, ctx) {
+var ISSUE_ERROR_MESSAGE = "Link code exchange failed";
+var DEVICE_NAME_FALLBACK = "VibeScore CLI";
+var PLATFORM_FALLBACK = "macos";
+module.exports = withRequestLogging("vibescore-link-code-exchange", async function(request) {
   const opt = handleOptions(request);
   if (opt) return opt;
   const methodErr = requireMethod(request, "POST");
@@ -190,35 +193,80 @@ module.exports = withRequestLogging("vibescore-link-code-exchange", async functi
   const baseUrl = getBaseUrl();
   const serviceRoleKey = getServiceRoleKey();
   if (!serviceRoleKey) return json({ error: "Missing service role key" }, 500);
+  const anonKey = getAnonKey();
+  const dbClient = createClient({
+    baseUrl,
+    anonKey: anonKey || serviceRoleKey,
+    edgeFunctionToken: serviceRoleKey
+  });
   const codeHash = await sha256Hex(linkCode);
   const token = await deriveToken({ secret: serviceRoleKey, codeHash, requestId });
   const tokenHash = await sha256Hex(token);
-  const url = new URL("/rpc/vibescore_exchange_link_code", baseUrl);
-  const res = await ctx.fetch(url.toString(), {
-    method: "POST",
-    headers: {
-      apikey: serviceRoleKey,
-      Authorization: `Bearer ${serviceRoleKey}`,
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify({
-      p_code_hash: codeHash,
-      p_request_id: requestId,
-      p_device_name: deviceName,
-      p_platform: platform,
-      p_token_hash: tokenHash
-    })
-  });
-  const { data, error } = await readApiJson(res);
-  if (!res.ok) {
-    const msg = error || "Link code exchange failed";
-    return json({ error: msg }, res.status >= 400 ? res.status : 500);
+  const { row: linkRow, error: linkErr } = await fetchLinkCodeRow({ dbClient, codeHash });
+  if (linkErr) {
+    logIssueError("link code select failed", linkErr?.message || ISSUE_ERROR_MESSAGE);
+    return json({ error: ISSUE_ERROR_MESSAGE }, 500);
   }
-  const row = Array.isArray(data) ? data[0] : data;
-  if (!row || typeof row.device_id !== "string" || typeof row.user_id !== "string") {
-    return json({ error: "Link code exchange failed" }, 500);
+  if (!linkRow) return json({ error: "invalid link code" }, 400);
+  if (linkRow.used_at) {
+    if (linkRow.request_id === requestId && typeof linkRow.device_id === "string") {
+      return json({ token, device_id: linkRow.device_id, user_id: linkRow.user_id }, 200);
+    }
+    return json({ error: "link code already used" }, 409);
   }
-  return json({ token, device_id: row.device_id, user_id: row.user_id }, 200);
+  if (isExpired(linkRow.expires_at)) {
+    return json({ error: "link code expired" }, 400);
+  }
+  const userId = linkRow.user_id;
+  if (typeof userId !== "string" || userId.length === 0) {
+    logIssueError("link code missing user_id", ISSUE_ERROR_MESSAGE);
+    return json({ error: ISSUE_ERROR_MESSAGE }, 500);
+  }
+  const deviceId = crypto.randomUUID();
+  const tokenId = crypto.randomUUID();
+  const nowIso = (/* @__PURE__ */ new Date()).toISOString();
+  const { error: deviceErr } = await dbClient.database.from("vibescore_tracker_devices").insert([
+    {
+      id: deviceId,
+      user_id: userId,
+      device_name: deviceName || DEVICE_NAME_FALLBACK,
+      platform: platform || PLATFORM_FALLBACK
+    }
+  ]);
+  if (deviceErr) {
+    logIssueError("device insert failed", deviceErr?.message || ISSUE_ERROR_MESSAGE);
+    return json({ error: ISSUE_ERROR_MESSAGE }, 500);
+  }
+  const { error: tokenErr } = await dbClient.database.from("vibescore_tracker_device_tokens").insert([
+    {
+      id: tokenId,
+      user_id: userId,
+      device_id: deviceId,
+      token_hash: tokenHash
+    }
+  ]);
+  if (tokenErr) {
+    logIssueError("token insert failed", tokenErr?.message || ISSUE_ERROR_MESSAGE);
+    await bestEffortDeleteDevice({ dbClient, deviceId, userId });
+    return json({ error: ISSUE_ERROR_MESSAGE }, 500);
+  }
+  const { data: updatedRow, error: updateErr } = await dbClient.database.from("vibescore_link_codes").update({ used_at: nowIso, request_id: requestId, device_id: deviceId }).eq("id", linkRow.id).is("used_at", null).select("user_id, device_id, request_id").maybeSingle();
+  if (updateErr) {
+    logIssueError("link code update failed", updateErr?.message || ISSUE_ERROR_MESSAGE);
+    await bestEffortDeleteToken({ dbClient, tokenId });
+    await bestEffortDeleteDevice({ dbClient, deviceId, userId });
+    return json({ error: ISSUE_ERROR_MESSAGE }, 500);
+  }
+  if (updatedRow && typeof updatedRow.device_id === "string") {
+    return json({ token, device_id: updatedRow.device_id, user_id: updatedRow.user_id }, 200);
+  }
+  await bestEffortDeleteToken({ dbClient, tokenId });
+  await bestEffortDeleteDevice({ dbClient, deviceId, userId });
+  const { row: freshRow } = await fetchLinkCodeRow({ dbClient, codeHash });
+  if (freshRow && freshRow.request_id === requestId && typeof freshRow.device_id === "string") {
+    return json({ token, device_id: freshRow.device_id, user_id: freshRow.user_id }, 200);
+  }
+  return json({ error: "link code already used" }, 409);
 });
 function sanitizeText(value, maxLen) {
   if (typeof value !== "string") return null;
@@ -230,13 +278,38 @@ async function deriveToken({ secret, codeHash, requestId }) {
   const input = `${secret}:${codeHash}:${requestId}`;
   return sha256Hex(input);
 }
-async function readApiJson(res) {
-  const text = await res.text();
-  if (!text) return { data: null, error: null };
+async function fetchLinkCodeRow({ dbClient, codeHash }) {
+  const { data, error } = await dbClient.database.from("vibescore_link_codes").select("id,user_id,expires_at,used_at,request_id,device_id").eq("code_hash", codeHash).maybeSingle();
+  return { row: data || null, error };
+}
+function isExpired(expiresAt) {
+  if (typeof expiresAt !== "string") return true;
+  const ts = Date.parse(expiresAt);
+  if (!Number.isFinite(ts)) return true;
+  return ts <= Date.now();
+}
+async function bestEffortDeleteToken({ dbClient, tokenId }) {
   try {
-    const parsed = JSON.parse(text);
-    return { data: parsed, error: parsed?.message || parsed?.error || null };
-  } catch (_e) {
-    return { data: null, error: text.slice(0, 300) };
+    const { error } = await dbClient.database.from("vibescore_tracker_device_tokens").delete().eq("id", tokenId);
+    if (error) {
+      logIssueError("compensation token delete failed", ISSUE_ERROR_MESSAGE);
+    }
+  } catch (_err) {
+    logIssueError("compensation token delete threw", ISSUE_ERROR_MESSAGE);
   }
+}
+async function bestEffortDeleteDevice({ dbClient, deviceId, userId }) {
+  try {
+    let query = dbClient.database.from("vibescore_tracker_devices").delete().eq("id", deviceId);
+    if (userId) query = query.eq("user_id", userId);
+    const { error } = await query;
+    if (error) {
+      logIssueError("compensation device delete failed", ISSUE_ERROR_MESSAGE);
+    }
+  } catch (_err) {
+    logIssueError("compensation device delete threw", ISSUE_ERROR_MESSAGE);
+  }
+}
+function logIssueError(stage, message) {
+  console.error(`link code exchange ${stage}: ${message}`);
 }

--- a/scripts/acceptance/link-code-exchange.cjs
+++ b/scripts/acceptance/link-code-exchange.cjs
@@ -28,17 +28,19 @@ async function main() {
 
   const linkCode = 'link_code_test';
   const requestId = 'req_123';
-  const deviceId = 'device_abc';
   const userId = '77777777-7777-7777-7777-777777777777';
-
-  const calls = [];
-  globalThis.fetch = async (url, init) => {
-    calls.push({ url, init });
-    return new Response(JSON.stringify({ device_id: deviceId, user_id: userId }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' }
-    });
+  const linkCodeRow = {
+    id: 'link_code_id',
+    user_id: userId,
+    code_hash: createHash('sha256').update(linkCode).digest('hex'),
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    used_at: null,
+    request_id: null,
+    device_id: null
   };
+
+  const db = createLinkCodeExchangeDbMock(linkCodeRow);
+  globalThis.createClient = () => ({ database: db.db });
 
   const req = new Request('http://localhost/functions/vibescore-link-code-exchange', {
     method: 'POST',
@@ -57,20 +59,114 @@ async function main() {
   const expectedTokenHash = createHash('sha256').update(expectedToken).digest('hex');
 
   assert.equal(body.token, expectedToken);
-  assert.equal(body.device_id, deviceId);
   assert.equal(body.user_id, userId);
 
-  assert.equal(calls.length, 1);
-  assert.ok(String(calls[0].url).includes('/rpc/vibescore_exchange_link_code'));
-  const payload = JSON.parse(calls[0].init?.body || '{}');
-  assert.equal(payload.p_code_hash, codeHash);
-  assert.equal(payload.p_request_id, requestId);
-  assert.equal(payload.p_token_hash, expectedTokenHash);
+  const deviceInsert = db.inserts.find((entry) => entry.table === 'vibescore_tracker_devices');
+  assert.ok(deviceInsert, 'device insert missing');
+  const deviceRow = deviceInsert.rows[0];
+  assert.equal(body.device_id, deviceRow.id);
 
-  process.stdout.write('ok: link code exchange uses /rpc and returns device token\n');
+  const tokenInsert = db.inserts.find((entry) => entry.table === 'vibescore_tracker_device_tokens');
+  assert.ok(tokenInsert, 'token insert missing');
+  assert.equal(tokenInsert.rows[0].token_hash, expectedTokenHash);
+  assert.equal(tokenInsert.rows[0].device_id, deviceRow.id);
+
+  const update = db.updates.find((entry) => entry.table === 'vibescore_link_codes');
+  assert.ok(update, 'link code update missing');
+  assert.equal(update.values.request_id, requestId);
+  assert.equal(update.values.device_id, deviceRow.id);
+
+  process.stdout.write('ok: link code exchange uses records api and returns device token\n');
 }
 
 main().catch((err) => {
   process.stderr.write(`${err && err.stack ? err.stack : String(err)}\n`);
   process.exitCode = 1;
 });
+
+function createLinkCodeExchangeDbMock(linkCodeRow) {
+  const inserts = [];
+  const updates = [];
+  let row = linkCodeRow ? { ...linkCodeRow } : null;
+
+  function matchesFilters(target, filters) {
+    if (!target) return false;
+    return filters.every((filter) => {
+      if (filter.op === 'eq') return target[filter.col] === filter.value;
+      if (filter.op === 'is') {
+        if (filter.value === null) return target[filter.col] == null;
+        return target[filter.col] === filter.value;
+      }
+      return false;
+    });
+  }
+
+  function from(table) {
+    if (table === 'vibescore_link_codes') {
+      return {
+        select: (columns) => {
+          const q = { table, columns, filters: [] };
+          return {
+            eq: (col, value) => {
+              q.filters.push({ op: 'eq', col, value });
+              return {
+                maybeSingle: async () => ({
+                  data: matchesFilters(row, q.filters) ? row : null,
+                  error: null
+                })
+              };
+            }
+          };
+        },
+        update: (values) => {
+          const q = { table, values, filters: [] };
+          const builder = {
+            eq: (col, value) => {
+              q.filters.push({ op: 'eq', col, value });
+              return builder;
+            },
+            is: (col, value) => {
+              q.filters.push({ op: 'is', col, value });
+              return builder;
+            },
+            select: (columns) => {
+              q.columns = columns;
+              return builder;
+            },
+            maybeSingle: async () => {
+              updates.push(q);
+              if (!matchesFilters(row, q.filters)) {
+                return { data: null, error: null };
+              }
+              row = { ...row, ...values };
+              return { data: row, error: null };
+            }
+          };
+          return builder;
+        }
+      };
+    }
+
+    if (table === 'vibescore_tracker_devices' || table === 'vibescore_tracker_device_tokens') {
+      return {
+        insert: async (rows) => {
+          inserts.push({ table, rows });
+          return { error: null };
+        },
+        delete: () => ({
+          eq: async () => ({ error: null })
+        })
+      };
+    }
+
+    return {
+      insert: async () => ({ error: null })
+    };
+  }
+
+  return {
+    db: { from },
+    inserts,
+    updates
+  };
+}

--- a/test/link-code-exchange-payload.test.js
+++ b/test/link-code-exchange-payload.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-test('link code exchange payload uses rpc parameter names', () => {
+test('link code exchange uses records API (no rpc)', () => {
   const filePath = path.join(
     __dirname,
     '..',
@@ -12,17 +12,8 @@ test('link code exchange payload uses rpc parameter names', () => {
     'vibescore-link-code-exchange.js'
   );
   const src = fs.readFileSync(filePath, 'utf8');
-  const requiredKeys = [
-    'p_code_hash',
-    'p_request_id',
-    'p_device_name',
-    'p_platform',
-    'p_token_hash'
-  ];
-  for (const key of requiredKeys) {
-    assert.ok(
-      src.includes(key),
-      `expected payload to include ${key}`
-    );
-  }
+  assert.ok(src.includes('vibescore_link_codes'), 'expected link code table access');
+  assert.ok(src.includes('vibescore_tracker_devices'), 'expected device table access');
+  assert.ok(src.includes('vibescore_tracker_device_tokens'), 'expected token table access');
+  assert.ok(!src.includes('/rpc/'), 'expected rpc path to be removed');
 });


### PR DESCRIPTION
# PR Template (Minimal)

## PR Goal (one sentence)
Replace link code exchange RPC calls with direct records API operations to avoid 404s on the InsForge gateway.

## Commit Narrative
- Commit 1: `fix(edge): implement link code exchange via records api`

## Rollback Semantics
- Reverting this PR restores the RPC path, which is not exposed on the current gateway and will break link code exchange.

## Hidden Context
- InsForge gateway does not expose `/rpc` or `/api/database/rpc` for this function.
- Exchange now performs best-effort idempotency with compensation deletes when race conditions occur.

## Regression Test Gate
### Most likely regression surface
- Link code exchange -> device token issuance; CLI `init --link-code`.

### Verification method (choose at least one)
- [x] Existing automated tests did not fail (command: `node --test test/edge-functions.test.js` => PASS)
- [x] New minimal test added and executed (command: `node scripts/acceptance/link-code-exchange.cjs` => PASS)
- [ ] Manual regression path executed (steps + expected result)

### Uncovered scope
- Live exchange against a deployed backend using a real link code.

## Fast-Track (only if applicable)
- Statement: N/A.

## Notes
- High-risk modules touched: auth flow, device token issuance, database writes.
