### PR TITLE
fix: preserve provider prefixes in usage models

### DIFF
--- a/architecture.canvas
+++ b/architecture.canvas
@@ -644,7 +644,7 @@
     {
       "id": "test_insforge-src-shared_test_110fa035",
       "type": "text",
-      "text": "**insforge-src-shared.test**\n`test/insforge-src-shared.test.js`\n\nTest module.\n\n包含：\n- insforge-src-shared.test (131 行)\n- exports (0 个参数)\n\n依赖：3 个模块\n被依赖：0 次",
+      "text": "**insforge-src-shared.test**\n`test/insforge-src-shared.test.js`\n\nTest module.\n\n包含：\n- insforge-src-shared.test (158 行)\n- exports (0 个参数)\n\n依赖：3 个模块\n被依赖：0 次",
       "x": 460,
       "y": 11572,
       "width": 280,
@@ -1675,7 +1675,7 @@
     {
       "id": "utils_model_516b2f36",
       "type": "text",
-      "text": "**model**\n`insforge-src/shared/model.js`\n\nShared utilities.\n\n包含：\n- model (67 行)\n- normalizeModel (1 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
+      "text": "**model**\n`insforge-src/shared/model.js`\n\nShared utilities.\n\n包含：\n- model (66 行)\n- normalizeModel (1 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
       "x": 1180,
       "y": 6736,
       "width": 280,

--- a/insforge-functions/vibescore-ingest.js
+++ b/insforge-functions/vibescore-ingest.js
@@ -450,10 +450,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel2(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -468,14 +465,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibescore-pricing-sync.js
+++ b/insforge-functions/vibescore-pricing-sync.js
@@ -559,10 +559,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel2(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -577,14 +574,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibescore-usage-daily.js
+++ b/insforge-functions/vibescore-usage-daily.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibescore-usage-heatmap.js
+++ b/insforge-functions/vibescore-usage-heatmap.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibescore-usage-hourly.js
+++ b/insforge-functions/vibescore-usage-hourly.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibescore-usage-model-breakdown.js
+++ b/insforge-functions/vibescore-usage-model-breakdown.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibescore-usage-monthly.js
+++ b/insforge-functions/vibescore-usage-monthly.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibescore-usage-summary.js
+++ b/insforge-functions/vibescore-usage-summary.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibeusage-ingest.js
+++ b/insforge-functions/vibeusage-ingest.js
@@ -450,10 +450,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -468,14 +465,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibeusage-pricing-sync.js
+++ b/insforge-functions/vibeusage-pricing-sync.js
@@ -559,10 +559,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -577,14 +574,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibeusage-usage-daily.js
+++ b/insforge-functions/vibeusage-usage-daily.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibeusage-usage-heatmap.js
+++ b/insforge-functions/vibeusage-usage-heatmap.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibeusage-usage-hourly.js
+++ b/insforge-functions/vibeusage-usage-hourly.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibeusage-usage-model-breakdown.js
+++ b/insforge-functions/vibeusage-usage-model-breakdown.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibeusage-usage-monthly.js
+++ b/insforge-functions/vibeusage-usage-monthly.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-functions/vibeusage-usage-summary.js
+++ b/insforge-functions/vibeusage-usage-summary.js
@@ -214,10 +214,7 @@ var require_model = __commonJS({
       const normalized = normalizeModel(value);
       if (!normalized) return null;
       const lowered = normalized.toLowerCase();
-      if (!lowered) return null;
-      const slashIndex = lowered.lastIndexOf("/");
-      const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-      return candidate ? candidate : null;
+      return lowered || null;
     }
     function escapeLike(value) {
       return String(value).replace(/[\\%_]/g, "\\$&");
@@ -232,14 +229,16 @@ var require_model = __commonJS({
         if (!normalized) continue;
         const safe = escapeLike(normalized);
         const exact = `model.ilike.${safe}`;
-        const suffixed = `model.ilike.%/${safe}`;
         if (!seen.has(exact)) {
           seen.add(exact);
           terms.push(exact);
         }
-        if (!seen.has(suffixed)) {
-          seen.add(suffixed);
-          terms.push(suffixed);
+        if (!normalized.includes("/")) {
+          const suffixed = `model.ilike.%/${safe}`;
+          if (!seen.has(suffixed)) {
+            seen.add(suffixed);
+            terms.push(suffixed);
+          }
         }
       }
       if (terms.length === 0) return query;

--- a/insforge-src/shared/model.js
+++ b/insforge-src/shared/model.js
@@ -10,10 +10,7 @@ function normalizeUsageModel(value) {
   const normalized = normalizeModel(value);
   if (!normalized) return null;
   const lowered = normalized.toLowerCase();
-  if (!lowered) return null;
-  const slashIndex = lowered.lastIndexOf('/');
-  const candidate = slashIndex >= 0 ? lowered.slice(slashIndex + 1) : lowered;
-  return candidate ? candidate : null;
+  return lowered || null;
 }
 
 function escapeLike(value) {
@@ -31,14 +28,16 @@ function applyUsageModelFilter(query, usageModels) {
     if (!normalized) continue;
     const safe = escapeLike(normalized);
     const exact = `model.ilike.${safe}`;
-    const suffixed = `model.ilike.%/${safe}`;
     if (!seen.has(exact)) {
       seen.add(exact);
       terms.push(exact);
     }
-    if (!seen.has(suffixed)) {
-      seen.add(suffixed);
-      terms.push(suffixed);
+    if (!normalized.includes('/')) {
+      const suffixed = `model.ilike.%/${safe}`;
+      if (!seen.has(suffixed)) {
+        seen.add(suffixed);
+        terms.push(suffixed);
+      }
     }
   }
 

--- a/test/insforge-src-shared.test.js
+++ b/test/insforge-src-shared.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { logSlowQuery } = require('../insforge-src/shared/logging');
 const { getUsageMaxDays } = require('../insforge-src/shared/date');
-const { normalizeUsageModel } = require('../insforge-src/shared/model');
+const { normalizeUsageModel, applyUsageModelFilter } = require('../insforge-src/shared/model');
 const pricing = require('../insforge-src/shared/pricing');
 
 test('insforge shared logging module exists', () => {
@@ -121,10 +121,37 @@ test('pricing defaults read VIBEUSAGE env with VIBESCORE fallback', () => {
   }
 });
 
-test('normalizeUsageModel canonicalizes usage model ids', () => {
+test('normalizeUsageModel preserves provider prefixes', () => {
   assert.equal(normalizeUsageModel(' GPT-4o '), 'gpt-4o');
-  assert.equal(normalizeUsageModel('openai/GPT-4o'), 'gpt-4o');
-  assert.equal(normalizeUsageModel('Anthropic/Claude-3.5'), 'claude-3.5');
+  assert.equal(normalizeUsageModel('openai/GPT-4o'), 'openai/gpt-4o');
+  assert.equal(normalizeUsageModel('Anthropic/Claude-3.5'), 'anthropic/claude-3.5');
   assert.equal(normalizeUsageModel('unknown'), 'unknown');
   assert.equal(normalizeUsageModel(''), null);
+});
+
+test('applyUsageModelFilter preserves provider prefixes', () => {
+  let orExpr = null;
+  const query = {
+    or: (expr) => {
+      orExpr = expr;
+      return query;
+    }
+  };
+
+  applyUsageModelFilter(query, ['openai/GPT-4o']);
+  assert.equal(orExpr, 'model.ilike.openai/gpt-4o');
+  assert.ok(!orExpr.includes('%/gpt-4o'));
+});
+
+test('applyUsageModelFilter expands unqualified models', () => {
+  let orExpr = null;
+  const query = {
+    or: (expr) => {
+      orExpr = expr;
+      return query;
+    }
+  };
+
+  applyUsageModelFilter(query, [' GPT-4o ']);
+  assert.equal(orExpr, 'model.ilike.gpt-4o,model.ilike.%/gpt-4o');
 });


### PR DESCRIPTION
## Summary
- Preserve provider prefixes when normalizing usage model IDs.
- Avoid suffix expansion for provider-qualified models in model filters.
- Add regression tests for provider-qualified vs unqualified models.

## Testing
- node --test test/insforge-src-shared.test.js
- npm run build:insforge
