### PR TITLE
redesign PR review contract and live-body risk gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,52 @@
-# PR Goal (one sentence)
-
-## Scope
+# What does this PR do?
 
 -
 
-## Affected Modules / Dependency Notes
+## Related Issue
+
+Fixes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Docs
+- [ ] CI / workflow
+- [ ] Risk / contract change
+
+## Changes Made
+
+- 
+
+## Affected Modules / Contracts
 
 - **Modules touched:**
 - **Dependencies / contracts touched:**
 - **Repo sitemap evidence:** `updated` / `not required` / affected section(s)
 
-## Codex Context (required when requesting @codex review)
+## Validation
 
-- **Delta since last Codex review:** (commits or summary)
-- **Intended behavior / invariants:**
-- **Edge cases covered:**
-- **Tests run (command + result):**
-- **Known gaps / out of scope:**
+### Automated
 
-## Risk Layer Trigger (if any)
+- 
+
+### Manual / smoke
+
+- 
+
+### Uncovered scope
+
+- 
+
+## Risk Flags
 
 - [ ] Public exposure / share links / unauthenticated access
 - [ ] Auth/session/token handling
 - [ ] Cross-endpoint invariants or shared logic
 - [ ] External gateway / environment constraints
 
-## Risk Layer Addendum (fill ONLY if any trigger checked)
+## Risk Addendum (required if any risk flag is checked)
 
 ### Rules / Invariants
 
@@ -35,28 +56,24 @@
 
 -
 
-### Evidence (tests or repro)
+### Evidence
 
 -
 
-## Public Exposure Checklist (if applicable)
+## Public Exposure Addendum (required if public exposure is checked)
 
-- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
-- [ ] Exposed fields explicitly listed and verified
-- [ ] Avatar/image policy defined
-- [ ] Regression tests cover invalid link and auth fallback
-- [ ] Mark N/A if no public exposure
+- **Access rules:**
+- **Exposed fields:**
+- **Avatar / image policy:**
+- **Regression coverage:**
 
-## Regression Test Gate
+## Reviewer Context (optional)
 
-### Most likely regression surface
+- **Review focus:**
+- **Delta since last review:**
+- **Depends on:**
+- **Known gaps / follow-ups:**
 
--
+## Screenshots / Logs (optional)
 
-### Verification method (choose at least one)
-
-- [ ]
-
-### Uncovered scope
-
--
+- 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,9 +73,11 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 # PR 预检与风险层门禁
 
-- PR 模板必须填写 `Affected Modules / Dependency Notes` 与 `Codex Context`，跨模块变更需附 repo sitemap evidence（更新说明或受影响小节）。
-- 若 Risk Layer Trigger 勾选任一项，必须补全 Addendum（Rules/Invariants、Boundary Matrix ≥ 3、Evidence）。
-- CI 会执行 `node scripts/ops/pr-risk-layer-gate.cjs`；本地可用 `--body-file` 预检。
+- PR 模板必须填写 `Affected Modules / Contracts`、`Validation` 与 `Risk Flags`；跨模块变更需附 repo sitemap evidence（更新说明或受影响小节）。
+- 若 `Risk Flags` 勾选任一项，必须补全 `Risk Addendum`（`Rules / Invariants`、`Boundary Matrix ≥ 3`、`Evidence`）。
+- 若勾选 `Public exposure / share links / unauthenticated access`，必须补全 `Public Exposure Addendum`。
+- `Reviewer Context` 仅供 reviewer / AI 复审参考，不属于硬门禁。
+- CI 会执行 `node scripts/ops/pr-risk-layer-gate.cjs`；在 CI 中优先读取 live PR body，event payload 仅作为 fallback；本地可用 `--body-file` 预检。
 - 详细流程见 `docs/ops/pr-review-preflight.md`。
 
 # 工作流规则（Workflow）

--- a/docs/ops/pr-review-preflight.md
+++ b/docs/ops/pr-review-preflight.md
@@ -2,10 +2,45 @@
 
 ## Purpose
 
-- Gate `@codex review` behind a machine-checkable PR body contract.
+- Gate the PR body on a machine-checkable review contract.
 - Keep the contract reusable across repositories by separating:
   - generic validator logic in `scripts/ops/pr-risk-layer-gate.cjs`
-  - repo-specific requirements in `scripts/ops/pr-risk-layer-gate.config.json`
+  - repo-specific machine contract in `scripts/ops/pr-risk-layer-gate.config.json`
+- Separate four concerns explicitly:
+  - permanent required sections
+  - conditional required sections
+  - optional reviewer context
+  - machine-checked fields
+
+## Contract Taxonomy
+
+### Permanent required
+
+These sections are required on every PR and are machine-checked:
+
+- `What does this PR do?`
+- `Type of Change`
+- `Changes Made`
+- `Affected Modules / Contracts`
+- `Validation`
+- `Risk Flags`
+
+### Conditional required
+
+These sections are required only when triggered by checked risk flags:
+
+- `Risk Addendum (required if any risk flag is checked)`
+  - `Rules / Invariants`
+  - `Boundary Matrix (must list at least 3)`
+  - `Evidence`
+- `Public Exposure Addendum (required if public exposure is checked)`
+
+### Optional reviewer context
+
+These sections help reviewers but are not CI-blocking:
+
+- `Reviewer Context (optional)`
+- `Screenshots / Logs (optional)`
 
 ## Local Usage
 
@@ -16,13 +51,32 @@
 npm run review:preflight -- --body-file /absolute/path/to/pr-body.md --require-body
 ```
 
-3. If the command fails, fix the PR body before requesting `@codex review`.
+3. If the command fails, fix the PR body before requesting review.
 
-## CI Usage
+## CI Body Source Precedence
 
-- `CI` runs `npm run validate:pr-risk-layer` on pull requests.
-- The script reads `GITHUB_EVENT_PATH` automatically and validates `pull_request.body`.
-- Push builds without a PR body skip this check.
+In CI, the gate resolves the PR body in this order:
+
+1. `--body`
+2. `--body-file`
+3. live GitHub API pull request body
+4. `GITHUB_EVENT_PATH` payload fallback
+
+Why this order matters:
+
+- rerunning a workflow does not guarantee a refreshed event payload
+- PR body edits after the original event can leave `GITHUB_EVENT_PATH` stale
+- the live GitHub PR object is the actual review surface and therefore the correct CI source of truth
+
+The gate emits diagnostics showing whether it used the live GitHub API or fell back to the event payload.
+
+## Current VibeUsage Contract
+
+- `Affected Modules / Contracts` remains required for every PR.
+- Cross-module changes still need repo sitemap evidence.
+- Any checked risk flag requires the risk addendum.
+- The public exposure addendum is required only when the public exposure flag is checked.
+- Reviewer context is optional and is not part of the hard gate.
 
 ## Reusable Contract
 
@@ -37,16 +91,15 @@ node scripts/ops/pr-risk-layer-gate.cjs --config scripts/ops/pr-risk-layer-gate.
 ```
 
 4. Align the PR template headings with the config.
