### PR TITLE
fix: prefer stored billable totals in UTC hourly

### DIFF
--- a/architecture.canvas
+++ b/architecture.canvas
@@ -166,40 +166,6 @@
       }
     },
     {
-      "id": "manual_billable-total-tokens-backfill_cjs",
-      "type": "text",
-      "text": "**billable-total-tokens-backfill**\n`scripts/ops/billable-total-tokens-backfill.cjs`\n\nRole: Backfill hourly billable_total_tokens.\nStatus: Implemented\nNotes: Offline backfill script for historical rows.",
-      "x": 1900,
-      "y": 10132,
-      "width": 320,
-      "height": 180,
-      "color": "4",
-      "meta": {
-        "relPath": "scripts/ops/billable-total-tokens-backfill.cjs",
-        "category": "utils",
-        "group": "utils",
-        "side": "right",
-        "layerIndex": 6
-      }
-    },
-    {
-      "id": "manual_billable-total-tokens-migration_sql",
-      "type": "text",
-      "text": "**billable-total-tokens-migration**\n`scripts/ops/billable-total-tokens-migration.sql`\n\nRole: Add billable_total_tokens columns.\nStatus: Implemented\nNotes: One-time migration for hourly table.",
-      "x": 2240,
-      "y": 10132,
-      "width": 320,
-      "height": 180,
-      "color": "4",
-      "meta": {
-        "relPath": "scripts/ops/billable-total-tokens-migration.sql",
-        "category": "utils",
-        "group": "utils",
-        "side": "right",
-        "layerIndex": 6
-      }
-    },
-    {
       "id": "test_boot-screen_test_21fc4cc4",
       "type": "text",
       "text": "**boot-screen.test**\n`test/boot-screen.test.js`\n\nTest module.\n\n包含：\n- boot-screen.test (86 行)\n- read (1 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
@@ -508,7 +474,7 @@
     {
       "id": "test_edge-functions_test_deffefcc",
       "type": "text",
-      "text": "**edge-functions.test**\n`test/edge-functions.test.js`\n\nTest module.\n\n包含：\n- edge-functions.test (3596 行)\n- toBase64Url (1 个参数)\n\n依赖：2 个模块\n被依赖：0 次",
+      "text": "**edge-functions.test**\n`test/edge-functions.test.js`\n\nTest module.\n\n包含：\n- edge-functions.test (3664 行)\n- toBase64Url (1 个参数)\n\n依赖：2 个模块\n被依赖：0 次",
       "x": 2620,
       "y": 10852,
       "width": 280,
@@ -1981,7 +1947,7 @@
     {
       "id": "edge-function_vibescore-usage-hourly_7f0e1821",
       "type": "text",
-      "text": "**vibescore-usage-hourly**\n`insforge-src/functions/vibescore-usage-hourly.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-hourly (500 行)\n- initHourlyBuckets (1 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
+      "text": "**vibescore-usage-hourly**\n`insforge-src/functions/vibescore-usage-hourly.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-hourly (508 行)\n- initHourlyBuckets (1 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
       "x": 2620,
       "y": 4936,
       "width": 280,
@@ -3588,6 +3554,40 @@
         "layerIndex": 4
       },
       "externalService": "Anthropic"
+    },
+    {
+      "id": "manual_billable-total-tokens-backfill_cjs",
+      "type": "text",
+      "text": "**billable-total-tokens-backfill (manual)**\n`scripts/ops/billable-total-tokens-backfill.cjs`\n\nManual ops script.\n\n包含：\n- billable-total-tokens-backfill (296 行)\n- parseArgs (1 个参数)\n- printHelp (0 个参数)\n- buildUpdates (1 个参数)\n- findLastCursorRow (1 个参数)\n- buildCursorFilter (1 个参数)\n- buildCursorFromRow (1 个参数)\n- sleep (1 个参数)",
+      "x": 100,
+      "y": 10480,
+      "width": 280,
+      "height": 232,
+      "color": "2",
+      "meta": {
+        "relPath": "scripts/ops/billable-total-tokens-backfill.cjs",
+        "category": "ops",
+        "group": "ops",
+        "side": "right",
+        "layerIndex": 6
+      }
+    },
+    {
+      "id": "manual_billable-total-tokens-migration_sql",
+      "type": "text",
+      "text": "**billable-total-tokens-migration (manual)**\n`scripts/ops/billable-total-tokens-migration.sql`\n\nManual ops SQL.\n\n包含：\n- billable-total-tokens-migration (7 行)",
+      "x": 460,
+      "y": 10480,
+      "width": 280,
+      "height": 232,
+      "color": "2",
+      "meta": {
+        "relPath": "scripts/ops/billable-total-tokens-migration.sql",
+        "category": "ops",
+        "group": "ops",
+        "side": "right",
+        "layerIndex": 6
+      }
     }
   ],
   "edges": [

--- a/docs/pr/2026-01-06-usage-hourly-billable.md
+++ b/docs/pr/2026-01-06-usage-hourly-billable.md
@@ -5,7 +5,9 @@ Prefer stored billable totals in the UTC aggregate path for hourly usage.
 
 ## Commit Narrative
 - fix(usage-hourly): use sum(billable_total_tokens) when present in UTC aggregate
+- fix(usage-hourly): fall back to computed billable when aggregate sum is partial
 - test(usage-hourly): cover stored billable totals in aggregate path
+- test(usage-hourly): cover partial aggregate billable fallback
 - docs(pr): record regression command and result
 
 ## Regression Test Gate
@@ -14,6 +16,7 @@ Prefer stored billable totals in the UTC aggregate path for hourly usage.
 
 ### Verification method (choose at least one)
 - [x] `node --test test/edge-functions.test.js --test-name-pattern "prefers stored billable totals in aggregate path"` => PASS
+- [x] `node --test test/edge-functions.test.js --test-name-pattern "aggregate path falls back when billable sums incomplete"` => PASS
 
 ### Uncovered scope
 - End-to-end hourly aggregate against production data.

--- a/insforge-functions/vibescore-usage-hourly.js
+++ b/insforge-functions/vibescore-usage-hourly.js
@@ -947,7 +947,10 @@ module.exports = withRequestLogging("vibescore-usage-hourly", async function(req
         const bucket = key ? bucketMap2.get(key) : null;
         if (!bucket) continue;
         bucket.total += toBigInt(row?.sum_total_tokens);
-        const hasStoredBillable = row && Object.prototype.hasOwnProperty.call(row, "sum_billable_total_tokens") && row.sum_billable_total_tokens != null;
+        const rowCount3 = Number(row?.count_rows);
+        const billableCount = Number(row?.count_billable_total_tokens);
+        const hasCompleteBillable = Number.isFinite(rowCount3) && Number.isFinite(billableCount) && rowCount3 > 0 && billableCount === rowCount3;
+        const hasStoredBillable = row && Object.prototype.hasOwnProperty.call(row, "sum_billable_total_tokens") && row.sum_billable_total_tokens != null && hasCompleteBillable;
         const billable = hasStoredBillable ? toBigInt(row.sum_billable_total_tokens) : computeBillableTotalTokens({
           source: row?.source || source,
           totals: {
@@ -1192,7 +1195,7 @@ function parseHalfHourSlotFromKey(key) {
 async function tryAggregateHourlyTotals({ edgeClient, userId, startIso, endIso, source, model }) {
   try {
     let query = edgeClient.database.from("vibescore_tracker_hourly").select(
-      "source,hour:hour_start,sum_total_tokens:sum(total_tokens),sum_input_tokens:sum(input_tokens),sum_cached_input_tokens:sum(cached_input_tokens),sum_output_tokens:sum(output_tokens),sum_reasoning_output_tokens:sum(reasoning_output_tokens),sum_billable_total_tokens:sum(billable_total_tokens)"
+      "source,hour:hour_start,sum_total_tokens:sum(total_tokens),sum_input_tokens:sum(input_tokens),sum_cached_input_tokens:sum(cached_input_tokens),sum_output_tokens:sum(output_tokens),sum_reasoning_output_tokens:sum(reasoning_output_tokens),sum_billable_total_tokens:sum(billable_total_tokens),count_rows:count(),count_billable_total_tokens:count(billable_total_tokens)"
     ).eq("user_id", userId);
     if (source) query = query.eq("source", source);
     if (model) query = query.eq("model", model);

--- a/insforge-functions/vibeusage-usage-hourly.js
+++ b/insforge-functions/vibeusage-usage-hourly.js
@@ -950,7 +950,10 @@ var require_vibescore_usage_hourly = __commonJS({
             const bucket = key ? bucketMap2.get(key) : null;
             if (!bucket) continue;
             bucket.total += toBigInt(row?.sum_total_tokens);
-            const hasStoredBillable = row && Object.prototype.hasOwnProperty.call(row, "sum_billable_total_tokens") && row.sum_billable_total_tokens != null;
+            const rowCount3 = Number(row?.count_rows);
+            const billableCount = Number(row?.count_billable_total_tokens);
+            const hasCompleteBillable = Number.isFinite(rowCount3) && Number.isFinite(billableCount) && rowCount3 > 0 && billableCount === rowCount3;
+            const hasStoredBillable = row && Object.prototype.hasOwnProperty.call(row, "sum_billable_total_tokens") && row.sum_billable_total_tokens != null && hasCompleteBillable;
             const billable = hasStoredBillable ? toBigInt(row.sum_billable_total_tokens) : computeBillableTotalTokens({
               source: row?.source || source,
               totals: {
@@ -1195,7 +1198,7 @@ var require_vibescore_usage_hourly = __commonJS({
     async function tryAggregateHourlyTotals({ edgeClient, userId, startIso, endIso, source, model }) {
       try {
         let query = edgeClient.database.from("vibescore_tracker_hourly").select(
-          "source,hour:hour_start,sum_total_tokens:sum(total_tokens),sum_input_tokens:sum(input_tokens),sum_cached_input_tokens:sum(cached_input_tokens),sum_output_tokens:sum(output_tokens),sum_reasoning_output_tokens:sum(reasoning_output_tokens),sum_billable_total_tokens:sum(billable_total_tokens)"
+          "source,hour:hour_start,sum_total_tokens:sum(total_tokens),sum_input_tokens:sum(input_tokens),sum_cached_input_tokens:sum(cached_input_tokens),sum_output_tokens:sum(output_tokens),sum_reasoning_output_tokens:sum(reasoning_output_tokens),sum_billable_total_tokens:sum(billable_total_tokens),count_rows:count(),count_billable_total_tokens:count(billable_total_tokens)"
         ).eq("user_id", userId);
         if (source) query = query.eq("source", source);
         if (model) query = query.eq("model", model);

--- a/test/edge-functions.test.js
+++ b/test/edge-functions.test.js
@@ -1600,7 +1600,9 @@ test('vibeusage-usage-hourly prefers stored billable totals in aggregate path', 
       sum_cached_input_tokens: '1',
       sum_output_tokens: '3',
       sum_reasoning_output_tokens: '2',
-      sum_billable_total_tokens: '8'
+      sum_billable_total_tokens: '8',
+      count_rows: '1',
+      count_billable_total_tokens: '1'
     }
   ];
 
@@ -1645,6 +1647,72 @@ test('vibeusage-usage-hourly prefers stored billable totals in aggregate path', 
   const body = await res.json();
   assert.equal(body.data[2].total_tokens, '10');
   assert.equal(body.data[2].billable_total_tokens, '8');
+});
+
+test('vibeusage-usage-hourly aggregate path falls back when billable sums incomplete', async () => {
+  const fn = require('../insforge-functions/vibeusage-usage-hourly');
+
+  const userId = '77777777-7777-7777-7777-777777777777';
+  const userJwt = 'user_jwt_test';
+  let selectColumns = '';
+
+  const aggregateRows = [
+    {
+      hour: '2025-12-21T01:00:00.000Z',
+      source: 'codex',
+      sum_total_tokens: '10',
+      sum_input_tokens: '4',
+      sum_cached_input_tokens: '1',
+      sum_output_tokens: '3',
+      sum_reasoning_output_tokens: '2',
+      sum_billable_total_tokens: '8',
+      count_rows: '2',
+      count_billable_total_tokens: '1'
+    }
+  ];
+
+  globalThis.createClient = (args) => {
+    if (args && args.edgeFunctionToken === userJwt) {
+      assert.equal(args.anonKey, ANON_KEY);
+      return {
+        auth: {
+          getCurrentUser: async () => ({ data: { user: { id: userId } }, error: null })
+        },
+        database: {
+          from: (table) => {
+            assert.equal(table, 'vibescore_tracker_hourly');
+            return {
+              select: (columns) => {
+                selectColumns = String(columns || '');
+                const isAggregate =
+                  typeof columns === 'string' && columns.includes('sum(');
+                if (isAggregate) {
+                  assert.ok(selectColumns.includes('count(billable_total_tokens)'));
+                  assert.ok(selectColumns.includes('count()'));
+                  const query = createQueryMock({ rows: aggregateRows });
+                  query.range = async () => ({ data: aggregateRows, error: null });
+                  return query;
+                }
+                throw new Error('raw hourly query should not be called in aggregate path');
+              }
+            };
+          }
+        }
+      };
+    }
+    throw new Error(`Unexpected createClient args: ${JSON.stringify(args)}`);
+  };
+
+  const req = new Request('http://localhost/functions/vibeusage-usage-hourly?day=2025-12-21', {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${userJwt}` }
+  });
+
+  const res = await fn(req);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data[2].total_tokens, '10');
+  assert.equal(body.data[2].billable_total_tokens, '9');
 });
 
 test('vibeusage-usage-monthly aggregates hourly rows into months', async () => {


### PR DESCRIPTION
## Summary\n- prefer stored billable totals in UTC aggregate path\n- add regression test for aggregate billable totals\n- sync generated edge artifacts and canvas\n\n## Testing\n- node --test test/edge-functions.test.js --test-name-pattern "prefers stored billable totals in aggregate path"