### PR TITLE
fix: use timestamptz in rollup backfill

### DIFF
--- a/scripts/ops/usage-daily-rollup-backfill.sql
+++ b/scripts/ops/usage-daily-rollup-backfill.sql
@@ -20,8 +20,8 @@ begin
     sum(coalesce(reasoning_output_tokens, 0))::bigint,
     now()
   from public.vibescore_tracker_hourly
-  where hour_start >= (p_from::timestamp at time zone 'UTC')
-    and hour_start < ((p_to + 1)::timestamp at time zone 'UTC')
+  where hour_start >= (p_from::timestamptz at time zone 'UTC')
+    and hour_start < ((p_to + 1)::timestamptz at time zone 'UTC')
   group by 1,2,3,4;
 end;
 $$ language plpgsql;


### PR DESCRIPTION
## Summary
- replace timestamp casts with timestamptz in rollup backfill SQL
- satisfy validate:guardrails SQL_TIMESTAMP rule

## Test Plan
- [x] npm run validate:guardrails