### PR TITLE
fix: align usage model breakdown pricing

### DIFF
--- a/architecture.canvas
+++ b/architecture.canvas
@@ -508,7 +508,7 @@
     {
       "id": "test_edge-functions_test_deffefcc",
       "type": "text",
-      "text": "**edge-functions.test**\n`test/edge-functions.test.js`\n\nTest module.\n\n包含：\n- edge-functions.test (5590 行)\n- toBase64Url (1 个参数)\n\n依赖：3 个模块\n被依赖：0 次",
+      "text": "**edge-functions.test**\n`test/edge-functions.test.js`\n\nTest module.\n\n包含：\n- edge-functions.test (5724 行)\n- toBase64Url (1 个参数)\n\n依赖：3 个模块\n被依赖：0 次",
       "x": 460,
       "y": 11212,
       "width": 280,
@@ -2185,7 +2185,7 @@
     {
       "id": "edge-function_vibescore-usage-model-breakdown_846bd53b",
       "type": "text",
-      "text": "**vibescore-usage-model-breakdown**\n`insforge-src/functions/vibescore-usage-model-breakdown.js`\n\nEdge function handler.\n\n包含：\n- vibescore-usage-model-breakdown (289 行)\n- createTotals (0 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
+      "text": "**vibescore-usage-model-breakdown**\n`insforge-src/functions/vibescore-usage-model-breakdown.js`\n\nEdge function handler.\nStatus: Implemented\nNotes: Align cost calculation with usage-summary (per-model/date pricing for totals).\n\n包含：\n- vibescore-usage-model-breakdown (356 行)\n- createTotals (0 个参数)\n\n依赖：0 个模块\n被依赖：0 次",
       "x": 100,
       "y": 5296,
       "width": 280,

--- a/docs/plans/2026-01-12-usage-breakdown-pricing-alignment-implementation-plan.md
+++ b/docs/plans/2026-01-12-usage-breakdown-pricing-alignment-implementation-plan.md
@@ -1,0 +1,236 @@
+# Usage Breakdown Pricing Alignment Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Align usage-model-breakdown cost totals with usage-summary by pricing per model/date buckets.
+
+**Architecture:** Extend vibescore-usage-model-breakdown to compute cost from model/date buckets (using resolvePricingProfile per bucket) and sum per source/model; keep pricing metadata aligned with summary’s mixed/add/overlap behavior.
+
+**Tech Stack:** Node.js, Insforge edge functions, shared pricing utilities, Node test runner.
+
+---
+
+### Task 1: Add failing test for per-alias pricing in model breakdown
+
+**Files:**
+- Modify: `test/edge-functions.test.js`
+
+**Step 1: 编写失败测试**
+
+```js
+test('vibeusage-usage-model-breakdown prices per-alias effective_from when unfiltered', async () => {
+  const fn = require('../insforge-functions/vibeusage-usage-model-breakdown');
+
+  const userId = '23232323-2323-2323-2323-232323232323';
+  const userJwt = 'user_jwt_test';
+
+  const hourlyRows = [
+    {
+      hour_start: '2025-01-15T00:00:00.000Z',
+      source: 'codex',
+      model: 'gpt-foo',
+      total_tokens: 1000000,
+      input_tokens: 1000000,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0
+    },
+    {
+      hour_start: '2025-02-15T00:00:00.000Z',
+      source: 'codex',
+      model: 'gpt-foo',
+      total_tokens: 1000000,
+      input_tokens: 1000000,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0
+    }
+  ];
+
+  const aliasRows = [
+    {
+      usage_model: 'gpt-foo',
+      canonical_model: 'alpha',
+      display_name: 'Alpha',
+      effective_from: '2025-01-01',
+      active: true
+    },
+    {
+      usage_model: 'gpt-foo',
+      canonical_model: 'beta',
+      display_name: 'Beta',
+      effective_from: '2025-02-01',
+      active: true
+    }
+  ];
+
+  const pricingProfiles = {
+    alpha: {
+      model: 'alpha',
+      source: 'openrouter',
+      effective_from: '2025-01-01',
+      input_rate_micro_per_million: 1000000,
+      cached_input_rate_micro_per_million: 0,
+      output_rate_micro_per_million: 0,
+      reasoning_output_rate_micro_per_million: 0
+    },
+    beta: {
+      model: 'beta',
+      source: 'openrouter',
+      effective_from: '2025-02-01',
+      input_rate_micro_per_million: 2000000,
+      cached_input_rate_micro_per_million: 0,
+      output_rate_micro_per_million: 0,
+      reasoning_output_rate_micro_per_million: 0
+    }
+  };
+
+  globalThis.createClient = (args) => {
+    if (args && args.edgeFunctionToken === userJwt) {
+      return {
+        auth: {
+          getCurrentUser: async () => ({ data: { user: { id: userId } }, error: null })
+        },
+        database: {
+          from: (table) => {
+            if (table === 'vibescore_tracker_hourly') {
+              const query = createQueryMock({ rows: hourlyRows });
+              return { select: () => query };
+            }
+            if (table === 'vibescore_model_aliases') {
+              return createQueryMock({ rows: aliasRows });
+            }
+            if (table === 'vibescore_pricing_profiles') {
+              const state = { model: null };
+              const query = {
+                select: () => query,
+                eq: (col, value) => {
+                  if (col === 'model') state.model = value;
+                  return query;
+                },
+                lte: () => query,
+                order: () => query,
+                or: (expr) => {
+                  const match = String(expr).match(/model\.eq\.([^,]+)/);
+                  if (match) state.model = match[1];
+                  return query;
+                },
+                limit: async () => {
+                  const row = pricingProfiles[state.model];
+                  return { data: row ? [row] : [], error: null };
+                }
+              };
+              return query;
+            }
+            if (table === 'vibescore_pricing_model_aliases') {
+              return createQueryMock({ rows: [] });
+            }
+            throw new Error(`Unexpected table ${table}`);
+          }
+        }
+      };
+    }
+    throw new Error(`Unexpected createClient args: ${JSON.stringify(args)}`);
+  };
+
+  const req = new Request(
+    'http://localhost/functions/vibeusage-usage-model-breakdown?from=2025-01-01&to=2025-02-15',
+    {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${userJwt}` }
+    }
+  );
+
+  const res = await fn(req);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  const source = body.sources.find((entry) => entry.source === 'codex');
+  const alpha = source?.models?.find((entry) => entry.model_id === 'alpha');
+  const beta = source?.models?.find((entry) => entry.model_id === 'beta');
+  assert.equal(alpha?.totals?.total_cost_usd, '1.000000');
+  assert.equal(beta?.totals?.total_cost_usd, '2.000000');
+  assert.equal(source?.totals?.total_cost_usd, '3.000000');
+});
+```
+
+**Step 2: 运行测试确认失败**
+
+Run: `node --test test/edge-functions.test.js`
+
+Expected: FAIL with mismatch on `total_cost_usd` (breakdown still uses single pricing profile).
+
+---
+
+### Task 2: Align breakdown cost calculation with summary buckets
+
+**Files:**
+- Modify: `insforge-src/functions/vibescore-usage-model-breakdown.js`
+
+**Step 1: 编写最小实现**
+
+目标：在按 source/model 聚合 totals 的同时，新增按 `source + model_id + dateKey` 的 cost bucket 聚合，并用 `resolvePricingProfile` 逐 bucket 计算成本，累加到 source/model。
+
+**Step 2: 更新 totals 输出**
+
+- 为 source/model entry 增加 `cost_micros` 仅用于内部累加。
+- 调整 `formatTotals`：当 entry 有 `cost_micros` 时优先用它生成 `total_cost_usd`，并避免把 `cost_micros` 暴露到响应。
+- pricing metadata：沿用 summary 的 `pricingModes` 规则（1 个用该模式，多于 1 个用 `mixed`），profile 取 `impliedModelId` 的 `resolvePricingProfile`。
+
+---
+
+### Task 3: 生成函数构建产物
+
+**Files:**
+- Modify (generated): `insforge-functions/vibescore-usage-model-breakdown.js`
+- Modify (generated): `insforge-functions/vibeusage-usage-model-breakdown.js`
+
+**Step 1: 运行构建脚本**
+
+Run: `node scripts/build-insforge-functions.cjs`
+
+Expected: Generated files updated.
+
+---
+
+### Task 4: 验证与回归
+
+**Step 1: 重新运行单测**
+
+Run: `node --test test/edge-functions.test.js`
+
+Expected: PASS for new breakdown pricing test.
+
+**Step 2: 回归用例记录**
+
+Run: `node --test test/edge-functions.test.js`
+
+Expected: PASS (记录命令与结果到提交说明/说明文档)。
+
+---
+
+### Task 5: Canvas 同步
+
+**Files:**
+- Modify: `architecture.canvas`
+
+**Step 1: 将 Proposed 改为 Implemented**
+
+把 `vibescore-usage-model-breakdown` 节点中的 `Status: Proposed` 改为 `Status: Implemented`。
+
+**Step 2: 重新生成画布并确认一致**
+
+Run: `node scripts/ops/architecture-canvas.cjs`
+
+Expected: No drift beyond known status/notes updates.
+
+---
+
+### Task 6: 提交
+
+**Step 1: Commit**
+
+```bash
+git add test/edge-functions.test.js insforge-src/functions/vibescore-usage-model-breakdown.js insforge-functions/vibescore-usage-model-breakdown.js insforge-functions/vibeusage-usage-model-breakdown.js architecture.canvas
+git commit -m "fix: align usage model breakdown pricing"
+```
+

--- a/insforge-functions/vibescore-usage-model-breakdown.js
+++ b/insforge-functions/vibescore-usage-model-breakdown.js
@@ -1526,6 +1526,7 @@ module.exports = withRequestLogging("vibescore-usage-model-breakdown", async fun
   });
   const aliasTimeline = buildAliasTimeline({ usageModels, aliasRows });
   const sourcesMap = /* @__PURE__ */ new Map();
+  const costBuckets = /* @__PURE__ */ new Map();
   const canonicalModels = /* @__PURE__ */ new Set();
   const grandTotals = createTotals();
   for (const row of rowsBuffer) {
@@ -1544,11 +1545,50 @@ module.exports = withRequestLogging("vibescore-usage-model-breakdown", async fun
     }
     const canonicalEntry = getCanonicalEntry(sourceEntry.models, identity);
     addTotals(canonicalEntry.totals, row);
+    const bucketModelId = identity?.model_id || DEFAULT_MODEL;
+    const bucketModelName = identity?.model || bucketModelId;
+    const bucketKey = buildCostBucketKey(row.source, bucketModelId, dateKey);
+    const bucket = costBuckets.get(bucketKey) || {
+      source: row.source,
+      model_id: bucketModelId,
+      model: bucketModelName,
+      dateKey,
+      totals: createTotals()
+    };
+    addTotals(bucket.totals, row);
+    costBuckets.set(bucketKey, bucket);
   }
-  const pricingModel = canonicalModels.size === 1 ? Array.from(canonicalModels)[0] : null;
+  const pricingModes = /* @__PURE__ */ new Set();
+  const profileCache = /* @__PURE__ */ new Map();
+  const getProfile = async (modelId, dateKey) => {
+    const key = `${modelId || ""}::${dateKey || ""}`;
+    if (profileCache.has(key)) return profileCache.get(key);
+    const profile = await resolvePricingProfile({
+      edgeClient: auth.edgeClient,
+      model: modelId || null,
+      effectiveDate: dateKey || to
+    });
+    profileCache.set(key, profile);
+    return profile;
+  };
+  for (const bucket of costBuckets.values()) {
+    const profile = await getProfile(bucket.model_id, bucket.dateKey);
+    const cost = computeUsageCost(bucket.totals, profile);
+    pricingModes.add(cost.pricing_mode);
+    const sourceEntry = sourcesMap.get(bucket.source);
+    addCostMicros(sourceEntry, cost.cost_micros);
+    if (sourceEntry) {
+      const modelEntry = getCanonicalEntry(sourceEntry.models, {
+        model_id: bucket.model_id,
+        model: bucket.model
+      });
+      addCostMicros(modelEntry, cost.cost_micros);
+    }
+  }
+  const impliedModelId = canonicalModels.size === 1 ? Array.from(canonicalModels)[0] : null;
   const pricingProfile = await resolvePricingProfile({
     edgeClient: auth.edgeClient,
-    model: pricingModel,
+    model: impliedModelId,
     effectiveDate: to
   });
   const sources = Array.from(sourcesMap.values()).map((entry) => {
@@ -1561,6 +1601,12 @@ module.exports = withRequestLogging("vibescore-usage-model-breakdown", async fun
     };
   }).sort((a, b) => a.source.localeCompare(b.source));
   const overallCost = computeUsageCost(grandTotals, pricingProfile);
+  let summaryPricingMode = overallCost.pricing_mode;
+  if (pricingModes.size === 1) {
+    summaryPricingMode = Array.from(pricingModes)[0];
+  } else if (pricingModes.size > 1) {
+    summaryPricingMode = "mixed";
+  }
   return respond(
     {
       from,
@@ -1569,7 +1615,7 @@ module.exports = withRequestLogging("vibescore-usage-model-breakdown", async fun
       sources,
       pricing: buildPricingMetadata({
         profile: overallCost.profile,
-        pricingMode: overallCost.pricing_mode
+        pricingMode: summaryPricingMode
       })
     },
     200,
@@ -1618,9 +1664,10 @@ function getCanonicalEntry(map, identity) {
 }
 function formatTotals(entry, pricingProfile) {
   const totals = entry.totals;
-  const cost = computeUsageCost(totals, pricingProfile);
+  const costMicros = resolveCostMicros(entry, pricingProfile);
+  const { cost_micros: _ignored, ...rest } = entry;
   return {
-    ...entry,
+    ...rest,
     totals: {
       total_tokens: totals.total_tokens.toString(),
       billable_total_tokens: totals.billable_total_tokens.toString(),
@@ -1628,7 +1675,7 @@ function formatTotals(entry, pricingProfile) {
       cached_input_tokens: totals.cached_input_tokens.toString(),
       output_tokens: totals.output_tokens.toString(),
       reasoning_output_tokens: totals.reasoning_output_tokens.toString(),
-      total_cost_usd: formatUsdFromMicros(cost.cost_micros)
+      total_cost_usd: formatUsdFromMicros(costMicros)
     }
   };
 }
@@ -1637,4 +1684,17 @@ function compareTotals(a, b) {
   const bSort = toBigInt(b?.totals?.billable_total_tokens ?? b?.totals?.total_tokens);
   if (aSort === bSort) return String(a?.model || "").localeCompare(String(b?.model || ""));
   return aSort > bSort ? -1 : 1;
+}
+function buildCostBucketKey(source, modelId, dateKey) {
+  return `${source || ""}::${modelId || ""}::${dateKey || ""}`;
+}
+function addCostMicros(entry, costMicros) {
+  if (!entry) return;
+  entry.cost_micros = toBigInt(entry.cost_micros) + toBigInt(costMicros);
+}
+function resolveCostMicros(entry, pricingProfile) {
+  if (!entry) return 0n;
+  if (typeof entry.cost_micros === "bigint") return entry.cost_micros;
+  const cost = computeUsageCost(entry.totals, pricingProfile);
+  return cost.cost_micros;
 }

--- a/insforge-functions/vibeusage-usage-model-breakdown.js
+++ b/insforge-functions/vibeusage-usage-model-breakdown.js
@@ -1529,6 +1529,7 @@ var require_vibescore_usage_model_breakdown = __commonJS({
       });
       const aliasTimeline = buildAliasTimeline({ usageModels, aliasRows });
       const sourcesMap = /* @__PURE__ */ new Map();
+      const costBuckets = /* @__PURE__ */ new Map();
       const canonicalModels = /* @__PURE__ */ new Set();
       const grandTotals = createTotals();
       for (const row of rowsBuffer) {
@@ -1547,11 +1548,50 @@ var require_vibescore_usage_model_breakdown = __commonJS({
         }
         const canonicalEntry = getCanonicalEntry(sourceEntry.models, identity);
         addTotals(canonicalEntry.totals, row);
+        const bucketModelId = identity?.model_id || DEFAULT_MODEL;
+        const bucketModelName = identity?.model || bucketModelId;
+        const bucketKey = buildCostBucketKey(row.source, bucketModelId, dateKey);
+        const bucket = costBuckets.get(bucketKey) || {
+          source: row.source,
+          model_id: bucketModelId,
+          model: bucketModelName,
+          dateKey,
+          totals: createTotals()
+        };
+        addTotals(bucket.totals, row);
+        costBuckets.set(bucketKey, bucket);
       }
-      const pricingModel = canonicalModels.size === 1 ? Array.from(canonicalModels)[0] : null;
+      const pricingModes = /* @__PURE__ */ new Set();
+      const profileCache = /* @__PURE__ */ new Map();
+      const getProfile = async (modelId, dateKey) => {
+        const key = `${modelId || ""}::${dateKey || ""}`;
+        if (profileCache.has(key)) return profileCache.get(key);
+        const profile = await resolvePricingProfile({
+          edgeClient: auth.edgeClient,
+          model: modelId || null,
+          effectiveDate: dateKey || to
+        });
+        profileCache.set(key, profile);
+        return profile;
+      };
+      for (const bucket of costBuckets.values()) {
+        const profile = await getProfile(bucket.model_id, bucket.dateKey);
+        const cost = computeUsageCost(bucket.totals, profile);
+        pricingModes.add(cost.pricing_mode);
+        const sourceEntry = sourcesMap.get(bucket.source);
+        addCostMicros(sourceEntry, cost.cost_micros);
+        if (sourceEntry) {
+          const modelEntry = getCanonicalEntry(sourceEntry.models, {
+            model_id: bucket.model_id,
+            model: bucket.model
+          });
+          addCostMicros(modelEntry, cost.cost_micros);
+        }
+      }
+      const impliedModelId = canonicalModels.size === 1 ? Array.from(canonicalModels)[0] : null;
       const pricingProfile = await resolvePricingProfile({
         edgeClient: auth.edgeClient,
-        model: pricingModel,
+        model: impliedModelId,
         effectiveDate: to
       });
       const sources = Array.from(sourcesMap.values()).map((entry) => {
@@ -1564,6 +1604,12 @@ var require_vibescore_usage_model_breakdown = __commonJS({
         };
       }).sort((a, b) => a.source.localeCompare(b.source));
       const overallCost = computeUsageCost(grandTotals, pricingProfile);
+      let summaryPricingMode = overallCost.pricing_mode;
+      if (pricingModes.size === 1) {
+        summaryPricingMode = Array.from(pricingModes)[0];
+      } else if (pricingModes.size > 1) {
+        summaryPricingMode = "mixed";
+      }
       return respond(
         {
           from,
@@ -1572,7 +1618,7 @@ var require_vibescore_usage_model_breakdown = __commonJS({
           sources,
           pricing: buildPricingMetadata({
             profile: overallCost.profile,
-            pricingMode: overallCost.pricing_mode
+            pricingMode: summaryPricingMode
           })
         },
         200,
@@ -1621,9 +1667,10 @@ var require_vibescore_usage_model_breakdown = __commonJS({
     }
     function formatTotals(entry, pricingProfile) {
       const totals = entry.totals;
-      const cost = computeUsageCost(totals, pricingProfile);
+      const costMicros = resolveCostMicros(entry, pricingProfile);
+      const { cost_micros: _ignored, ...rest } = entry;
       return {
-        ...entry,
+        ...rest,
         totals: {
           total_tokens: totals.total_tokens.toString(),
           billable_total_tokens: totals.billable_total_tokens.toString(),
@@ -1631,7 +1678,7 @@ var require_vibescore_usage_model_breakdown = __commonJS({
           cached_input_tokens: totals.cached_input_tokens.toString(),
           output_tokens: totals.output_tokens.toString(),
           reasoning_output_tokens: totals.reasoning_output_tokens.toString(),
-          total_cost_usd: formatUsdFromMicros(cost.cost_micros)
+          total_cost_usd: formatUsdFromMicros(costMicros)
         }
       };
     }
@@ -1640,6 +1687,19 @@ var require_vibescore_usage_model_breakdown = __commonJS({
       const bSort = toBigInt(b?.totals?.billable_total_tokens ?? b?.totals?.total_tokens);
       if (aSort === bSort) return String(a?.model || "").localeCompare(String(b?.model || ""));
       return aSort > bSort ? -1 : 1;
+    }
+    function buildCostBucketKey(source, modelId, dateKey) {
+      return `${source || ""}::${modelId || ""}::${dateKey || ""}`;
+    }
+    function addCostMicros(entry, costMicros) {
+      if (!entry) return;
+      entry.cost_micros = toBigInt(entry.cost_micros) + toBigInt(costMicros);
+    }
+    function resolveCostMicros(entry, pricingProfile) {
+      if (!entry) return 0n;
+      if (typeof entry.cost_micros === "bigint") return entry.cost_micros;
+      const cost = computeUsageCost(entry.totals, pricingProfile);
+      return cost.cost_micros;
     }
   }
 });

--- a/insforge-src/functions/vibescore-usage-model-breakdown.js
+++ b/insforge-src/functions/vibescore-usage-model-breakdown.js
@@ -156,6 +156,7 @@ module.exports = withRequestLogging('vibescore-usage-model-breakdown', async fun
   const aliasTimeline = buildAliasTimeline({ usageModels, aliasRows });
 
   const sourcesMap = new Map();
+  const costBuckets = new Map();
   const canonicalModels = new Set();
   const grandTotals = createTotals();
 
@@ -175,12 +176,55 @@ module.exports = withRequestLogging('vibescore-usage-model-breakdown', async fun
     }
     const canonicalEntry = getCanonicalEntry(sourceEntry.models, identity);
     addTotals(canonicalEntry.totals, row);
+
+    const bucketModelId = identity?.model_id || DEFAULT_MODEL;
+    const bucketModelName = identity?.model || bucketModelId;
+    const bucketKey = buildCostBucketKey(row.source, bucketModelId, dateKey);
+    const bucket = costBuckets.get(bucketKey) || {
+      source: row.source,
+      model_id: bucketModelId,
+      model: bucketModelName,
+      dateKey,
+      totals: createTotals()
+    };
+    addTotals(bucket.totals, row);
+    costBuckets.set(bucketKey, bucket);
   }
 
-  const pricingModel = canonicalModels.size === 1 ? Array.from(canonicalModels)[0] : null;
+  const pricingModes = new Set();
+  const profileCache = new Map();
+  const getProfile = async (modelId, dateKey) => {
+    const key = `${modelId || ''}::${dateKey || ''}`;
+    if (profileCache.has(key)) return profileCache.get(key);
+    const profile = await resolvePricingProfile({
+      edgeClient: auth.edgeClient,
+      model: modelId || null,
+      effectiveDate: dateKey || to
+    });
+    profileCache.set(key, profile);
+    return profile;
+  };
+
+  for (const bucket of costBuckets.values()) {
+    const profile = await getProfile(bucket.model_id, bucket.dateKey);
+    const cost = computeUsageCost(bucket.totals, profile);
+    pricingModes.add(cost.pricing_mode);
+    const sourceEntry = sourcesMap.get(bucket.source);
+    addCostMicros(sourceEntry, cost.cost_micros);
+    if (sourceEntry) {
+      const modelEntry = getCanonicalEntry(sourceEntry.models, {
+        model_id: bucket.model_id,
+        model: bucket.model
+      });
+      addCostMicros(modelEntry, cost.cost_micros);
+    }
+  }
+
+  const impliedModelId =
+    canonicalModels.size === 1 ? Array.from(canonicalModels)[0] : null;
   const pricingProfile = await resolvePricingProfile({
     edgeClient: auth.edgeClient,
-    model: pricingModel,
+    model: impliedModelId,
     effectiveDate: to
   });
 
@@ -199,6 +243,12 @@ module.exports = withRequestLogging('vibescore-usage-model-breakdown', async fun
     .sort((a, b) => a.source.localeCompare(b.source));
 
   const overallCost = computeUsageCost(grandTotals, pricingProfile);
+  let summaryPricingMode = overallCost.pricing_mode;
+  if (pricingModes.size === 1) {
+    summaryPricingMode = Array.from(pricingModes)[0];
+  } else if (pricingModes.size > 1) {
+    summaryPricingMode = 'mixed';
+  }
 
   return respond(
     {
@@ -208,7 +258,7 @@ module.exports = withRequestLogging('vibescore-usage-model-breakdown', async fun
       sources,
       pricing: buildPricingMetadata({
         profile: overallCost.profile,
-        pricingMode: overallCost.pricing_mode
+        pricingMode: summaryPricingMode
       })
     },
     200,
@@ -265,9 +315,10 @@ function getCanonicalEntry(map, identity) {
 
 function formatTotals(entry, pricingProfile) {
   const totals = entry.totals;
-  const cost = computeUsageCost(totals, pricingProfile);
+  const costMicros = resolveCostMicros(entry, pricingProfile);
+  const { cost_micros: _ignored, ...rest } = entry;
   return {
-    ...entry,
+    ...rest,
     totals: {
       total_tokens: totals.total_tokens.toString(),
       billable_total_tokens: totals.billable_total_tokens.toString(),
@@ -275,7 +326,7 @@ function formatTotals(entry, pricingProfile) {
       cached_input_tokens: totals.cached_input_tokens.toString(),
       output_tokens: totals.output_tokens.toString(),
       reasoning_output_tokens: totals.reasoning_output_tokens.toString(),
-      total_cost_usd: formatUsdFromMicros(cost.cost_micros)
+      total_cost_usd: formatUsdFromMicros(costMicros)
     }
   };
 }
@@ -285,4 +336,20 @@ function compareTotals(a, b) {
   const bSort = toBigInt(b?.totals?.billable_total_tokens ?? b?.totals?.total_tokens);
   if (aSort === bSort) return String(a?.model || '').localeCompare(String(b?.model || ''));
   return aSort > bSort ? -1 : 1;
+}
+
+function buildCostBucketKey(source, modelId, dateKey) {
+  return `${source || ''}::${modelId || ''}::${dateKey || ''}`;
+}
+
+function addCostMicros(entry, costMicros) {
+  if (!entry) return;
+  entry.cost_micros = toBigInt(entry.cost_micros) + toBigInt(costMicros);
+}
+
+function resolveCostMicros(entry, pricingProfile) {
+  if (!entry) return 0n;
+  if (typeof entry.cost_micros === 'bigint') return entry.cost_micros;
+  const cost = computeUsageCost(entry.totals, pricingProfile);
+  return cost.cost_micros;
 }

--- a/test/edge-functions.test.js
+++ b/test/edge-functions.test.js
@@ -4128,6 +4128,140 @@ test('vibeusage-usage-model-breakdown honors alias effective_from across range',
   assert.equal(beta?.totals?.total_tokens, '200');
 });
 
+test('vibeusage-usage-model-breakdown prices per-alias effective_from when unfiltered', async () => {
+  const fn = require('../insforge-functions/vibeusage-usage-model-breakdown');
+
+  const userId = '23232323-2323-2323-2323-232323232323';
+  const userJwt = 'user_jwt_test';
+
+  const hourlyRows = [
+    {
+      hour_start: '2025-01-15T00:00:00.000Z',
+      source: 'codex',
+      model: 'gpt-foo',
+      total_tokens: 1000000,
+      input_tokens: 1000000,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0
+    },
+    {
+      hour_start: '2025-02-15T00:00:00.000Z',
+      source: 'codex',
+      model: 'gpt-foo',
+      total_tokens: 1000000,
+      input_tokens: 1000000,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0
+    }
+  ];
+
+  const aliasRows = [
+    {
+      usage_model: 'gpt-foo',
+      canonical_model: 'alpha',
+      display_name: 'Alpha',
+      effective_from: '2025-01-01',
+      active: true
+    },
+    {
+      usage_model: 'gpt-foo',
+      canonical_model: 'beta',
+      display_name: 'Beta',
+      effective_from: '2025-02-01',
+      active: true
+    }
+  ];
+
+  const pricingProfiles = {
+    alpha: {
+      model: 'alpha',
+      source: 'openrouter',
+      effective_from: '2025-01-01',
+      input_rate_micro_per_million: 1000000,
+      cached_input_rate_micro_per_million: 0,
+      output_rate_micro_per_million: 0,
+      reasoning_output_rate_micro_per_million: 0
+    },
+    beta: {
+      model: 'beta',
+      source: 'openrouter',
+      effective_from: '2025-02-01',
+      input_rate_micro_per_million: 2000000,
+      cached_input_rate_micro_per_million: 0,
+      output_rate_micro_per_million: 0,
+      reasoning_output_rate_micro_per_million: 0
+    }
+  };
+
+  globalThis.createClient = (args) => {
+    if (args && args.edgeFunctionToken === userJwt) {
+      return {
+        auth: {
+          getCurrentUser: async () => ({ data: { user: { id: userId } }, error: null })
+        },
+        database: {
+          from: (table) => {
+            if (table === 'vibescore_tracker_hourly') {
+              const query = createQueryMock({ rows: hourlyRows });
+              return { select: () => query };
+            }
+            if (table === 'vibescore_model_aliases') {
+              return createQueryMock({ rows: aliasRows });
+            }
+            if (table === 'vibescore_pricing_profiles') {
+              const state = { model: null };
+              const query = {
+                select: () => query,
+                eq: (col, value) => {
+                  if (col === 'model') state.model = value;
+                  return query;
+                },
+                lte: () => query,
+                order: () => query,
+                or: (expr) => {
+                  const match = String(expr).match(/model\.eq\.([^,]+)/);
+                  if (match) state.model = match[1];
+                  return query;
+                },
+                limit: async () => {
+                  const row = pricingProfiles[state.model];
+                  return { data: row ? [row] : [], error: null };
+                }
+              };
+              return query;
+            }
+            if (table === 'vibescore_pricing_model_aliases') {
+              return createQueryMock({ rows: [] });
+            }
+            throw new Error(`Unexpected table ${table}`);
+          }
+        }
+      };
+    }
+    throw new Error(`Unexpected createClient args: ${JSON.stringify(args)}`);
+  };
+
+  const req = new Request(
+    'http://localhost/functions/vibeusage-usage-model-breakdown?from=2025-01-01&to=2025-02-15',
+    {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${userJwt}` }
+    }
+  );
+
+  const res = await fn(req);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  const source = body.sources.find((entry) => entry.source === 'codex');
+  const alpha = source?.models?.find((entry) => entry.model_id === 'alpha');
+  const beta = source?.models?.find((entry) => entry.model_id === 'beta');
+  assert.equal(alpha?.totals?.total_cost_usd, '1.000000');
+  assert.equal(beta?.totals?.total_cost_usd, '2.000000');
+  assert.equal(source?.totals?.total_cost_usd, '3.000000');
+});
+
 test('vibeusage-usage-daily canonical model filter includes alias rows', async () => {
   const fn = require('../insforge-functions/vibeusage-usage-daily');
 


### PR DESCRIPTION
## Summary
- align usage-model-breakdown cost calculation with per-model/date pricing buckets
- cache pricing profiles and propagate per-model/source totals consistently
- add regression test and regenerate edge function artifacts

## Test Plan
- [x] node --test test/edge-functions.test.js