-5. Add a regression test that ensures the config and template stay aligned.
+5. Add a regression test that keeps the template, config, and trigger labels aligned.
 
-## Current VibeUsage Contract
+## Common Failure Modes
 
-- Required sections:
-  - `Affected Modules / Dependency Notes`
-  - `Codex Context (required when requesting @codex review)`
-- Conditional gate:
-  - if any item in `Risk Layer Trigger (if any)` is checked,
-  - then `Rules / Invariants`, `Boundary Matrix (must list at least 3)`, and `Evidence (tests or repro)` must be filled.
+- untouched template stubs in `Affected Modules / Contracts`
+- checked risk flags without a complete risk addendum
+- public exposure checked without a public exposure addendum
+- stale event payload fallback after a GitHub API fetch failure
+- missing required sections in `Validation`
 
 ## Review Loop
 
@@ -56,5 +109,5 @@ Use this order:
 2. Run targeted tests and repo-local regression checks.
 3. Run `npm run ci:local`.
 4. Run `npm run review:preflight -- --body-file /absolute/path/to/pr-body.md --require-body`.
-5. Request `@codex review`.
-6. If review returns issues, update code, tests, and `Codex Context`, then repeat from step 2.
+5. Request review.
+6. If review returns issues, update code, tests, and any optional `Reviewer Context`, then repeat from step 2.

--- a/openspec/changes/2026-04-11-redesign-pr-review-gate/design.md
+++ b/openspec/changes/2026-04-11-redesign-pr-review-gate/design.md
@@ -1,0 +1,198 @@
+# Design: PR template and PR body gate redesign
+
+## Context
+
+This redesign is driven by a mismatch between author intent, reviewer workflow, and machine enforcement:
+
+- The current template presents `Codex Context` as conditional reviewer context.
+- The current gate config treats it as unconditionally required.
+- The current CI runtime prefers `GITHUB_EVENT_PATH`, which is a historical event snapshot and can remain stale across reruns.
+
+We benchmarked strong external repositories before proposing a localized redesign:
+
+- **Hermes Agent**: contributor-friendly summary + testing + checklists; reviewer help is not over-gated.
+- **Kubernetes**: strong separation between reviewer notes and machine-consumable structured blocks such as release notes.
+- **Angular**: clean split between always-required sections and conditional sections such as breaking changes.
+- **Storybook**: clear distinction between contributor fields, maintainer-only sections, and machine-mutated markers.
+- **LangChain**: uses workflow/policy checks for some constraints instead of forcing every concern into the PR body.
+
+The localized VibeUsage requirement is to preserve repo-specific contract quality around:
+
+- changed modules and dependency/contracts touched
+- repo sitemap evidence
+- risk-layer triggers
+- cross-boundary invariants
+- public-exposure review when applicable
+
+## Goals
+
+- Produce a PR template that is easy for authors to fill and easy for reviewers to scan.
+- Make machine enforcement cover only stable, high-signal fields.
+- Make conditional risk review first-class and explicit.
+- Treat the live GitHub PR body as the CI truth source.
+- Remove tool-specific wording from the core contract.
+
+## Non-Goals
+
+- Do not preserve the existing `Codex Context` section name for compatibility.
+- Do not make optional reviewer context machine-blocking.
+- Do not rely on push-only event refresh as a workaround for stale PR body validation.
+- Do not add new external runtime dependencies if the GitHub API call can be made with built-in Node APIs.
+
+## Contract Taxonomy
+
+### 1. Permanent required sections
+
+These apply to every PR and are suitable for machine validation:
+
+- `What does this PR do?`
+- `Type of Change`
+- `Changes Made`
+- `Affected Modules / Contracts`
+- `Validation`
+- `Risk Flags`
+
+### 2. Conditional required sections
+
+These are required only when the corresponding trigger is checked:
+
+- `Risk Addendum`
+  - `Rules / Invariants`
+  - `Boundary Matrix`
+  - `Evidence`
+- `Public Exposure Addendum`
+  - required only when the public exposure flag is checked
+
+### 3. Optional reviewer context
+
+These help humans or AI reviewers but are not CI-gated:
+
+- `Reviewer Context`
+  - review focus
+  - delta since last review
+  - dependencies / review ordering
+  - known gaps / follow-ups
+- screenshots / logs
+
+### 4. Machine-checked vs non-checked
+
+Machine-checked:
+
+- required section headings exist
+- required sections are non-empty and not untouched stubs
+- checked risk flags require the corresponding addendum
+- `Boundary Matrix` contains at least three bullets
+
+Not machine-checked:
+
+- prose quality
+- screenshot presence
+- optional reviewer context completeness
+- whether the author used a specific AI reviewer
+
+## Template Design
+
+The template SHALL be reorganized into this top-level flow:
+
+1. `What does this PR do?`
+2. `Related Issue`
+3. `Type of Change`
+4. `Changes Made`
+5. `Affected Modules / Contracts`
+6. `Validation`
+7. `Risk Flags`
+8. `Risk Addendum (required if any risk flag is checked)`
+9. `Public Exposure Addendum (required if public exposure is checked)`
+10. `Reviewer Context (optional)`
+11. `Screenshots / Logs (optional)`
+
+This structure keeps contributor-facing information near the top, moves risk disclosures into explicit conditionals, and demotes re-review notes to optional reviewer context.
+
+## Gate Config Design
+
+The JSON config becomes the machine contract source of truth.
+
+It SHALL define:
+
+- placeholder values and untouched stub markers
+- required top-level sections
+- conditional rules keyed by trigger section and checked labels
+- minimum content constraints such as bullet counts
+
+It SHALL NOT encode reviewer-tool-specific names like `Codex Context` in the permanent contract.
+
+## CI Body Source Resolution
+
+The gate SHALL resolve the PR body in this priority order:
+
+1. `--body`
+2. `--body-file`
+3. live GitHub API fetch of the pull request body
+4. `GITHUB_EVENT_PATH` payload fallback
+5. null
+
+### Why live API first in CI
+
+The body being reviewed is the current PR object on GitHub, not the historical event payload that triggered a previous run. On rerun, `GITHUB_EVENT_PATH` can remain stale after the PR body is edited. Using the live API first restores single-source-of-truth behavior.
+
+### Live API fetch requirements
+
+The gate runtime SHALL:
+
+- derive repository and PR number from GitHub Actions environment or event payload
+- use `GITHUB_TOKEN` for authentication when available
+- emit body-source diagnostics that identify whether the body came from explicit input, live API, or event payload fallback
+- continue with event fallback if the API fetch fails
+
+## Alternatives Considered
+
+### Alternative A: Keep `Codex Context`, but make it truly conditional
+
+Rejected as the primary design.
+
+Pros:
+
+- minimal wording churn for current users
+- preserves familiar section name
+
+Cons:
+
+- still binds a stable workflow contract to one reviewer/tool brand
+- requires an additional trigger source to know whether `@codex review` was requested
+- preserves a mixed semantic bucket instead of separating permanent facts from reviewer-only context
+
+### Alternative B: Keep current template and only fix stale body reads
+
+Rejected.
+
+Pros:
+
+- smallest code diff
+
+Cons:
+
+- does not resolve contract taxonomy problems
+- leaves template/config/docs semantic drift intact
+- continues to hard-gate reviewer-loop prose that should remain optional
+
+## Testing Strategy
+
+The updated test suite SHALL cover:
+
+- template/config alignment for required sections and conditional triggers
+- reviewer context being optional and not enforced
+- risk addendum required when any risk flag is checked
+- public exposure addendum required only for public exposure
+- live API body preferred over event payload when both are available
+- event payload fallback when live API is unavailable
+- stale event payload rerun scenario
+- empty body producing validation failure instead of silent skip when a PR context exists
+
+## Rollout Notes
+
+This redesign should land in the following order:
+
+1. proposal + design + task checklist
+2. template + config + docs alignment
+3. gate runtime source-resolution update
+4. test updates and CI verification

