### PR TITLE
修复 summary 成本口径与弹窗一致

### DIFF
--- a/insforge-src/functions/vibescore-usage-summary.js
+++ b/insforge-src/functions/vibescore-usage-summary.js
@@ -114,9 +114,11 @@ module.exports = async function(request) {
     effectiveDate: to
   });
   let totalCostMicros = 0n;
+  const pricingModes = new Set();
   for (const entry of sourcesMap.values()) {
     const sourceCost = computeUsageCost(entry.totals, pricingProfile);
     totalCostMicros += sourceCost.cost_micros;
+    pricingModes.add(sourceCost.pricing_mode);
   }
 
   const overallCost = computeUsageCost(
@@ -129,6 +131,13 @@ module.exports = async function(request) {
     },
     pricingProfile
   );
+
+  let summaryPricingMode = overallCost.pricing_mode;
+  if (pricingModes.size === 1) {
+    summaryPricingMode = Array.from(pricingModes)[0];
+  } else if (pricingModes.size > 1) {
+    summaryPricingMode = 'mixed';
+  }
 
   const totals = {
     total_tokens: totalTokens.toString(),
@@ -147,7 +156,7 @@ module.exports = async function(request) {
       totals,
       pricing: buildPricingMetadata({
         profile: overallCost.profile,
-        pricingMode: overallCost.pricing_mode
+        pricingMode: summaryPricingMode
       })
     },
     200

--- a/scripts/acceptance/usage-summary-aggregate.cjs
+++ b/scripts/acceptance/usage-summary-aggregate.cjs
@@ -153,6 +153,7 @@ async function main() {
   assert.equal(body.totals.cached_input_tokens, '60');
   assert.equal(body.totals.output_tokens, '300');
   assert.equal(body.totals.reasoning_output_tokens, '30');
+  assert.equal(body.pricing.pricing_mode, 'mixed');
   const expectedCost = formatUsdFromMicros(
     computeUsageCost(
       {


### PR DESCRIPTION
## 概要
- summary 成本改为按来源聚合后再汇总，避免默认定价偏差
- usage-summary 接口补齐 source/model 读取并统一成本口径
- 更新 usage-summary 回归用例以覆盖多来源成本

## 测试
- node scripts/acceptance/usage-summary-aggregate.cjs
- node scripts/acceptance/usage-model-breakdown.cjs
