### PR TITLE
fix: align prefixed model filter identity

### DIFF
--- a/architecture.canvas
+++ b/architecture.canvas
@@ -508,8 +508,8 @@
     {
       "id": "test_edge-functions_test_deffefcc",
       "type": "text",
-      "text": "**edge-functions.test**\n`test/edge-functions.test.js`\n\nTest module.\n\n包含：\n- edge-functions.test (5347 行)\n- toBase64Url (1 个参数)\n\n依赖：3 个模块\n被依赖：0 次",
-      "x": 100,
+      "text": "**edge-functions.test**\n`test/edge-functions.test.js`\n\nTest module.\n\n包含：\n- edge-functions.test (5417 行)\n- toBase64Url (1 个参数)\n\n依赖：3 个模块\n被依赖：0 次",
+      "x": 460,
       "y": 11212,
       "width": 280,
       "height": 232,
@@ -679,7 +679,7 @@
       "id": "test_insforge-src-shared_test_110fa035",
       "type": "text",
       "text": "**insforge-src-shared.test**\n`test/insforge-src-shared.test.js`\n\nTest module.\n\n包含：\n- insforge-src-shared.test (251 行)\n- createPricingEdgeClient (2 个参数)\n\n依赖：2 个模块\n被依赖：0 次",
-      "x": 460,
+      "x": 1180,
       "y": 11572,
       "width": 280,
       "height": 232,
@@ -2117,7 +2117,7 @@
     {
       "id": "edge-function_vibescore-usage-daily_13bc8f2d",
       "type": "text",
-      "text": "**vibescore-usage-daily**\n`insforge-src/functions/vibescore-usage-daily.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-daily (472 行)\n- getSourceEntry (2 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
+      "text": "**vibescore-usage-daily**\n`insforge-src/functions/vibescore-usage-daily.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-daily (484 行)\n- getSourceEntry (2 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
       "x": 1900,
       "y": 4936,
       "width": 280,
@@ -2134,7 +2134,7 @@
     {
       "id": "edge-function_vibescore-usage-heatmap_67a4af30",
       "type": "text",
-      "text": "**vibescore-usage-heatmap**\n`insforge-src/functions/vibescore-usage-heatmap.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-heatmap (451 行)\n- normalizeWeeks (1 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
+      "text": "**vibescore-usage-heatmap**\n`insforge-src/functions/vibescore-usage-heatmap.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-heatmap (463 行)\n- normalizeWeeks (1 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
       "x": 2260,
       "y": 4936,
       "width": 280,
@@ -2151,7 +2151,7 @@
     {
       "id": "edge-function_vibescore-usage-hourly_7f0e1821",
       "type": "text",
-      "text": "**vibescore-usage-hourly**\n`insforge-src/functions/vibescore-usage-hourly.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-hourly (568 行)\n- initHourlyBuckets (1 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
+      "text": "**vibescore-usage-hourly**\n`insforge-src/functions/vibescore-usage-hourly.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-hourly (580 行)\n- initHourlyBuckets (1 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
       "x": 2620,
       "y": 4936,
       "width": 280,
@@ -2185,7 +2185,7 @@
     {
       "id": "edge-function_vibescore-usage-monthly_3f4484b1",
       "type": "text",
-      "text": "**vibescore-usage-monthly**\n`insforge-src/functions/vibescore-usage-monthly.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-monthly (210 行)\n- respond (3 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
+      "text": "**vibescore-usage-monthly**\n`insforge-src/functions/vibescore-usage-monthly.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-monthly (216 行)\n- respond (3 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
       "x": 460,
       "y": 5296,
       "width": 280,
@@ -2202,7 +2202,7 @@
     {
       "id": "edge-function_vibescore-usage-summary_57a00ab8",
       "type": "text",
-      "text": "**vibescore-usage-summary**\n`insforge-src/functions/vibescore-usage-summary.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-summary (500 行)\n- getSourceEntry (2 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
+      "text": "**vibescore-usage-summary**\n`insforge-src/functions/vibescore-usage-summary.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-summary (506 行)\n- getSourceEntry (2 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
       "x": 820,
       "y": 5296,
       "width": 280,

--- a/docs/pr/2026-01-07-prefixed-model-filter.md
+++ b/docs/pr/2026-01-07-prefixed-model-filter.md
@@ -1,0 +1,19 @@
+# PR Template (Minimal)
+
+## PR Goal (one sentence)
+Ensure prefixed model filters keep alias-mapped usage rows.
+
+## Commit Narrative
+- fix(usage): compare filter identity against alias-resolved identity for prefixed models
+- test(usage-daily): cover prefixed model alias filter
+- docs(pr): record regression command and result
+
+## Regression Test Gate
+### Most likely regression surface
+- Prefixed model filters on usage daily/hourly/heatmap/monthly/summary.
+
+### Verification method (choose at least one)
+- [x] `node --test test/edge-functions.test.js -t "vibeusage-usage-daily prefixed model filter includes alias rows"` => PASS
+
+### Uncovered scope
+- End-to-end usage queries against live data.

--- a/insforge-functions/vibescore-usage-daily.js
+++ b/insforge-functions/vibescore-usage-daily.js
@@ -1550,7 +1550,13 @@ module.exports = withRequestLogging("vibescore-usage-daily", async function(requ
             const rawModel = normalizeUsageModel(row?.model);
             const dateKey = extractDateKey(ts) || to;
             const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-            if (identity.model_id !== canonicalModel) continue;
+            const filterIdentity = resolveIdentityAtDate({
+              rawModel: canonicalModel,
+              usageKey: canonicalModel,
+              dateKey,
+              timeline: aliasTimeline
+            });
+            if (identity.model_id !== filterIdentity.model_id) continue;
           }
           const day = formatLocalDateKey(dt, tzContext);
           const bucket = buckets.get(day);
@@ -1598,7 +1604,13 @@ module.exports = withRequestLogging("vibescore-usage-daily", async function(requ
           const rawModel = normalizeUsageModel(row?.model);
           const dateKey = extractDateKey(day) || to;
           const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-          if (identity.model_id !== canonicalModel) continue;
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
         }
         bucket.total += toBigInt(row?.total_tokens);
         const billable = ingestRow(row);

--- a/insforge-functions/vibescore-usage-heatmap.js
+++ b/insforge-functions/vibescore-usage-heatmap.js
@@ -1214,7 +1214,13 @@ module.exports = withRequestLogging("vibescore-usage-heatmap", async function(re
             const rawModel = normalizeUsageModel(row?.model);
             const dateKey = extractDateKey(ts) || to2;
             const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline2 });
-            if (identity.model_id !== canonicalModel2) continue;
+            const filterIdentity = resolveIdentityAtDate({
+              rawModel: canonicalModel2,
+              usageKey: canonicalModel2,
+              dateKey,
+              timeline: aliasTimeline2
+            });
+            if (identity.model_id !== filterIdentity.model_id) continue;
           }
           const day = formatDateUTC(dt);
           const prev = valuesByDay2.get(day) || 0n;
@@ -1359,7 +1365,13 @@ module.exports = withRequestLogging("vibescore-usage-heatmap", async function(re
           const rawModel = normalizeUsageModel(row?.model);
           const dateKey = extractDateKey(ts) || to;
           const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-          if (identity.model_id !== canonicalModel) continue;
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
         }
         const key = formatLocalDateKey(dt, tzContext);
         const prev = valuesByDay.get(key) || 0n;

--- a/insforge-functions/vibescore-usage-hourly.js
+++ b/insforge-functions/vibescore-usage-hourly.js
@@ -1274,7 +1274,13 @@ module.exports = withRequestLogging("vibescore-usage-hourly", async function(req
             const rawModel = normalizeUsageModel(row?.model);
             const dateKey = extractDateKey(ts) || dayLabel;
             const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline2 });
-            if (identity.model_id !== canonicalModel2) continue;
+            const filterIdentity = resolveIdentityAtDate({
+              rawModel: canonicalModel2,
+              usageKey: canonicalModel2,
+              dateKey,
+              timeline: aliasTimeline2
+            });
+            if (identity.model_id !== filterIdentity.model_id) continue;
           }
           const hour = dt.getUTCHours();
           const minute = dt.getUTCMinutes();
@@ -1376,7 +1382,13 @@ module.exports = withRequestLogging("vibescore-usage-hourly", async function(req
           const rawModel = normalizeUsageModel(row?.model);
           const dateKey = extractDateKey(ts) || dayKey;
           const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-          if (identity.model_id !== canonicalModel) continue;
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
         }
         const localParts = getLocalParts(dt, tzContext);
         const localDay = formatDateParts(localParts);

--- a/insforge-functions/vibescore-usage-monthly.js
+++ b/insforge-functions/vibescore-usage-monthly.js
@@ -1227,7 +1227,13 @@ module.exports = withRequestLogging("vibescore-usage-monthly", async function(re
           const rawModel = normalizeUsageModel(row?.model);
           const dateKey = extractDateKey(ts) || to;
           const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-          if (identity.model_id !== canonicalModel) continue;
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
         }
         const localParts = getLocalParts(dt, tzContext);
         const key = `${localParts.year}-${String(localParts.month).padStart(2, "0")}`;

--- a/insforge-functions/vibescore-usage-summary.js
+++ b/insforge-functions/vibescore-usage-summary.js
@@ -1503,7 +1503,13 @@ module.exports = withRequestLogging("vibescore-usage-summary", async function(re
       dateKey,
       timeline: aliasTimeline
     });
-    return identity.model_id === canonicalModel;
+    const filterIdentity = resolveIdentityAtDate({
+      rawModel: canonicalModel,
+      usageKey: canonicalModel,
+      dateKey,
+      timeline: aliasTimeline
+    });
+    return identity.model_id === filterIdentity.model_id;
   };
   const ingestRow = (row) => {
     if (!shouldIncludeRow(row)) return;

--- a/insforge-functions/vibeusage-usage-daily.js
+++ b/insforge-functions/vibeusage-usage-daily.js
@@ -1553,7 +1553,13 @@ var require_vibescore_usage_daily = __commonJS({
                 const rawModel = normalizeUsageModel(row?.model);
                 const dateKey = extractDateKey(ts) || to;
                 const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-                if (identity.model_id !== canonicalModel) continue;
+                const filterIdentity = resolveIdentityAtDate({
+                  rawModel: canonicalModel,
+                  usageKey: canonicalModel,
+                  dateKey,
+                  timeline: aliasTimeline
+                });
+                if (identity.model_id !== filterIdentity.model_id) continue;
               }
               const day = formatLocalDateKey(dt, tzContext);
               const bucket = buckets.get(day);
@@ -1601,7 +1607,13 @@ var require_vibescore_usage_daily = __commonJS({
               const rawModel = normalizeUsageModel(row?.model);
               const dateKey = extractDateKey(day) || to;
               const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-              if (identity.model_id !== canonicalModel) continue;
+              const filterIdentity = resolveIdentityAtDate({
+                rawModel: canonicalModel,
+                usageKey: canonicalModel,
+                dateKey,
+                timeline: aliasTimeline
+              });
+              if (identity.model_id !== filterIdentity.model_id) continue;
             }
             bucket.total += toBigInt(row?.total_tokens);
             const billable = ingestRow(row);

--- a/insforge-functions/vibeusage-usage-heatmap.js
+++ b/insforge-functions/vibeusage-usage-heatmap.js
@@ -1217,7 +1217,13 @@ var require_vibescore_usage_heatmap = __commonJS({
                 const rawModel = normalizeUsageModel(row?.model);
                 const dateKey = extractDateKey(ts) || to2;
                 const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline2 });
-                if (identity.model_id !== canonicalModel2) continue;
+                const filterIdentity = resolveIdentityAtDate({
+                  rawModel: canonicalModel2,
+                  usageKey: canonicalModel2,
+                  dateKey,
+                  timeline: aliasTimeline2
+                });
+                if (identity.model_id !== filterIdentity.model_id) continue;
               }
               const day = formatDateUTC(dt);
               const prev = valuesByDay2.get(day) || 0n;
@@ -1362,7 +1368,13 @@ var require_vibescore_usage_heatmap = __commonJS({
               const rawModel = normalizeUsageModel(row?.model);
               const dateKey = extractDateKey(ts) || to;
               const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-              if (identity.model_id !== canonicalModel) continue;
+              const filterIdentity = resolveIdentityAtDate({
+                rawModel: canonicalModel,
+                usageKey: canonicalModel,
+                dateKey,
+                timeline: aliasTimeline
+              });
+              if (identity.model_id !== filterIdentity.model_id) continue;
             }
             const key = formatLocalDateKey(dt, tzContext);
             const prev = valuesByDay.get(key) || 0n;

--- a/insforge-functions/vibeusage-usage-hourly.js
+++ b/insforge-functions/vibeusage-usage-hourly.js
@@ -1277,7 +1277,13 @@ var require_vibescore_usage_hourly = __commonJS({
                 const rawModel = normalizeUsageModel(row?.model);
                 const dateKey = extractDateKey(ts) || dayLabel;
                 const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline2 });
-                if (identity.model_id !== canonicalModel2) continue;
+                const filterIdentity = resolveIdentityAtDate({
+                  rawModel: canonicalModel2,
+                  usageKey: canonicalModel2,
+                  dateKey,
+                  timeline: aliasTimeline2
+                });
+                if (identity.model_id !== filterIdentity.model_id) continue;
               }
               const hour = dt.getUTCHours();
               const minute = dt.getUTCMinutes();
@@ -1379,7 +1385,13 @@ var require_vibescore_usage_hourly = __commonJS({
               const rawModel = normalizeUsageModel(row?.model);
               const dateKey = extractDateKey(ts) || dayKey;
               const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-              if (identity.model_id !== canonicalModel) continue;
+              const filterIdentity = resolveIdentityAtDate({
+                rawModel: canonicalModel,
+                usageKey: canonicalModel,
+                dateKey,
+                timeline: aliasTimeline
+              });
+              if (identity.model_id !== filterIdentity.model_id) continue;
             }
             const localParts = getLocalParts(dt, tzContext);
             const localDay = formatDateParts(localParts);

--- a/insforge-functions/vibeusage-usage-monthly.js
+++ b/insforge-functions/vibeusage-usage-monthly.js
@@ -1230,7 +1230,13 @@ var require_vibescore_usage_monthly = __commonJS({
               const rawModel = normalizeUsageModel(row?.model);
               const dateKey = extractDateKey(ts) || to;
               const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-              if (identity.model_id !== canonicalModel) continue;
+              const filterIdentity = resolveIdentityAtDate({
+                rawModel: canonicalModel,
+                usageKey: canonicalModel,
+                dateKey,
+                timeline: aliasTimeline
+              });
+              if (identity.model_id !== filterIdentity.model_id) continue;
             }
             const localParts = getLocalParts(dt, tzContext);
             const key = `${localParts.year}-${String(localParts.month).padStart(2, "0")}`;

--- a/insforge-functions/vibeusage-usage-summary.js
+++ b/insforge-functions/vibeusage-usage-summary.js
@@ -1506,7 +1506,13 @@ var require_vibescore_usage_summary = __commonJS({
           dateKey,
           timeline: aliasTimeline
         });
-        return identity.model_id === canonicalModel;
+        const filterIdentity = resolveIdentityAtDate({
+          rawModel: canonicalModel,
+          usageKey: canonicalModel,
+          dateKey,
+          timeline: aliasTimeline
+        });
+        return identity.model_id === filterIdentity.model_id;
       };
       const ingestRow = (row) => {
         if (!shouldIncludeRow(row)) return;

--- a/insforge-src/functions/vibescore-usage-daily.js
+++ b/insforge-src/functions/vibescore-usage-daily.js
@@ -209,12 +209,18 @@ module.exports = withRequestLogging('vibescore-usage-daily', async function(requ
           if (!ts) continue;
           const dt = new Date(ts);
           if (!Number.isFinite(dt.getTime())) continue;
-          if (hasModelFilter) {
-            const rawModel = normalizeUsageModel(row?.model);
-            const dateKey = extractDateKey(ts) || to;
-            const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-            if (identity.model_id !== canonicalModel) continue;
-          }
+        if (hasModelFilter) {
+          const rawModel = normalizeUsageModel(row?.model);
+          const dateKey = extractDateKey(ts) || to;
+          const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
+        }
           const day = formatLocalDateKey(dt, tzContext);
           const bucket = buckets.get(day);
           if (!bucket) continue;
@@ -270,7 +276,13 @@ module.exports = withRequestLogging('vibescore-usage-daily', async function(requ
           const rawModel = normalizeUsageModel(row?.model);
           const dateKey = extractDateKey(day) || to;
           const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-          if (identity.model_id !== canonicalModel) continue;
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
         }
         bucket.total += toBigInt(row?.total_tokens);
         const billable = ingestRow(row);

--- a/insforge-src/functions/vibescore-usage-heatmap.js
+++ b/insforge-src/functions/vibescore-usage-heatmap.js
@@ -139,7 +139,13 @@ module.exports = withRequestLogging('vibescore-usage-heatmap', async function(re
             const rawModel = normalizeUsageModel(row?.model);
             const dateKey = extractDateKey(ts) || to;
             const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-            if (identity.model_id !== canonicalModel) continue;
+            const filterIdentity = resolveIdentityAtDate({
+              rawModel: canonicalModel,
+              usageKey: canonicalModel,
+              dateKey,
+              timeline: aliasTimeline
+            });
+            if (identity.model_id !== filterIdentity.model_id) continue;
           }
           const day = formatDateUTC(dt);
           const prev = valuesByDay.get(day) || 0n;
@@ -313,7 +319,13 @@ module.exports = withRequestLogging('vibescore-usage-heatmap', async function(re
           const rawModel = normalizeUsageModel(row?.model);
           const dateKey = extractDateKey(ts) || to;
           const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-          if (identity.model_id !== canonicalModel) continue;
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
         }
         const key = formatLocalDateKey(dt, tzContext);
         const prev = valuesByDay.get(key) || 0n;

--- a/insforge-src/functions/vibescore-usage-hourly.js
+++ b/insforge-src/functions/vibescore-usage-hourly.js
@@ -213,7 +213,13 @@ module.exports = withRequestLogging('vibescore-usage-hourly', async function(req
           const rawModel = normalizeUsageModel(row?.model);
           const dateKey = extractDateKey(ts) || dayLabel;
           const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-          if (identity.model_id !== canonicalModel) continue;
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
         }
           const hour = dt.getUTCHours();
           const minute = dt.getUTCMinutes();
@@ -337,7 +343,13 @@ module.exports = withRequestLogging('vibescore-usage-hourly', async function(req
           const rawModel = normalizeUsageModel(row?.model);
           const dateKey = extractDateKey(ts) || dayKey;
           const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-          if (identity.model_id !== canonicalModel) continue;
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
         }
         const localParts = getLocalParts(dt, tzContext);
         const localDay = formatDateParts(localParts);

--- a/insforge-src/functions/vibescore-usage-monthly.js
+++ b/insforge-src/functions/vibescore-usage-monthly.js
@@ -153,7 +153,13 @@ module.exports = withRequestLogging('vibescore-usage-monthly', async function(re
           const rawModel = normalizeUsageModel(row?.model);
           const dateKey = extractDateKey(ts) || to;
           const identity = resolveIdentityAtDate({ rawModel, dateKey, timeline: aliasTimeline });
-          if (identity.model_id !== canonicalModel) continue;
+          const filterIdentity = resolveIdentityAtDate({
+            rawModel: canonicalModel,
+            usageKey: canonicalModel,
+            dateKey,
+            timeline: aliasTimeline
+          });
+          if (identity.model_id !== filterIdentity.model_id) continue;
         }
         const localParts = getLocalParts(dt, tzContext);
         const key = `${localParts.year}-${String(localParts.month).padStart(2, '0')}`;

--- a/insforge-src/functions/vibescore-usage-summary.js
+++ b/insforge-src/functions/vibescore-usage-summary.js
@@ -150,7 +150,13 @@ module.exports = withRequestLogging('vibescore-usage-summary', async function(re
       dateKey,
       timeline: aliasTimeline
     });
-    return identity.model_id === canonicalModel;
+    const filterIdentity = resolveIdentityAtDate({
+      rawModel: canonicalModel,
+      usageKey: canonicalModel,
+      dateKey,
+      timeline: aliasTimeline
+    });
+    return identity.model_id === filterIdentity.model_id;
   };
 
   const ingestRow = (row) => {


### PR DESCRIPTION
# PR Template (Minimal)

## PR Goal (one sentence)
Ensure prefixed model filters keep alias-mapped usage rows.

## Commit Narrative
- fix(usage): compare filter identity against alias-resolved identity for prefixed models
- test(usage-daily): cover prefixed model alias filter
- docs(pr): record regression command and result

## Regression Test Gate
### Most likely regression surface
- Prefixed model filters on usage daily/hourly/heatmap/monthly/summary.

### Verification method (choose at least one)
- [x] `node --test test/edge-functions.test.js -t "vibeusage-usage-daily prefixed model filter includes alias rows"` => PASS

### Uncovered scope
- End-to-end usage queries against live data.