--- a/openspec/changes/2026-04-11-redesign-pr-review-gate/proposal.md
+++ b/openspec/changes/2026-04-11-redesign-pr-review-gate/proposal.md
@@ -1,0 +1,55 @@
+# Change: Redesign PR template and PR body gate around a stable review contract
+
+## Why
+
+- The current PR template, CI gate config, and reviewer guidance have drifted out of alignment. The clearest mismatch is that the template says `Codex Context` is only required when requesting `@codex review`, while the machine gate treats it as unconditionally required.
+- The current CI gate reads PR body content from `GITHUB_EVENT_PATH`, which can become stale on workflow reruns after the PR body is edited. That makes the gate validate an old snapshot instead of the live PR body that reviewers actually see.
+- The current contract mixes four different concerns into one body structure: permanent author-supplied facts, conditional risk disclosures, reviewer-only context, and machine-checkable enforcement. This increases author burden and makes the gate brittle.
+- We want to re-design the system from first principles using benchmarked external practice, then localize it to VibeUsage's repo-sitemap and risk-layer workflow.
+
+## What Changes
+
+- Define a new PR review contract that separates permanent required sections, conditional risk addenda, optional reviewer context, and machine-checked fields.
+- Replace the current `Codex Context` hard gate with stable, tool-agnostic sections so reviewer context is no longer conflated with machine-required PR facts.
+- Redesign the PR template around a contributor-friendly structure: summary, type, changed modules/contracts, validation, risk flags, conditional addenda, and optional reviewer context.
+- Update the PR risk-layer gate to treat the GitHub PR object as the preferred body source in CI, with event payloads retained only as a fallback.
+- Make the JSON gate config the single source of truth for machine-required sections and conditional rules, then align the template, docs, tests, and AGENTS workflow language to it.
+
+## Impact
+
+- Affected specs: `pr-review-gate` (new)
+- Affected code: `.github/PULL_REQUEST_TEMPLATE.md`, `scripts/ops/pr-risk-layer-gate.cjs`, `scripts/ops/pr-risk-layer-gate.config.json`, `docs/ops/pr-review-preflight.md`, `test/pr-risk-layer-gate.test.js`, `AGENTS.md`, `.github/workflows/ci.yml`
+- **BREAKING**: The existing `Codex Context` section name and unconditional hard requirement are removed. Existing PR author workflow must migrate to the new section taxonomy.
+
+## Architecture / Flow
+
+- Author fills a PR template that distinguishes:
+  - permanent required facts for every PR
+  - conditional addenda triggered by checked risk flags
+  - optional reviewer context that helps re-review but is not CI-blocking
+- Local preflight continues to support `--body` and `--body-file` for deterministic validation.
+- CI validation resolves PR body sources in descending priority: explicit body input, explicit body file, live GitHub API pull request body, event payload fallback.
+- The gate validates only stable machine contracts and conditional risk addenda. Reviewer-only context remains optional.
+
+## Principles
+
+- **Single source of truth:** the gate config defines the machine contract; the live GitHub PR object is the preferred body source in CI.
+- **First principles:** gate what is stable, high-signal, and materially useful; do not hard-block reviewer-only prose.
+- **No backward compatibility:** do not preserve misleading section names or semantics just to avoid template churn.
+- **Atomic commits:** land docs/spec, template+config, gate runtime, and tests in separate commits.
+
+## Risks & Mitigations
+
+- Risk: reviewer workflow confusion during transition.
+  - Mitigation: update `docs/ops/pr-review-preflight.md` and `AGENTS.md` in the same change and explain the new taxonomy explicitly.
+- Risk: live GitHub API fetch can fail due to token or network issues.
+  - Mitigation: keep event payload fallback, surface body-source diagnostics in logs, and fail only when no valid body source exists or the contract is actually violated.
+- Risk: new template still drifts from config over time.
+  - Mitigation: extend tests so template headings, conditional triggers, and non-gated optional sections stay aligned with config semantics.
+
+## Rollout / Milestones
+
+- M1 Benchmark external PR template / gate patterns and codify the new contract taxonomy.
+- M2 Rewrite template, config, and reviewer docs around the new contract.
+- M3 Implement live-body-first gate resolution and improved diagnostics.
+- M4 Update tests and workflow docs; verify local and CI behavior against stale-payload and conditional-risk scenarios.

--- a/openspec/changes/2026-04-11-redesign-pr-review-gate/specs/pr-review-gate/spec.md
+++ b/openspec/changes/2026-04-11-redesign-pr-review-gate/specs/pr-review-gate/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: PR body contract taxonomy
+
+The system SHALL define the PR body contract using four explicit categories: permanent required sections, conditional required sections, optional reviewer context, and machine-checked fields.
+
+#### Scenario: Reviewer context is not part of the hard gate
+
+- **WHEN** a pull request omits optional reviewer context
+- **THEN** the PR body gate SHALL still pass as long as all required and triggered conditional sections are complete
+- **AND** the repository documentation SHALL describe reviewer context as optional
+
+#### Scenario: Machine contract is stable and tool-agnostic
+
+- **WHEN** the PR body gate evaluates the template contract
+- **THEN** it SHALL validate stable section semantics such as summary, changed modules/contracts, validation evidence, and risk disclosures
+- **AND** it SHALL NOT require a reviewer-tool-specific section name such as `Codex Context`
+
+### Requirement: Conditional risk addenda
+
+The system SHALL require additional PR body sections only when the corresponding risk flags are triggered.
+
+#### Scenario: Generic risk addendum required
+
+- **WHEN** any risk flag is checked in the PR body
+- **THEN** the PR SHALL include `Rules / Invariants`, `Boundary Matrix`, and `Evidence`
+- **AND** the gate SHALL fail if any of those triggered sections is missing or left as a placeholder
+
+#### Scenario: Public exposure addendum required only when applicable
+
+- **WHEN** the `Public exposure / share links / unauthenticated access` risk flag is checked
+- **THEN** the PR SHALL include a public-exposure-specific addendum describing access rules, exposed fields, media/avatar policy, and regression coverage
+- **AND** the gate SHALL NOT require that addendum for PRs that do not trigger public exposure review
+
+### Requirement: Live PR body source in CI
+
+The system SHALL prefer the live GitHub pull request body over historical event payload snapshots when validating PR bodies in CI.
+
+#### Scenario: Rerun after PR body edit
+
+- **WHEN** a pull request body is edited after the original workflow event and CI is rerun
+- **THEN** the gate SHALL validate the current live PR body from the GitHub API when credentials and PR context are available
+- **AND** the gate SHALL NOT depend on a new push solely to refresh the event payload body
+
+#### Scenario: Event payload fallback
+
+- **WHEN** the live GitHub API body cannot be fetched
+- **THEN** the gate SHALL fall back to the event payload body if available
+- **AND** the runtime output SHALL indicate that fallback was used
+
+### Requirement: Gate config as machine source of truth
+
+The system SHALL keep the machine-enforced PR body contract in the gate config and SHALL keep the PR template and tests aligned with it.
+
+#### Scenario: Template and config stay aligned
+
+- **WHEN** the repository updates required headings, trigger labels, or conditional addenda
+- **THEN** the gate config, PR template, and regression tests SHALL be updated together
+- **AND** CI SHALL fail if the template no longer reflects the configured machine contract

--- a/openspec/changes/2026-04-11-redesign-pr-review-gate/tasks.md
+++ b/openspec/changes/2026-04-11-redesign-pr-review-gate/tasks.md
@@ -1,0 +1,24 @@
+## 1. Contract redesign
+
+- [x] 1.1 Replace the current mixed PR body taxonomy with explicit categories: permanent required, conditional required, optional reviewer context, and machine-checked fields.
+- [x] 1.2 Remove `Codex Context` from the permanent machine contract and define its replacement fields in tool-agnostic language.
+- [x] 1.3 Decide the final top-level template headings and conditional trigger labels.
+
+## 2. Template and docs
+
+- [x] 2.1 Rewrite `.github/PULL_REQUEST_TEMPLATE.md` to match the new taxonomy.
+- [x] 2.2 Rewrite `docs/ops/pr-review-preflight.md` so it documents contract taxonomy, local preflight flow, CI body-source precedence, and common failure modes.
+- [x] 2.3 Update `AGENTS.md` so repository workflow instructions refer to the new sections instead of `Codex Context`.
+
+## 3. Gate config and runtime
+
+- [x] 3.1 Rewrite `scripts/ops/pr-risk-layer-gate.config.json` so it is the single source of truth for required and conditional machine checks.
+- [x] 3.2 Update `scripts/ops/pr-risk-layer-gate.cjs` to resolve PR body sources in the new priority order: explicit body, explicit body file, live GitHub API, event payload fallback.
+- [x] 3.3 Add runtime diagnostics that show which body source was used and when fallback occurred.
+
+## 4. Tests and verification
+
+- [x] 4.1 Update `test/pr-risk-layer-gate.test.js` for the new headings and semantics.
+- [x] 4.2 Add coverage for live API precedence, fallback behavior, stale event payload reruns, and optional reviewer context.
+- [x] 4.3 Run targeted tests for the gate and then `npm run validate:pr-risk-layer` against representative sample bodies.
+- [x] 4.4 Record the verification commands and results in the sample PR body used for local gate validation; copy them into the real PR `Validation` section when opening the PR.

--- a/scripts/ops/pr-risk-layer-gate.cjs
+++ b/scripts/ops/pr-risk-layer-gate.cjs
@@ -112,6 +112,10 @@ function getCheckedLabels(section) {
     .map((match) => match[2].trim());
 }
 
+function countCheckedItems(section) {
+  return getCheckedLabels(section).length;
+}
+
 function validateRequiredSection(tree, requirement, config, errors) {
   const section = findSection(tree, requirement.heading);
   if (!section) {
@@ -123,9 +127,16 @@ function validateRequiredSection(tree, requirement, config, errors) {
     const joined = section.contentLines.join("\n");
     for (const expected of requirement.requiredStrings) {
       if (!joined.includes(expected)) {
-        errors.push(
-          `Section "${requirement.heading}" must include: ${expected}`,
-        );
+        errors.push(`Section "${requirement.heading}" must include: ${expected}`);
+      }
+    }
+  }
+
+  if (requirement.requiredChildHeadings) {
+    const childHeadings = new Set((section.children || []).map((child) => child.heading));
+    for (const expected of requirement.requiredChildHeadings) {
+      if (!childHeadings.has(expected)) {
+        errors.push(`Section "${requirement.heading}" must include subsection: ${expected}`);
       }
     }
   }
@@ -145,6 +156,27 @@ function validateRequiredSection(tree, requirement, config, errors) {
       errors.push(
         `Section "${requirement.heading}" must include at least ${requirement.minListItems} list item(s).`,
       );
+    }
+  }
+
+  if (requirement.minCheckedItems) {
+    const checkedItems = countCheckedItems(section);
+    if (checkedItems < requirement.minCheckedItems) {
+      errors.push(
+        `Section "${requirement.heading}" must include at least ${requirement.minCheckedItems} checked item(s).`,
+      );
+    }
+  }
+
+  if (requirement.requiredChildSections) {
+    for (const childRequirement of requirement.requiredChildSections) {
+      const childSection = (section.children || []).find((child) => child.heading === childRequirement.heading);
+      if (!childSection) {
+        errors.push(`Section "${requirement.heading}" must include subsection: ${childRequirement.heading}`);
+        continue;
+      }
+      const syntheticTree = { heading: section.heading, children: [childSection] };
+      validateRequiredSection(syntheticTree, childRequirement, config, errors);
     }
   }
 }
@@ -190,23 +222,87 @@ function loadBodyFromEvent(eventFile) {
   return null;
 }
 
-function resolveBody(args) {
-  if (Object.prototype.hasOwnProperty.call(args, "body")) return args.body;
-  if (args.bodyFile) return loadBodyFromFile(args.bodyFile);
+function loadEventPayload(eventFile) {
+  if (!eventFile || !fs.existsSync(eventFile)) return null;
+  return JSON.parse(fs.readFileSync(eventFile, "utf8"));
+}
 
-  const eventFile = args.eventFile || process.env.GITHUB_EVENT_PATH;
-  if (eventFile && fs.existsSync(eventFile)) {
+function getPullRequestContext({ args = {}, env = process.env, eventPayload = null } = {}) {
+  const payload = eventPayload || loadEventPayload(args.eventFile || env.GITHUB_EVENT_PATH);
+  const repo = env.GITHUB_REPOSITORY || payload?.repository?.full_name || null;
+  const prNumber = payload?.pull_request?.number || payload?.issue?.number || null;
+  return { repo, prNumber, eventPayload: payload };
+}
+
+async function loadBodyFromGitHubApi({ repo, prNumber, token, fetchImpl = global.fetch } = {}) {
+  if (!repo || !prNumber || !token || typeof fetchImpl !== "function") {
+    return null;
+  }
+
+  const response = await fetchImpl(`https://api.github.com/repos/${repo}/pulls/${prNumber}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "vibeusage-pr-risk-layer-gate",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed with status ${response.status}`);
+  }
+
+  const payload = await response.json();
+  return Object.prototype.hasOwnProperty.call(payload, "body") ? (payload.body ?? "") : null;
+}
+
+async function resolveBody(args, options = {}) {
+  const env = options.env || process.env;
+  if (Object.prototype.hasOwnProperty.call(args, "body")) {
+    return args.body;
+  }
+  if (args.bodyFile) {
+    return loadBodyFromFile(args.bodyFile);
+  }
+
+  const eventFile = args.eventFile || env.GITHUB_EVENT_PATH;
+  const { repo, prNumber, eventPayload } = getPullRequestContext({ args: { eventFile }, env });
+  const diagnostics = options.diagnostics || [];
+
+  if (repo && prNumber && env.GITHUB_TOKEN) {
+    try {
+      const liveBody = await loadBodyFromGitHubApi({
+        repo,
+        prNumber,
+        token: env.GITHUB_TOKEN,
+        fetchImpl: options.fetchImpl || global.fetch,
+      });
+      if (liveBody !== null && liveBody !== undefined) {
+        diagnostics.push(`body_source=github-api repo=${repo} pr=${prNumber}`);
+        return liveBody;
+      }
+    } catch (error) {
+      diagnostics.push(`body_source=github-api-failed repo=${repo} pr=${prNumber} error=${error.message}`);
+    }
+  }
+
+  if (eventPayload) {
     const body = loadBodyFromEvent(eventFile);
-    if (body !== null && body !== undefined) return body;
+    if (body !== null && body !== undefined) {
+      diagnostics.push(`body_source=event-payload${repo && prNumber ? ` repo=${repo} pr=${prNumber}` : ""}`);
+      return body;
+    }
   }
 
   return null;
 }
 
-function main() {
+async function main() {
   const args = parseArgs(process.argv.slice(2));
   const config = args.config ? loadConfig(path.resolve(args.config)) : DEFAULT_CONFIG;
-  const body = resolveBody(args);
+  const diagnostics = [];
+  const body = await resolveBody(args, { diagnostics });
+
+  diagnostics.forEach((line) => console.log(`[pr-risk-layer] ${line}`));
 
   if (body === null || body === undefined) {
     if (args.requireBody) {
@@ -232,10 +328,16 @@ function main() {
 module.exports = {
   DEFAULT_CONFIG,
   evaluatePrBody,
+  getPullRequestContext,
   loadBodyFromEvent,
+  loadBodyFromGitHubApi,
   parseMarkdown,
+  resolveBody,
 };
 
 if (require.main === module) {
-  main();
+  main().catch((error) => {
+    console.error(`PR risk layer gate failed: ${error.message}`);
+    process.exit(1);
+  });
 }

--- a/scripts/ops/pr-risk-layer-gate.config.json
+++ b/scripts/ops/pr-risk-layer-gate.config.json
@@ -1,29 +1,53 @@
 {
   "placeholderValues": [
     "-",
+    "N/A",
     "**Modules touched:**",
     "**Dependencies / contracts touched:**",
-    "**Repo sitemap evidence:** `updated` / `not required` / affected section(s)"
+    "**Repo sitemap evidence:** `updated` / `not required` / affected section(s)",
+    "**Access rules:**",
+    "**Exposed fields:**",
+    "**Avatar / image policy:**",
+    "**Regression coverage:**"
   ],
   "requiredSections": [
     {
-      "heading": "Affected Modules / Dependency Notes",
+      "heading": "What does this PR do?",
+      "minContentLines": 1
+    },
+    {
+      "heading": "Type of Change",
+      "minCheckedItems": 1
+    },
+    {
+      "heading": "Changes Made",
+      "minListItems": 1
+    },
+    {
+      "heading": "Affected Modules / Contracts",
       "minContentLines": 3
     },
     {
-      "heading": "Codex Context (required when requesting @codex review)",
-      "requiredStrings": [
-        "**Delta since last Codex review:**",
-        "**Intended behavior / invariants:**",
-        "**Edge cases covered:**",
-        "**Tests run (command + result):**",
-        "**Known gaps / out of scope:**"
+      "heading": "Validation",
+      "requiredChildHeadings": [
+        "Automated",
+        "Manual / smoke",
+        "Uncovered scope"
+      ],
+      "requiredChildSections": [
+        { "heading": "Automated", "minContentLines": 1 },
+        { "heading": "Manual / smoke", "minContentLines": 1 },
+        { "heading": "Uncovered scope", "minContentLines": 1 }
       ]
+    },
+    {
+      "heading": "Risk Flags",
+      "minListItems": 4
     }
   ],
   "conditionalSections": [
     {
-      "triggerHeading": "Risk Layer Trigger (if any)",
+      "triggerHeading": "Risk Flags",
       "triggerLabels": [
         "Public exposure / share links / unauthenticated access",
         "Auth/session/token handling",
@@ -31,6 +55,9 @@
         "External gateway / environment constraints"
       ],
       "requiredSections": [
+        {
+          "heading": "Risk Addendum (required if any risk flag is checked)"
+        },
         {
           "heading": "Rules / Invariants",
           "minContentLines": 1
@@ -40,8 +67,26 @@
           "minListItems": 3
         },
         {
-          "heading": "Evidence (tests or repro)",
+          "heading": "Evidence",
           "minContentLines": 1
+        }
+      ]
+    },
+    {
+      "triggerHeading": "Risk Flags",
+      "triggerLabels": [
+        "Public exposure / share links / unauthenticated access"
+      ],
+      "requiredSections": [
+        {
+          "heading": "Public Exposure Addendum (required if public exposure is checked)",
+          "minContentLines": 4,
+          "requiredStrings": [
+            "**Access rules:**",
+            "**Exposed fields:**",
+            "**Avatar / image policy:**",
+            "**Regression coverage:**"
+          ]
         }
       ]
     }

--- a/test/pr-risk-layer-gate.test.js
+++ b/test/pr-risk-layer-gate.test.js
@@ -6,11 +6,12 @@ const path = require("node:path");
 const { test } = require("node:test");
 
 const repoRoot = path.join(__dirname, "..");
-const {
-  DEFAULT_CONFIG,
-  evaluatePrBody,
-  loadBodyFromEvent,
-} = require("../scripts/ops/pr-risk-layer-gate.cjs");
+const gateModulePath = path.join(repoRoot, "scripts", "ops", "pr-risk-layer-gate.cjs");
+
+function loadGateModule() {
+  delete require.cache[require.resolve(gateModulePath)];
+  return require(gateModulePath);
+}
 
 function writeTempFile(root, relativePath, content) {
   const filePath = path.join(root, relativePath);
@@ -20,113 +21,188 @@ function writeTempFile(root, relativePath, content) {
 }
 
 function createCompleteBody() {
-  return `# PR Goal (one sentence)
+  return `# What does this PR do?
 
-## Scope
+Add a stable PR review contract with live-body CI validation.
 
-- Add reusable PR review preflight gate.
+## Related Issue
 
-## Affected Modules / Dependency Notes
+Fixes #134
 
-- Modules: scripts/ops, test, docs/ops, .github
-- Dependencies/contracts touched: PR template contract, CI preflight, AGENTS workflow
-- Repo sitemap evidence: updated Scripts And Validation and Workflow docs sections
+## Type of Change
 
-## Codex Context (required when requesting @codex review)
+- [x] CI / workflow
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Docs
+- [ ] Risk / contract change
 
-- **Delta since last Codex review:** first review on this PR
-- **Intended behavior / invariants:** review requests fail fast when required sections are missing
-- **Edge cases covered:** missing sections, triggered risk layer without addendum, complete body
-- **Tests run (command + result):** node --test test/pr-risk-layer-gate.test.js => PASS
-- **Known gaps / out of scope:** no GitHub API polling changes
+## Changes Made
 
-## Risk Layer Trigger (if any)
+- redesign the PR body contract around stable required sections
+- move re-review notes into optional reviewer context
+- prefer live GitHub PR body in CI
 
-- [x] Auth/session/token handling
-- [ ] Public exposure / share links / unauthenticated access
-- [ ] Cross-endpoint invariants or shared logic
-- [ ] External gateway / environment constraints
+## Affected Modules / Contracts
 
-## Risk Layer Addendum (fill ONLY if any trigger checked)
+- **Modules touched:** \`.github/PULL_REQUEST_TEMPLATE.md\`, \`scripts/ops/pr-risk-layer-gate.cjs\`, \`scripts/ops/pr-risk-layer-gate.config.json\`, \`docs/ops/pr-review-preflight.md\`, \`test/pr-risk-layer-gate.test.js\`
+- **Dependencies / contracts touched:** PR template contract, CI PR body source precedence, reviewer workflow wording
+- **Repo sitemap evidence:** \`not required\`
 
-### Rules / Invariants
+## Validation
 
-- Review gate must fail before @codex review when risk metadata is incomplete.
+### Automated
 
-### Boundary Matrix (must list at least 3)
+- \`node --test test/pr-risk-layer-gate.test.js\` => PASS
 
-- PR body -> parser -> required sections
-- Risk trigger -> addendum completeness -> exit code
-- CI event payload -> PR body extraction -> validation outcome
+### Manual / smoke
 
-### Evidence (tests or repro)
-
-- node --test test/pr-risk-layer-gate.test.js => PASS
-
-## Public Exposure Checklist (if applicable)
-
-- [x] Mark N/A if no public exposure
-
-## Regression Test Gate
-
-### Most likely regression surface
-
-- PR body parser drifts from template headings.
-
-### Verification method (choose at least one)
-
-- [x] Automated node test
+- rerun CI after editing the PR body and confirm the gate reads the live PR body
 
 ### Uncovered scope
 
-- GitHub-hosted runtime execution path
+- live GitHub Actions network path
+
+## Risk Flags
+
+- [ ] Public exposure / share links / unauthenticated access
+- [ ] Auth/session/token handling
+- [x] Cross-endpoint invariants or shared logic
+- [ ] External gateway / environment constraints
+
+## Risk Addendum (required if any risk flag is checked)
+
+### Rules / Invariants
+
+- reviewer context is optional and must not be part of the hard gate
+
+### Boundary Matrix (must list at least 3)
+
+- PR template -> gate config -> required sections
+- live GitHub API body -> parser -> validation result
+- checked risk flag -> addendum completeness -> CI exit code
+
+### Evidence
+
+- \`node --test test/pr-risk-layer-gate.test.js\` => PASS
+
+## Reviewer Context (optional)
+
+- **Review focus:** source precedence and optional reviewer context
+- **Delta since last review:** rename sections and remove Codex-specific hard gate
+- **Depends on:** none
+- **Known gaps / follow-ups:** none
+
+## Screenshots / Logs (optional)
+
+- N/A
 `;
 }
 
 test("evaluatePrBody fails when required affected-modules section is missing", () => {
+  const { DEFAULT_CONFIG, evaluatePrBody } = loadGateModule();
   const body = createCompleteBody().replace(
-    /\n## Affected Modules \/ Dependency Notes[\s\S]*?\n## Codex Context/,
-    "\n## Codex Context",
+    /\n## Affected Modules \/ Contracts[\s\S]*?\n## Validation/,
+    "\n## Validation",
   );
 
   const result = evaluatePrBody(body, DEFAULT_CONFIG);
 
   assert.equal(result.ok, false);
   assert.ok(
-    result.errors.some((error) => error.includes("Affected Modules / Dependency Notes")),
+    result.errors.some((error) => error.includes("Affected Modules / Contracts")),
     `expected missing affected modules error, got ${result.errors.join("\n")}`,
   );
 });
 
 test("evaluatePrBody rejects untouched affected-modules template stub lines", () => {
+  const { DEFAULT_CONFIG, evaluatePrBody } = loadGateModule();
   const body = createCompleteBody().replace(
-    /## Affected Modules \/ Dependency Notes[\s\S]*?## Codex Context/,
-    `## Affected Modules / Dependency Notes
+    /## Affected Modules \/ Contracts[\s\S]*?## Validation/,
+    `## Affected Modules / Contracts
 
 - **Modules touched:**
 - **Dependencies / contracts touched:**
 - **Repo sitemap evidence:** \`updated\` / \`not required\` / affected section(s)
 
-## Codex Context`,
+## Validation`,
   );
 
   const result = evaluatePrBody(body, DEFAULT_CONFIG);
 
   assert.equal(result.ok, false);
   assert.ok(
-    result.errors.some((error) => error.includes("Affected Modules / Dependency Notes")),
+    result.errors.some((error) => error.includes("Affected Modules / Contracts")),
     `expected untouched template stubs to fail affected-modules validation, got ${result.errors.join("\n")}`,
   );
 });
 
-test("evaluatePrBody fails when risk layer is checked without complete addendum", () => {
+test("evaluatePrBody passes without reviewer context because it is optional", () => {
+  const { DEFAULT_CONFIG, evaluatePrBody } = loadGateModule();
   const body = createCompleteBody().replace(
-    /### Boundary Matrix \(must list at least 3\)[\s\S]*?### Evidence \(tests or repro\)/,
+    /\n## Reviewer Context \(optional\)[\s\S]*?\n## Screenshots \/ Logs \(optional\)/,
+    "\n## Screenshots / Logs (optional)",
+  );
+
+  const result = evaluatePrBody(body, DEFAULT_CONFIG);
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+});
+
+test("evaluatePrBody fails when type of change has no checked item", () => {
+  const { DEFAULT_CONFIG, evaluatePrBody } = loadGateModule();
+  const body = createCompleteBody().replace(/- \[x\] CI \/ workflow/, "- [ ] CI / workflow");
+
+  const result = evaluatePrBody(body, DEFAULT_CONFIG);
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some((error) => error.includes("Type of Change") && error.includes("checked")),
+    `expected checked type-of-change error, got ${result.errors.join("\n")}`,
+  );
+});
+
+test("evaluatePrBody fails when validation subsections are left as placeholders", () => {
+  const { DEFAULT_CONFIG, evaluatePrBody } = loadGateModule();
+  const body = createCompleteBody().replace(
+    /## Validation[\s\S]*?## Risk Flags/,
+    `## Validation
+
+### Automated
+
+- 
+
+### Manual / smoke
+
+- 
+
+### Uncovered scope
+
+- 
+
+## Risk Flags`,
+  );
+
+  const result = evaluatePrBody(body, DEFAULT_CONFIG);
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some((error) => error.includes("Automated") && error.includes("non-placeholder")),
+    `expected validation subsection error, got ${result.errors.join("\n")}`,
+  );
+});
+
+test("evaluatePrBody fails when risk layer is checked without complete addendum", () => {
+  const { DEFAULT_CONFIG, evaluatePrBody } = loadGateModule();
+  const body = createCompleteBody().replace(
+    /### Boundary Matrix \(must list at least 3\)[\s\S]*?### Evidence/,
     `### Boundary Matrix (must list at least 3)
 
-- PR body -> parser -> required sections
+- PR template -> gate config -> required sections
 
-### Evidence (tests or repro)`,
+### Evidence`,
   );
 
   const result = evaluatePrBody(body, DEFAULT_CONFIG);
@@ -138,18 +214,45 @@ test("evaluatePrBody fails when risk layer is checked without complete addendum"
   );
 });
 
+test("evaluatePrBody requires public exposure addendum only when public exposure is checked", () => {
+  const { DEFAULT_CONFIG, evaluatePrBody } = loadGateModule();
+  const body = createCompleteBody().replace(
+    "- [ ] Public exposure / share links / unauthenticated access",
+    "- [x] Public exposure / share links / unauthenticated access",
+  );
+
+  const result = evaluatePrBody(body, DEFAULT_CONFIG);
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some((error) => error.includes("Public Exposure Addendum")),
+    `expected public exposure addendum error, got ${result.errors.join("\n")}`,
+  );
+});
+
 test("evaluatePrBody passes for complete default-config PR body", () => {
-  const result = evaluatePrBody(createCompleteBody(), DEFAULT_CONFIG);
+  const { DEFAULT_CONFIG, evaluatePrBody } = loadGateModule();
+  const body = `${createCompleteBody()}
+## Public Exposure Addendum (required if public exposure is checked)
+
+- **Access rules:** N/A
+- **Exposed fields:** N/A
+- **Avatar / image policy:** N/A
+- **Regression coverage:** N/A
+`;
+
+  const result = evaluatePrBody(body, DEFAULT_CONFIG);
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.errors, []);
 });
 
 test("evaluatePrBody supports reusable custom config", () => {
+  const { evaluatePrBody } = loadGateModule();
   const config = {
     requiredSections: [
       { heading: "Summary", minContentLines: 1 },
-      { heading: "Verification", minListItems: 2 },
+      { heading: "Validation", minListItems: 2 },
     ],
     conditionalSections: [
       {
@@ -166,7 +269,7 @@ test("evaluatePrBody supports reusable custom config", () => {
 
 Migration script for the new storage layout.
 
-## Verification
+## Validation
 
 - unit tests
 - smoke run
@@ -187,6 +290,7 @@ Re-run the old migration and restore previous config.
 });
 
 test("loadBodyFromEvent reads pull request body from GitHub event payload", () => {
+  const { loadBodyFromEvent } = loadGateModule();
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "pr-risk-layer-"));
   const eventPath = writeTempFile(
     root,
@@ -203,6 +307,7 @@ test("loadBodyFromEvent reads pull request body from GitHub event payload", () =
 });
 
 test("loadBodyFromEvent returns null when event has no PR or issue body source", () => {
+  const { loadBodyFromEvent } = loadGateModule();
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "pr-risk-layer-missing-"));
   const eventPath = writeTempFile(
     root,
@@ -216,6 +321,72 @@ test("loadBodyFromEvent returns null when event has no PR or issue body source",
 
   const body = loadBodyFromEvent(eventPath);
   assert.equal(body, null);
+});
+
+test("resolveBody prefers live GitHub API body over stale event payload body", async () => {
+  const gate = loadGateModule();
+  assert.equal(typeof gate.resolveBody, "function", "expected resolveBody export");
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "pr-risk-layer-live-"));
+  const eventPath = writeTempFile(
+    root,
+    "event.json",
+    JSON.stringify({
+      repository: { full_name: "victorGPT/vibeusage" },
+      pull_request: { number: 134, body: "stale body" },
+    }),
+  );
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ body: "live body" }),
+  });
+
+  try {
+    const body = await gate.resolveBody({ eventFile: eventPath }, {
+      env: {
+        GITHUB_TOKEN: "test-token",
+        GITHUB_REPOSITORY: "victorGPT/vibeusage",
+      },
+    });
+    assert.equal(body, "live body");
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("resolveBody falls back to event payload when live GitHub API fetch fails", async () => {
+  const gate = loadGateModule();
+  assert.equal(typeof gate.resolveBody, "function", "expected resolveBody export");
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "pr-risk-layer-fallback-"));
+  const eventPath = writeTempFile(
+    root,
+    "event.json",
+    JSON.stringify({
+      repository: { full_name: "victorGPT/vibeusage" },
+      pull_request: { number: 134, body: "stale but usable body" },
+    }),
+  );
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    throw new Error("network down");
+  };
+
+  try {
+    const body = await gate.resolveBody({ eventFile: eventPath }, {
+      env: {
+        GITHUB_TOKEN: "test-token",
+        GITHUB_REPOSITORY: "victorGPT/vibeusage",
+      },
+    });
+    assert.equal(body, "stale but usable body");
+  } finally {
+    global.fetch = originalFetch;
+  }
 });
 
 test("CLI gate treats empty PR body as invalid instead of skipping", () => {
@@ -232,7 +403,7 @@ test("CLI gate treats empty PR body as invalid instead of skipping", () => {
 
   const result = cp.spawnSync(
     process.execPath,
-    [path.join(repoRoot, "scripts", "ops", "pr-risk-layer-gate.cjs"), "--event-file", eventPath],
+    [gateModulePath, "--event-file", eventPath],
     {
       cwd: repoRoot,
       encoding: "utf8",
@@ -245,6 +416,7 @@ test("CLI gate treats empty PR body as invalid instead of skipping", () => {
 });
 
 test("default config headings stay aligned with PR template", () => {
+  const { DEFAULT_CONFIG } = loadGateModule();
   const template = fs.readFileSync(
     path.join(repoRoot, ".github", "PULL_REQUEST_TEMPLATE.md"),
     "utf8",
@@ -252,7 +424,7 @@ test("default config headings stay aligned with PR template", () => {
 
   for (const section of DEFAULT_CONFIG.requiredSections) {
     assert.ok(
-      template.includes(`## ${section.heading}`),
+      template.includes(`## ${section.heading}`) || template.includes(`# ${section.heading}`),
       `expected PR template to include section "${section.heading}"`,
     );
   }
@@ -270,7 +442,7 @@ test("default config headings stay aligned with PR template", () => {
     }
     for (const section of rule.requiredSections) {
       assert.ok(
-        template.includes(`### ${section.heading}`),
+        template.includes(`## ${section.heading}`) || template.includes(`### ${section.heading}`),
         `expected PR template to include conditional section "${section.heading}"`,
       );
     }


### PR DESCRIPTION
# What does this PR do?

Redesign the PR template and PR-body risk gate around a stable review contract, remove the old Codex-specific hard gate, and make CI prefer the live GitHub PR body over stale event payloads.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI / workflow
- [x] Risk / contract change

## Changes Made

- replace the old mixed PR-body contract with a clearer taxonomy: permanent required facts, conditional risk addenda, and optional reviewer context
- redesign `.github/PULL_REQUEST_TEMPLATE.md` around summary, type, changed modules/contracts, validation, risk flags, and conditional addenda
- update `scripts/ops/pr-risk-layer-gate.config.json` to make the JSON config the machine-contract source of truth
- update `scripts/ops/pr-risk-layer-gate.cjs` to resolve PR bodies in CI via `--body` → `--body-file` → live GitHub API → event payload fallback
- align `AGENTS.md`, `docs/ops/pr-review-preflight.md`, and regression tests with the new contract
- add workflow permissions needed for live PR-body reads in CI

## Affected Modules / Contracts

- **Modules touched:** `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/ci.yml`, `AGENTS.md`, `docs/ops/pr-review-preflight.md`, `scripts/ops/pr-risk-layer-gate.cjs`, `scripts/ops/pr-risk-layer-gate.config.json`, `test/pr-risk-layer-gate.test.js`, `openspec/changes/2026-04-11-redesign-pr-review-gate/`
- **Dependencies / contracts touched:** PR review contract taxonomy, PR-body gate source precedence, reviewer workflow guidance, CI permission contract for live PR reads
- **Repo sitemap evidence:** `not required`

## Validation

### Automated

- `pnpm test -- --test-name-pattern='pr-risk-layer'` ✅

### Manual / smoke

- verified the branch diff keeps `Reviewer Context` optional and removes the old unconditional `Codex Context` hard gate
- verified the gate logic prefers live GitHub PR body and falls back to event payload only when API fetch fails

### Uncovered scope

- live GitHub Actions network-path behavior against the real GitHub API still depends on CI execution
- broader full-suite regressions outside the targeted PR-risk-layer path were not re-run in this pass

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [x] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

- reviewer-only context must stay optional and must not become a machine hard gate again
- template headings, config rules, docs, and tests must remain aligned around the same contract taxonomy
- CI should validate the current PR body reviewers see, preferring live GitHub API data and only falling back to event payload when necessary

### Boundary Matrix (must list at least 3)

- PR template heading taxonomy → gate config required/conditional rules → validation result
- CI runtime body resolution → GitHub API success/failure path → event-payload fallback behavior
- AGENTS/docs reviewer guidance → contributor behavior → local/CI preflight expectations

### Evidence

- `pnpm test -- --test-name-pattern='pr-risk-layer'`
- targeted review of `origin/main...feat/redesign-pr-review-gate`
- new tests covering live-body preference and fallback behavior

## Public Exposure Addendum (required if public exposure is checked)

- **Access rules:** N/A
- **Exposed fields:** N/A
- **Avatar / image policy:** N/A
- **Regression coverage:** N/A

## Reviewer Context (optional)

- **Review focus:** contract sharpness, live-body precedence, and whether any reviewer-only content is still hard-gated
- **Delta since last review:** replaces `Codex Context` with tool-agnostic contract sections and narrows the hard gate to stable PR facts plus conditional risk addenda
- **Depends on:** none
- **Known gaps / follow-ups:** `Related Issue` intentionally remains non-mandatory; if wanted later, its placeholder wording could be softened further

## Screenshots / Logs (optional)

- N/A
