### PR TITLE
fix: handle bigint Hermes hourly ingest

### DIFF
--- a/insforge-functions/vibeusage-ingest.js
+++ b/insforge-functions/vibeusage-ingest.js
@@ -1793,7 +1793,7 @@ if (!usageModelCore2) throw new Error("usage-model core not initialized");
 var usageMetricsCore = globalThis.__vibeusageUsageMetricsCore;
 if (!usageMetricsCore) throw new Error("usage metrics core not initialized");
 var { normalizeIso: normalizeIso2 } = dateCore;
-var { normalizeSource: normalizeSource2 } = runtimePrimitivesCore3;
+var { normalizeSource: normalizeSource2, toBigInt: toBigInt2 } = runtimePrimitivesCore3;
 var { normalizeUsageModel: normalizeUsageModel2 } = usageModelCore2;
 var { computeBillableTotalTokens: computeBillableTotalTokens2 } = usageMetricsCore;
 function normalizeHourlyPayload(data) {
@@ -1854,12 +1854,22 @@ function parseUtcHalfHourStart(value) {
   );
   return hourStart.toISOString();
 }
-function toNonNegativeInt(n) {
-  if (typeof n !== "number") return null;
-  if (!Number.isFinite(n)) return null;
-  if (!Number.isInteger(n)) return null;
-  if (n < 0) return null;
-  return n;
+function toNonNegativeBigInt(n) {
+  if (typeof n === "bigint") return n >= 0n ? n : null;
+  if (typeof n === "number") {
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return null;
+    return BigInt(n);
+  }
+  if (typeof n === "string") {
+    const trimmed = n.trim();
+    if (!/^[0-9]+$/.test(trimmed)) return null;
+    try {
+      return BigInt(trimmed);
+    } catch (_error) {
+      return null;
+    }
+  }
+  return null;
 }
 function parseHourlyBucket(raw) {
   if (!raw || typeof raw !== "object") return { ok: false, error: "Invalid half-hour bucket" };
@@ -1869,11 +1879,11 @@ function parseHourlyBucket(raw) {
   }
   const source = normalizeSource2(raw.source);
   const model = normalizeUsageModel2(raw.model) || DEFAULT_MODEL2;
-  const input = toNonNegativeInt(raw.input_tokens);
-  const cached = toNonNegativeInt(raw.cached_input_tokens);
-  const output = toNonNegativeInt(raw.output_tokens);
-  const reasoning = toNonNegativeInt(raw.reasoning_output_tokens);
-  const total = toNonNegativeInt(raw.total_tokens);
+  const input = toNonNegativeBigInt(raw.input_tokens);
+  const cached = toNonNegativeBigInt(raw.cached_input_tokens);
+  const output = toNonNegativeBigInt(raw.output_tokens);
+  const reasoning = toNonNegativeBigInt(raw.reasoning_output_tokens);
+  const total = toNonNegativeBigInt(raw.total_tokens);
   if ([input, cached, output, reasoning, total].some((n) => n == null)) {
     return { ok: false, error: "Token fields must be non-negative integers" };
   }
@@ -1883,11 +1893,11 @@ function parseHourlyBucket(raw) {
       source,
       model,
       hour_start: hourStart,
-      input_tokens: input,
-      cached_input_tokens: cached,
-      output_tokens: output,
-      reasoning_output_tokens: reasoning,
-      total_tokens: total
+      input_tokens: input.toString(),
+      cached_input_tokens: cached.toString(),
+      output_tokens: output.toString(),
+      reasoning_output_tokens: reasoning.toString(),
+      total_tokens: total.toString()
     }
   };
 }
@@ -1902,11 +1912,11 @@ function parseProjectHourlyBucket(raw) {
   const source = normalizeSource2(raw.source);
   const projectKey = typeof raw.project_key === "string" ? raw.project_key.trim() : "";
   const projectRef = typeof raw.project_ref === "string" ? raw.project_ref.trim() : "";
-  const input = toNonNegativeInt(raw.input_tokens);
-  const cached = toNonNegativeInt(raw.cached_input_tokens);
-  const output = toNonNegativeInt(raw.output_tokens);
-  const reasoning = toNonNegativeInt(raw.reasoning_output_tokens);
-  const total = toNonNegativeInt(raw.total_tokens);
+  const input = toNonNegativeBigInt(raw.input_tokens);
+  const cached = toNonNegativeBigInt(raw.cached_input_tokens);
+  const output = toNonNegativeBigInt(raw.output_tokens);
+  const reasoning = toNonNegativeBigInt(raw.reasoning_output_tokens);
+  const total = toNonNegativeBigInt(raw.total_tokens);
   if (!projectKey) return { ok: false, error: "project_key is required" };
   if (!projectRef) return { ok: false, error: "project_ref is required" };
   if ([input, cached, output, reasoning, total].some((n) => n == null)) {
@@ -1919,11 +1929,11 @@ function parseProjectHourlyBucket(raw) {
       project_key: projectKey,
       project_ref: projectRef,
       hour_start: hourStart,
-      input_tokens: input,
-      cached_input_tokens: cached,
-      output_tokens: output,
-      reasoning_output_tokens: reasoning,
-      total_tokens: total
+      input_tokens: input.toString(),
+      cached_input_tokens: cached.toString(),
+      output_tokens: output.toString(),
+      reasoning_output_tokens: reasoning.toString(),
+      total_tokens: total.toString()
     }
   };
 }
@@ -1977,7 +1987,7 @@ function buildRows({ hourly, tokenRow, nowIso, billableRuleVersion = BILLABLE_RU
       reasoning_output_tokens: bucket.reasoning_output_tokens,
       total_tokens: bucket.total_tokens,
       billable_total_tokens: billable.toString(),
-      billable_rule_version: billableRuleVersion,
+      billable_rule_version: Number(toBigInt2(billableRuleVersion) || 1n),
       updated_at: nowIso
     });
   }
@@ -2009,7 +2019,7 @@ function buildProjectRows({ hourly, tokenRow, nowIso }) {
       reasoning_output_tokens: bucket.reasoning_output_tokens,
       total_tokens: bucket.total_tokens,
       billable_total_tokens: billable.toString(),
-      billable_rule_version: BILLABLE_RULE_VERSION,
+      billable_rule_version: Number(toBigInt2(BILLABLE_RULE_VERSION) || 1n),
       updated_at: nowIso
     });
   }
@@ -2070,7 +2080,7 @@ if (!globalThis[CORE_KEY12]) {
       parseHourlyBucket,
       parseProjectHourlyBucket,
       parseUtcHalfHourStart,
-      toNonNegativeInt
+      toNonNegativeBigInt
     },
     configurable: true,
     enumerable: false,
@@ -2166,7 +2176,7 @@ var DEVICE_TOKEN_SELECT = "id,user_id,device_id,revoked_at,last_sync_at";
 var dateCore2 = globalThis.__vibeusageDateCore;
 if (!dateCore2) throw new Error("date core not initialized");
 var { isWithinInterval: isWithinInterval2, normalizeIso: normalizeIso3 } = dateCore2;
-function toNonNegativeInt2(value) {
+function toNonNegativeInt(value) {
   if (typeof value !== "number") return 0;
   if (!Number.isFinite(value)) return 0;
   if (!Number.isInteger(value)) return 0;
@@ -2549,9 +2559,9 @@ async function recordIngestBatchMetrics({
     device_id: tokenRow.device_id,
     device_token_id: tokenRow.id,
     source: typeof source === "string" ? source : null,
-    bucket_count: toNonNegativeInt2(bucketCount),
-    inserted: toNonNegativeInt2(inserted),
-    skipped: toNonNegativeInt2(skipped)
+    bucket_count: toNonNegativeInt(bucketCount),
+    inserted: toNonNegativeInt(inserted),
+    skipped: toNonNegativeInt(skipped)
   };
   try {
     if (serviceClient?.database?.from) {

--- a/insforge-src/shared/core/ingest.mjs
+++ b/insforge-src/shared/core/ingest.mjs
@@ -19,7 +19,7 @@ const usageMetricsCore = globalThis.__vibeusageUsageMetricsCore;
 if (!usageMetricsCore) throw new Error("usage metrics core not initialized");
 
 const { normalizeIso } = dateCore;
-const { normalizeSource } = runtimePrimitivesCore;
+const { normalizeSource, toBigInt } = runtimePrimitivesCore;
 const { normalizeUsageModel } = usageModelCore;
 const { computeBillableTotalTokens } = usageMetricsCore;
 
@@ -91,12 +91,22 @@ function parseUtcHalfHourStart(value) {
   return hourStart.toISOString();
 }
 
-function toNonNegativeInt(n) {
-  if (typeof n !== "number") return null;
-  if (!Number.isFinite(n)) return null;
-  if (!Number.isInteger(n)) return null;
-  if (n < 0) return null;
-  return n;
+function toNonNegativeBigInt(n) {
+  if (typeof n === "bigint") return n >= 0n ? n : null;
+  if (typeof n === "number") {
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return null;
+    return BigInt(n);
+  }
+  if (typeof n === "string") {
+    const trimmed = n.trim();
+    if (!/^[0-9]+$/.test(trimmed)) return null;
+    try {
+      return BigInt(trimmed);
+    } catch (_error) {
+      return null;
+    }
+  }
+  return null;
 }
 
 function parseHourlyBucket(raw) {
@@ -109,11 +119,11 @@ function parseHourlyBucket(raw) {
 
   const source = normalizeSource(raw.source);
   const model = normalizeUsageModel(raw.model) || DEFAULT_MODEL;
-  const input = toNonNegativeInt(raw.input_tokens);
-  const cached = toNonNegativeInt(raw.cached_input_tokens);
-  const output = toNonNegativeInt(raw.output_tokens);
-  const reasoning = toNonNegativeInt(raw.reasoning_output_tokens);
-  const total = toNonNegativeInt(raw.total_tokens);
+  const input = toNonNegativeBigInt(raw.input_tokens);
+  const cached = toNonNegativeBigInt(raw.cached_input_tokens);
+  const output = toNonNegativeBigInt(raw.output_tokens);
+  const reasoning = toNonNegativeBigInt(raw.reasoning_output_tokens);
+  const total = toNonNegativeBigInt(raw.total_tokens);
 
   if ([input, cached, output, reasoning, total].some((n) => n == null)) {
     return { ok: false, error: "Token fields must be non-negative integers" };
@@ -125,11 +135,11 @@ function parseHourlyBucket(raw) {
       source,
       model,
       hour_start: hourStart,
-      input_tokens: input,
-      cached_input_tokens: cached,
-      output_tokens: output,
-      reasoning_output_tokens: reasoning,
-      total_tokens: total,
+      input_tokens: input.toString(),
+      cached_input_tokens: cached.toString(),
+      output_tokens: output.toString(),
+      reasoning_output_tokens: reasoning.toString(),
+      total_tokens: total.toString(),
     },
   };
 }
@@ -147,11 +157,11 @@ function parseProjectHourlyBucket(raw) {
   const source = normalizeSource(raw.source);
   const projectKey = typeof raw.project_key === "string" ? raw.project_key.trim() : "";
   const projectRef = typeof raw.project_ref === "string" ? raw.project_ref.trim() : "";
-  const input = toNonNegativeInt(raw.input_tokens);
-  const cached = toNonNegativeInt(raw.cached_input_tokens);
-  const output = toNonNegativeInt(raw.output_tokens);
-  const reasoning = toNonNegativeInt(raw.reasoning_output_tokens);
-  const total = toNonNegativeInt(raw.total_tokens);
+  const input = toNonNegativeBigInt(raw.input_tokens);
+  const cached = toNonNegativeBigInt(raw.cached_input_tokens);
+  const output = toNonNegativeBigInt(raw.output_tokens);
+  const reasoning = toNonNegativeBigInt(raw.reasoning_output_tokens);
+  const total = toNonNegativeBigInt(raw.total_tokens);
 
   if (!projectKey) return { ok: false, error: "project_key is required" };
   if (!projectRef) return { ok: false, error: "project_ref is required" };
@@ -166,11 +176,11 @@ function parseProjectHourlyBucket(raw) {
       project_key: projectKey,
       project_ref: projectRef,
       hour_start: hourStart,
-      input_tokens: input,
-      cached_input_tokens: cached,
-      output_tokens: output,
-      reasoning_output_tokens: reasoning,
-      total_tokens: total,
+      input_tokens: input.toString(),
+      cached_input_tokens: cached.toString(),
+      output_tokens: output.toString(),
+      reasoning_output_tokens: reasoning.toString(),
+      total_tokens: total.toString(),
     },
   };
 }
@@ -231,7 +241,7 @@ function buildRows({ hourly, tokenRow, nowIso, billableRuleVersion = BILLABLE_RU
       reasoning_output_tokens: bucket.reasoning_output_tokens,
       total_tokens: bucket.total_tokens,
       billable_total_tokens: billable.toString(),
-      billable_rule_version: billableRuleVersion,
+      billable_rule_version: Number(toBigInt(billableRuleVersion) || 1n),
       updated_at: nowIso,
     });
   }
@@ -267,7 +277,7 @@ function buildProjectRows({ hourly, tokenRow, nowIso }) {
       reasoning_output_tokens: bucket.reasoning_output_tokens,
       total_tokens: bucket.total_tokens,
       billable_total_tokens: billable.toString(),
-      billable_rule_version: BILLABLE_RULE_VERSION,
+      billable_rule_version: Number(toBigInt(BILLABLE_RULE_VERSION) || 1n),
       updated_at: nowIso,
     });
   }
@@ -334,7 +344,7 @@ if (!globalThis[CORE_KEY]) {
       parseHourlyBucket,
       parseProjectHourlyBucket,
       parseUtcHalfHourStart,
-      toNonNegativeInt,
+      toNonNegativeBigInt,
     },
     configurable: true,
     enumerable: false,
@@ -356,5 +366,5 @@ export {
   parseHourlyBucket,
   parseProjectHourlyBucket,
   parseUtcHalfHourStart,
-  toNonNegativeInt,
+  toNonNegativeBigInt,
 };

--- a/openspec/changes/2026-04-12-fix-hermes-bigint-hourly-ingest/design.md
+++ b/openspec/changes/2026-04-12-fix-hermes-bigint-hourly-ingest/design.md
@@ -1,0 +1,21 @@
+## Goal
+
+Hermes can emit per-bucket token counts above the PostgreSQL `integer` ceiling. `vibeusage_tracker_hourly` still accepts/writes those fields as `integer` on live Insforge, which causes hourly upserts to fail even though ingest batch rows land.
+
+## Minimal complete fix
+
+1. Change all raw token columns on `public.vibeusage_tracker_hourly` to `bigint`.
+2. Keep the ingest write path string-safe for large integers so JSON/PostgREST does not coerce through JS `Number`.
+3. Preserve `billable_rule_version` as a normal integer.
+4. Recreate dependent views separately only where live deployment requires it (`scripts/ops/hermes-token-bigint-migration.sql`).
+
+## Scope
+
+- `vibeusage_tracker_hourly` schema
+- Hermes hourly/project ingest parsing/build rows
+- Regression test for bigint-scale payloads
+
+## Non-goals
+
+- Rewriting archived historical openspec SQL
+- Changing leaderboard rank field types

--- a/openspec/changes/2026-04-12-fix-hermes-bigint-hourly-ingest/sql/001_fix_hermes_bigint_hourly_ingest.sql
+++ b/openspec/changes/2026-04-12-fix-hermes-bigint-hourly-ingest/sql/001_fix_hermes_bigint_hourly_ingest.sql
@@ -1,0 +1,243 @@
+begin;
+
+-- Drop dependent leaderboard source views that reference vibeusage_tracker_hourly token columns.
+drop view if exists public.vibeusage_leaderboard_source_week;
+drop view if exists public.vibeusage_leaderboard_source_month;
+drop view if exists public.vibeusage_leaderboard_source_total;
+
+alter table public.vibeusage_tracker_hourly
+  alter column input_tokens type bigint using input_tokens::bigint,
+  alter column cached_input_tokens type bigint using cached_input_tokens::bigint,
+  alter column output_tokens type bigint using output_tokens::bigint,
+  alter column reasoning_output_tokens type bigint using reasoning_output_tokens::bigint,
+  alter column total_tokens type bigint using total_tokens::bigint,
+  alter column billable_total_tokens type bigint using billable_total_tokens::bigint;
+
+create or replace view public.vibeusage_leaderboard_source_week as
+with base as (
+  select (now() at time zone 'utc')::date as today
+),
+params as (
+  select
+    (base.today - extract(dow from base.today)::int) as from_day,
+    (base.today - extract(dow from base.today)::int + 6) as to_day
+  from base
+),
+classified as (
+  select
+    h.user_id,
+    coalesce(h.billable_total_tokens, h.total_tokens::bigint)::bigint as row_tokens,
+    (
+      h.model like 'gpt-%'
+      or h.model like 'openai/%'
+      or h.model like '%/gpt-%'
+    ) as is_gpt,
+    (
+      h.model like 'claude-%'
+      or h.model like 'anthropic/%'
+      or h.model like '%/claude-%'
+    ) as is_claude
+  from public.vibeusage_tracker_hourly h
+  join params p
+    on h.hour_start >= (p.from_day::timestamp at time zone 'utc')
+   and h.hour_start < ((p.to_day + 1)::timestamp at time zone 'utc')
+  where h.source <> 'canary'
+),
+totals as (
+  select
+    c.user_id,
+    sum(case when c.is_gpt then c.row_tokens else 0::bigint end)::bigint as gpt_tokens,
+    sum(case when c.is_claude then c.row_tokens else 0::bigint end)::bigint as claude_tokens,
+    sum(case when (not c.is_gpt and not c.is_claude) then c.row_tokens else 0::bigint end)::bigint as other_tokens
+  from classified c
+  group by c.user_id
+),
+ranked as (
+  select
+    dense_rank() over (order by (t.gpt_tokens + t.claude_tokens + t.other_tokens) desc)::int as rank,
+    dense_rank() over (order by t.gpt_tokens desc)::int as rank_gpt,
+    dense_rank() over (order by t.claude_tokens desc)::int as rank_claude,
+    dense_rank() over (order by t.other_tokens desc)::int as rank_other,
+    t.user_id,
+    (t.gpt_tokens + t.claude_tokens + t.other_tokens)::bigint as total_tokens,
+    t.gpt_tokens,
+    t.claude_tokens,
+    t.other_tokens
+  from totals t
+)
+select
+  r.user_id,
+  r.rank,
+  r.total_tokens,
+  case
+    when coalesce(s.leaderboard_public, false) then coalesce(nullif(u.nickname, ''), 'Anonymous')
+    else 'Anonymous'
+  end as display_name,
+  case
+    when coalesce(s.leaderboard_public, false) then u.avatar_url
+    else null
+  end as avatar_url,
+  p.from_day,
+  p.to_day,
+  r.gpt_tokens,
+  r.claude_tokens,
+  r.other_tokens,
+  r.rank_gpt,
+  r.rank_claude,
+  r.rank_other
+from ranked r
+cross join params p
+left join public.vibeusage_user_settings s on s.user_id = r.user_id
+left join public.users u on u.id = r.user_id
+order by r.rank, r.user_id;
+
+create or replace view public.vibeusage_leaderboard_source_month as
+with base as (
+  select (now() at time zone 'utc')::date as today
+),
+params as (
+  select
+    date_trunc('month', base.today)::date as from_day,
+    (date_trunc('month', base.today)::date + interval '1 month' - interval '1 day')::date as to_day
+  from base
+),
+classified as (
+  select
+    h.user_id,
+    coalesce(h.billable_total_tokens, h.total_tokens::bigint)::bigint as row_tokens,
+    (
+      h.model like 'gpt-%'
+      or h.model like 'openai/%'
+      or h.model like '%/gpt-%'
+    ) as is_gpt,
+    (
+      h.model like 'claude-%'
+      or h.model like 'anthropic/%'
+      or h.model like '%/claude-%'
+    ) as is_claude
+  from public.vibeusage_tracker_hourly h
+  join params p
+    on h.hour_start >= (p.from_day::timestamp at time zone 'utc')
+   and h.hour_start < ((p.to_day + 1)::timestamp at time zone 'utc')
+  where h.source <> 'canary'
+),
+totals as (
+  select
+    c.user_id,
+    sum(case when c.is_gpt then c.row_tokens else 0::bigint end)::bigint as gpt_tokens,
+    sum(case when c.is_claude then c.row_tokens else 0::bigint end)::bigint as claude_tokens,
+    sum(case when (not c.is_gpt and not c.is_claude) then c.row_tokens else 0::bigint end)::bigint as other_tokens
+  from classified c
+  group by c.user_id
+),
+ranked as (
+  select
+    dense_rank() over (order by (t.gpt_tokens + t.claude_tokens + t.other_tokens) desc)::int as rank,
+    dense_rank() over (order by t.gpt_tokens desc)::int as rank_gpt,
+    dense_rank() over (order by t.claude_tokens desc)::int as rank_claude,
+    dense_rank() over (order by t.other_tokens desc)::int as rank_other,
+    t.user_id,
+    (t.gpt_tokens + t.claude_tokens + t.other_tokens)::bigint as total_tokens,
+    t.gpt_tokens,
+    t.claude_tokens,
+    t.other_tokens
+  from totals t
+)
+select
+  r.user_id,
+  r.rank,
+  r.total_tokens,
+  case
+    when coalesce(s.leaderboard_public, false) then coalesce(nullif(u.nickname, ''), 'Anonymous')
+    else 'Anonymous'
+  end as display_name,
+  case
+    when coalesce(s.leaderboard_public, false) then u.avatar_url
+    else null
+  end as avatar_url,
+  p.from_day,
+  p.to_day,
+  r.gpt_tokens,
+  r.claude_tokens,
+  r.other_tokens,
+  r.rank_gpt,
+  r.rank_claude,
+  r.rank_other
+from ranked r
+cross join params p
+left join public.vibeusage_user_settings s on s.user_id = r.user_id
+left join public.users u on u.id = r.user_id
+order by r.rank, r.user_id;
+
+create or replace view public.vibeusage_leaderboard_source_total as
+with params as (
+  select
+    '1970-01-01'::date as from_day,
+    '9999-12-31'::date as to_day
+),
+classified as (
+  select
+    h.user_id,
+    coalesce(h.billable_total_tokens, h.total_tokens::bigint)::bigint as row_tokens,
+    (
+      h.model like 'gpt-%'
+      or h.model like 'openai/%'
+      or h.model like '%/gpt-%'
+    ) as is_gpt,
+    (
+      h.model like 'claude-%'
+      or h.model like 'anthropic/%'
+      or h.model like '%/claude-%'
+    ) as is_claude
+  from public.vibeusage_tracker_hourly h
+  where h.source <> 'canary'
+),
+totals as (
+  select
+    c.user_id,
+    sum(case when c.is_gpt then c.row_tokens else 0::bigint end)::bigint as gpt_tokens,
+    sum(case when c.is_claude then c.row_tokens else 0::bigint end)::bigint as claude_tokens,
+    sum(case when (not c.is_gpt and not c.is_claude) then c.row_tokens else 0::bigint end)::bigint as other_tokens
+  from classified c
+  group by c.user_id
+),
+ranked as (
+  select
+    dense_rank() over (order by (t.gpt_tokens + t.claude_tokens + t.other_tokens) desc)::int as rank,
+    dense_rank() over (order by t.gpt_tokens desc)::int as rank_gpt,
+    dense_rank() over (order by t.claude_tokens desc)::int as rank_claude,
+    dense_rank() over (order by t.other_tokens desc)::int as rank_other,
+    t.user_id,
+    (t.gpt_tokens + t.claude_tokens + t.other_tokens)::bigint as total_tokens,
+    t.gpt_tokens,
+    t.claude_tokens,
+    t.other_tokens
+  from totals t
+)
+select
+  r.user_id,
+  r.rank,
+  r.total_tokens,
+  case
+    when coalesce(s.leaderboard_public, false) then coalesce(nullif(u.nickname, ''), 'Anonymous')
+    else 'Anonymous'
+  end as display_name,
+  case
+    when coalesce(s.leaderboard_public, false) then u.avatar_url
+    else null
+  end as avatar_url,
+  p.from_day,
+  p.to_day,
+  r.gpt_tokens,
+  r.claude_tokens,
+  r.other_tokens,
+  r.rank_gpt,
+  r.rank_claude,
+  r.rank_other
+from ranked r
+cross join params p
+left join public.vibeusage_user_settings s on s.user_id = r.user_id
+left join public.users u on u.id = r.user_id
+order by r.rank, r.user_id;
+
+commit;

--- a/scripts/ops/hermes-token-bigint-migration.sql
+++ b/scripts/ops/hermes-token-bigint-migration.sql
@@ -1,0 +1,246 @@
+begin;
+
+-- Drop dependent leaderboard source views that reference vibeusage_tracker_hourly.total_tokens.
+drop view if exists public.vibeusage_leaderboard_source_week;
+drop view if exists public.vibeusage_leaderboard_source_month;
+drop view if exists public.vibeusage_leaderboard_source_total;
+
+-- Ensure Hermes-scale per-bucket token counts can land without integer overflow.
+
+alter table public.vibeusage_tracker_hourly
+  alter column input_tokens type bigint using input_tokens::bigint,
+  alter column cached_input_tokens type bigint using cached_input_tokens::bigint,
+  alter column output_tokens type bigint using output_tokens::bigint,
+  alter column reasoning_output_tokens type bigint using reasoning_output_tokens::bigint,
+  alter column total_tokens type bigint using total_tokens::bigint,
+  alter column billable_total_tokens type bigint using billable_total_tokens::bigint;
+
+-- Recreate the dropped views exactly as defined in the leaderboard source scope rollout.
+create or replace view public.vibeusage_leaderboard_source_week as
+with base as (
+  select (now() at time zone 'utc')::date as today
+),
+params as (
+  select
+    (base.today - extract(dow from base.today)::int) as from_day,
+    (base.today - extract(dow from base.today)::int + 6) as to_day
+  from base
+),
+classified as (
+  select
+    h.user_id,
+    coalesce(h.billable_total_tokens, h.total_tokens::bigint)::bigint as row_tokens,
+    (
+      h.model like 'gpt-%'
+      or h.model like 'openai/%'
+      or h.model like '%/gpt-%'
+    ) as is_gpt,
+    (
+      h.model like 'claude-%'
+      or h.model like 'anthropic/%'
+      or h.model like '%/claude-%'
+    ) as is_claude
+  from public.vibeusage_tracker_hourly h
+  join params p
+    on h.hour_start >= (p.from_day::timestamp at time zone 'utc')
+   and h.hour_start < ((p.to_day + 1)::timestamp at time zone 'utc')
+  where h.source <> 'canary'
+),
+totals as (
+  select
+    c.user_id,
+    sum(case when c.is_gpt then c.row_tokens else 0::bigint end)::bigint as gpt_tokens,
+    sum(case when c.is_claude then c.row_tokens else 0::bigint end)::bigint as claude_tokens,
+    sum(case when (not c.is_gpt and not c.is_claude) then c.row_tokens else 0::bigint end)::bigint as other_tokens
+  from classified c
+  group by c.user_id
+),
+ranked as (
+  select
+    dense_rank() over (order by (t.gpt_tokens + t.claude_tokens + t.other_tokens) desc)::int as rank,
+    dense_rank() over (order by t.gpt_tokens desc)::int as rank_gpt,
+    dense_rank() over (order by t.claude_tokens desc)::int as rank_claude,
+    dense_rank() over (order by t.other_tokens desc)::int as rank_other,
+    t.user_id,
+    (t.gpt_tokens + t.claude_tokens + t.other_tokens)::bigint as total_tokens,
+    t.gpt_tokens,
+    t.claude_tokens,
+    t.other_tokens
+  from totals t
+)
+select
+  r.user_id,
+  r.rank,
+  r.total_tokens,
+  case
+    when coalesce(s.leaderboard_public, false) then coalesce(nullif(u.nickname, ''), 'Anonymous')
+    else 'Anonymous'
+  end as display_name,
+  case
+    when coalesce(s.leaderboard_public, false) then u.avatar_url
+    else null
+  end as avatar_url,
+  p.from_day,
+  p.to_day,
+  r.gpt_tokens,
+  r.claude_tokens,
+  r.other_tokens,
+  r.rank_gpt,
+  r.rank_claude,
+  r.rank_other
+from ranked r
+cross join params p
+left join public.vibeusage_user_settings s on s.user_id = r.user_id
+left join public.users u on u.id = r.user_id
+order by r.rank, r.user_id;
+
+create or replace view public.vibeusage_leaderboard_source_month as
+with base as (
+  select (now() at time zone 'utc')::date as today
+),
+params as (
+  select
+    date_trunc('month', base.today)::date as from_day,
+    (date_trunc('month', base.today)::date + interval '1 month' - interval '1 day')::date as to_day
+  from base
+),
+classified as (
+  select
+    h.user_id,
+    coalesce(h.billable_total_tokens, h.total_tokens::bigint)::bigint as row_tokens,
+    (
+      h.model like 'gpt-%'
+      or h.model like 'openai/%'
+      or h.model like '%/gpt-%'
+    ) as is_gpt,
+    (
+      h.model like 'claude-%'
+      or h.model like 'anthropic/%'
+      or h.model like '%/claude-%'
+    ) as is_claude
+  from public.vibeusage_tracker_hourly h
+  join params p
+    on h.hour_start >= (p.from_day::timestamp at time zone 'utc')
+   and h.hour_start < ((p.to_day + 1)::timestamp at time zone 'utc')
+  where h.source <> 'canary'
+),
+totals as (
+  select
+    c.user_id,
+    sum(case when c.is_gpt then c.row_tokens else 0::bigint end)::bigint as gpt_tokens,
+    sum(case when c.is_claude then c.row_tokens else 0::bigint end)::bigint as claude_tokens,
+    sum(case when (not c.is_gpt and not c.is_claude) then c.row_tokens else 0::bigint end)::bigint as other_tokens
+  from classified c
+  group by c.user_id
+),
+ranked as (
+  select
+    dense_rank() over (order by (t.gpt_tokens + t.claude_tokens + t.other_tokens) desc)::int as rank,
+    dense_rank() over (order by t.gpt_tokens desc)::int as rank_gpt,
+    dense_rank() over (order by t.claude_tokens desc)::int as rank_claude,
+    dense_rank() over (order by t.other_tokens desc)::int as rank_other,
+    t.user_id,
+    (t.gpt_tokens + t.claude_tokens + t.other_tokens)::bigint as total_tokens,
+    t.gpt_tokens,
+    t.claude_tokens,
+    t.other_tokens
+  from totals t
+)
+select
+  r.user_id,
+  r.rank,
+  r.total_tokens,
+  case
+    when coalesce(s.leaderboard_public, false) then coalesce(nullif(u.nickname, ''), 'Anonymous')
+    else 'Anonymous'
+  end as display_name,
+  case
+    when coalesce(s.leaderboard_public, false) then u.avatar_url
+    else null
+  end as avatar_url,
+  p.from_day,
+  p.to_day,
+  r.gpt_tokens,
+  r.claude_tokens,
+  r.other_tokens,
+  r.rank_gpt,
+  r.rank_claude,
+  r.rank_other
+from ranked r
+cross join params p
+left join public.vibeusage_user_settings s on s.user_id = r.user_id
+left join public.users u on u.id = r.user_id
+order by r.rank, r.user_id;
+
+create or replace view public.vibeusage_leaderboard_source_total as
+with params as (
+  select
+    '1970-01-01'::date as from_day,
+    '9999-12-31'::date as to_day
+),
+classified as (
+  select
+    h.user_id,
+    coalesce(h.billable_total_tokens, h.total_tokens::bigint)::bigint as row_tokens,
+    (
+      h.model like 'gpt-%'
+      or h.model like 'openai/%'
+      or h.model like '%/gpt-%'
+    ) as is_gpt,
+    (
+      h.model like 'claude-%'
+      or h.model like 'anthropic/%'
+      or h.model like '%/claude-%'
+    ) as is_claude
+  from public.vibeusage_tracker_hourly h
+  where h.source <> 'canary'
+),
+totals as (
+  select
+    c.user_id,
+    sum(case when c.is_gpt then c.row_tokens else 0::bigint end)::bigint as gpt_tokens,
+    sum(case when c.is_claude then c.row_tokens else 0::bigint end)::bigint as claude_tokens,
+    sum(case when (not c.is_gpt and not c.is_claude) then c.row_tokens else 0::bigint end)::bigint as other_tokens
+  from classified c
+  group by c.user_id
+),
+ranked as (
+  select
+    dense_rank() over (order by (t.gpt_tokens + t.claude_tokens + t.other_tokens) desc)::int as rank,
+    dense_rank() over (order by t.gpt_tokens desc)::int as rank_gpt,
+    dense_rank() over (order by t.claude_tokens desc)::int as rank_claude,
+    dense_rank() over (order by t.other_tokens desc)::int as rank_other,
+    t.user_id,
+    (t.gpt_tokens + t.claude_tokens + t.other_tokens)::bigint as total_tokens,
+    t.gpt_tokens,
+    t.claude_tokens,
+    t.other_tokens
+  from totals t
+)
+select
+  r.user_id,
+  r.rank,
+  r.total_tokens,
+  case
+    when coalesce(s.leaderboard_public, false) then coalesce(nullif(u.nickname, ''), 'Anonymous')
+    else 'Anonymous'
+  end as display_name,
+  case
+    when coalesce(s.leaderboard_public, false) then u.avatar_url
+    else null
+  end as avatar_url,
+  p.from_day,
+  p.to_day,
+  r.gpt_tokens,
+  r.claude_tokens,
+  r.other_tokens,
+  r.rank_gpt,
+  r.rank_claude,
+  r.rank_other
+from ranked r
+cross join params p
+left join public.vibeusage_user_settings s on s.user_id = r.user_id
+left join public.users u on u.id = r.user_id
+order by r.rank, r.user_id;
+
+commit;

--- a/test/edge-functions.test.js
+++ b/test/edge-functions.test.js
@@ -1113,6 +1113,11 @@ test("vibeusage-ingest uses serviceRoleKey as edgeFunctionToken and ingests hour
   assert.equal(postBody[0]?.hour_start, bucket.hour_start);
   assert.equal(postBody[0]?.source, "codex");
   assert.equal(postBody[0]?.model, "unknown");
+  assert.equal(postBody[0]?.input_tokens, "1");
+  assert.equal(postBody[0]?.cached_input_tokens, "1");
+  assert.equal(postBody[0]?.output_tokens, "2");
+  assert.equal(postBody[0]?.reasoning_output_tokens, "0");
+  assert.equal(postBody[0]?.total_tokens, "4");
   assert.equal(postBody[0]?.billable_total_tokens, "3");
   assert.equal(postBody[0]?.billable_rule_version, 1);
 
@@ -1227,7 +1232,11 @@ test("vibeusage-ingest ingests project_hourly buckets and upserts project regist
   assert.equal(usageRows.length, 1);
   assert.equal(usageRows[0]?.project_ref, projectBucket.project_ref);
   assert.equal(usageRows[0]?.project_key, projectBucket.project_key);
-  assert.equal(usageRows[0]?.total_tokens, 6);
+  assert.equal(usageRows[0]?.input_tokens, "3");
+  assert.equal(usageRows[0]?.cached_input_tokens, "2");
+  assert.equal(usageRows[0]?.output_tokens, "1");
+  assert.equal(usageRows[0]?.reasoning_output_tokens, "0");
+  assert.equal(usageRows[0]?.total_tokens, "6");
   assert.equal(usageRows[0]?.billable_total_tokens, "6");
   assert.equal(usageRows[0]?.billable_rule_version, 1);
 
@@ -1248,6 +1257,109 @@ test("vibeusage-ingest ingests project_hourly buckets and upserts project regist
   assert.equal(registryRows[0]?.source, projectBucket.source);
   assert.ok(registryRows[0]?.updated_at, "updated_at missing");
   assert.ok(registryRows[0]?.last_seen_at, "last_seen_at missing");
+});
+
+test("vibeusage-ingest stringifies bigint-scale hourly token payloads", async () => {
+  const fn = await loadEdgeFunction("vibeusage-ingest");
+
+  const calls = [];
+  const fetchCalls = [];
+
+  const tokenRow = {
+    id: "token-id",
+    user_id: "33333333-3333-3333-3333-333333333333",
+    device_id: "44444444-4444-4444-4444-444444444444",
+    revoked_at: null,
+  };
+
+  function from(table) {
+    if (table === "vibeusage_tracker_device_tokens") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: tokenRow, error: null }),
+          }),
+        }),
+        update: () => ({ eq: async () => ({ error: null }) }),
+      };
+    }
+
+    if (table === "vibeusage_tracker_devices") {
+      return {
+        update: () => ({ eq: async () => ({ error: null }) }),
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }
+
+  globalThis.createClient = (args) => {
+    calls.push(args);
+    if (args && args.edgeFunctionToken === SERVICE_ROLE_KEY) {
+      return { database: { from } };
+    }
+    throw new Error(`Unexpected createClient args: ${JSON.stringify(args)}`);
+  };
+
+  globalThis.fetch = async (url, init) => {
+    fetchCalls.push({ url, init });
+    const u = new URL(url);
+
+    if (u.pathname.endsWith("/api/database/records/vibeusage_tracker_hourly")) {
+      return new Response(JSON.stringify([{ hour_start: "2025-12-17T00:00:00.000Z" }]), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  };
+
+  const deviceToken = "device_token_test";
+  const bucket = {
+    hour_start: new Date("2025-12-17T00:00:00.000Z").toISOString(),
+    source: "hermes",
+    model: "gpt-5",
+    input_tokens: "2609396608",
+    cached_input_tokens: "0",
+    output_tokens: "12",
+    reasoning_output_tokens: "0",
+    total_tokens: "2609396620",
+  };
+
+  const req = new Request("http://localhost/functions/vibeusage-ingest", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${deviceToken}` },
+    body: JSON.stringify({ hourly: [bucket] }),
+  });
+
+  const res = await fn(req);
+  assert.equal(res.status, 200);
+
+  const data = await res.json();
+  assert.deepEqual(data, {
+    success: true,
+    inserted: 1,
+    skipped: 0,
+    project_inserted: 0,
+    project_skipped: 0,
+  });
+  assert.equal(fetchCalls.length, 1);
+  const postCall = fetchCalls[0];
+  const postBody = JSON.parse(postCall.init?.body || "[]");
+  assert.equal(postBody.length, 1);
+  assert.equal(postBody[0]?.source, "hermes");
+  assert.equal(postBody[0]?.model, "gpt-5");
+  assert.equal(postBody[0]?.input_tokens, "2609396608");
+  assert.equal(postBody[0]?.cached_input_tokens, "0");
+  assert.equal(postBody[0]?.output_tokens, "12");
+  assert.equal(postBody[0]?.reasoning_output_tokens, "0");
+  assert.equal(postBody[0]?.total_tokens, "2609396620");
+  assert.equal(postBody[0]?.billable_total_tokens, "2609396620");
+  assert.equal(postBody[0]?.billable_rule_version, 1);
+
+  const serviceClientCall = calls.find((c) => c && c.edgeFunctionToken === SERVICE_ROLE_KEY);
+  assert.ok(serviceClientCall, "service client not created");
 });
 
 test("vibeusage-ingest accepts wrapped payload with data.hourly", async () => {
@@ -1339,6 +1451,11 @@ test("vibeusage-ingest accepts wrapped payload with data.hourly", async () => {
   const postBody = JSON.parse(postCall.init?.body || "[]");
   assert.equal(postBody.length, 1);
   assert.equal(postBody[0]?.source, "codex");
+  assert.equal(postBody[0]?.input_tokens, "1");
+  assert.equal(postBody[0]?.cached_input_tokens, "0");
+  assert.equal(postBody[0]?.output_tokens, "2");
+  assert.equal(postBody[0]?.reasoning_output_tokens, "0");
+  assert.equal(postBody[0]?.total_tokens, "3");
 
   const serviceClientCall = calls.find((c) => c && c.edgeFunctionToken === SERVICE_ROLE_KEY);
   assert.ok(serviceClientCall, "service client not created");
@@ -1689,6 +1806,13 @@ test("vibeusage-ingest works without serviceRoleKey via anonKey records API", as
   assert.ok(String(postCall.url).includes("/api/database/records/vibeusage_tracker_hourly"));
   assert.equal(postCall.init?.method, "POST");
   assert.equal(postCall.init?.headers?.Prefer, "return=representation,resolution=merge-duplicates");
+  const postRows = JSON.parse(postCall.init?.body || "[]");
+  assert.equal(postRows.length, 1);
+  assert.equal(postRows[0]?.input_tokens, "1");
+  assert.equal(postRows[0]?.cached_input_tokens, "0");
+  assert.equal(postRows[0]?.output_tokens, "2");
+  assert.equal(postRows[0]?.reasoning_output_tokens, "0");
+  assert.equal(postRows[0]?.total_tokens, "3");
   const postUrl = new URL(postCall.url);
   assert.equal(
     postUrl.searchParams.get("on_conflict"),

--- a/test/insforge-src-core-db.test.js
+++ b/test/insforge-src-core-db.test.js
@@ -64,10 +64,26 @@ test("parseHourlyBucket validates half-hour boundaries and tokens", () => {
   });
   assert.equal(valid.ok, true);
   assert.equal(valid.value.hour_start, "2026-01-25T10:30:00.000Z");
-  assert.equal(valid.value.total_tokens, 3);
+  assert.equal(valid.value.total_tokens, "3");
 
   const invalid = ingestCore.parseHourlyBucket({ hour_start: "2026-01-25T10:31:00.000Z" });
   assert.equal(invalid.ok, false);
+});
+
+test("parseHourlyBucket accepts bigint-scale token strings without overflow", () => {
+  const valid = ingestCore.parseHourlyBucket({
+    hour_start: "2026-01-25T10:30:00.000Z",
+    source: "hermes",
+    model: "gpt-5",
+    input_tokens: "2609396608",
+    cached_input_tokens: "0",
+    output_tokens: "12",
+    reasoning_output_tokens: "0",
+    total_tokens: "2609396620",
+  });
+  assert.equal(valid.ok, true);
+  assert.equal(valid.value.input_tokens, "2609396608");
+  assert.equal(valid.value.total_tokens, "2609396620");
 });
 
 test("parseProjectHourlyBucket validates half-hour boundaries and project fields", () => {


### PR DESCRIPTION
# What does this PR do?

- Fix Hermes hourly ingest so raw token fields can exceed PostgreSQL `integer` without overflow.
- Keep the records/edge-function write path string-safe for bigint-sized token values.
- Add the live DB migration/ops script needed to widen `vibeusage_tracker_hourly` token columns and recreate dependent leaderboard source views.

## Related Issue

- N/A

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [x] Risk / contract change

## Changes Made

- Update `insforge-src/shared/core/ingest.mjs` so hourly/project-hourly token fields parse as bigint-safe values and serialize back out as strings before records API upsert.
- Rebuild `insforge-functions/vibeusage-ingest.js` from the updated ESM source.
- Add repo-tracked live migration SQL in `scripts/ops/hermes-token-bigint-migration.sql` and OpenSpec SQL in `openspec/changes/2026-04-12-fix-hermes-bigint-hourly-ingest/sql/001_fix_hermes_bigint_hourly_ingest.sql`.
- Add regression coverage for bigint-scale hourly token payloads in `test/edge-functions.test.js` and parser coverage in `test/insforge-src-core-db.test.js`.

## Affected Modules / Contracts

- **Modules touched:** `insforge-src/shared/core/ingest.mjs`, `insforge-functions/vibeusage-ingest.js`, `scripts/ops/hermes-token-bigint-migration.sql`, `openspec/changes/2026-04-12-fix-hermes-bigint-hourly-ingest/*`, `test/edge-functions.test.js`, `test/insforge-src-core-db.test.js`
- **Dependencies / contracts touched:** Hermes hourly/project-hourly payload token serialization; PostgREST records upsert typing for `public.vibeusage_tracker_hourly`; dependent leaderboard source views rebuilt around the schema width change
- **Repo sitemap evidence:** `not required` (bugfix; no module boundary or first-read path change)

## Validation

### Automated

- [x] `node --test --test-concurrency=1 test/insforge-src-core-db.test.js test/edge-functions.test.js`
- [x] `npm run build:insforge:check`

### Manual / smoke

- [x] Applied `scripts/ops/hermes-token-bigint-migration.sql` on live Insforge DB
- [x] Triggered `notify pgrst, 'reload schema'` and confirmed schema reload in `postgREST.logs`
- [x] Deployed `vibeusage-ingest` via Insforge CLI from rebuilt `insforge-functions/vibeusage-ingest.js`
- [x] Ran local `node bin/tracker.js sync --drain` after correcting tracker `baseUrl`, observed `49 inserted, 0 skipped`
- [x] Verified live `public.vibeusage_tracker_hourly` token columns are `bigint`
- [x] Verified live Hermes rows now include multi-million token buckets (for example `max_total_tokens = 12629847`)
- [x] Verified local pending Hermes hourly/project queues are empty after drain
- [x] Checked recent `postgres.logs` and did not observe new `out of range for type integer` errors after deploy/drain

### Uncovered scope

- Full `npm run ci:local` not run for this bugfix branch; dashboard/build paths are unchanged by this PR.
- Live verification focused on Hermes ingest/hourly/project-hourly paths, not broader dashboard rendering snapshots.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [x] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

- Hermes hourly raw token fields must not overflow when payload values exceed 32-bit integer range.
- `billable_rule_version` must remain a normal integer-like scalar, not bigint/stringified token data.
- Dependent leaderboard source views must be restored after widening `public.vibeusage_tracker_hourly` token columns.

### Boundary Matrix (must list at least 3)

- Hermes payload (`hourly` / `project_hourly`) -> `insforge-src/shared/core/ingest.mjs` bigint-safe parse -> records API POST body uses string token fields
- PostgREST records insert/upsert -> `json_to_recordset` typing -> `public.vibeusage_tracker_hourly` bigint columns
- Live DB migration -> leaderboard source view recreation -> existing leaderboard source reads remain valid
- Local tracker drain -> `vibeusage-ingest` live function -> live `vibeusage_tracker_hourly` / `vibeusage_project_usage_hourly`

### Evidence

- Regression tests added for bigint-scale hourly payload values (including `2609396608`) pass in `test/edge-functions.test.js` and `test/insforge-src-core-db.test.js`
- Live schema verification after deploy shows all raw hourly token columns are `bigint`
- Live drain inserted 49 rows successfully and populated Hermes hourly/project-hourly rows with multi-million token buckets
- Recent logs show historical overflow entries only; no new `out of range for type integer` after deploy and drain

## Public Exposure Addendum (required if public exposure is checked)

- **Access rules:** N/A
- **Exposed fields:** N/A
- **Avatar / image policy:** N/A
- **Regression coverage:** N/A

## Reviewer Context (optional)

- **Review focus:** Confirm the fix is limited to Hermes hourly ingest typing/serialization and that the migration recreates the dependent leaderboard source views correctly.
- **Delta since last review:** Adds the live migration SQL + bigint-safe ingest parser/write-path + regression tests.
- **Depends on:** Manual live deploy already completed for validation; this PR records the repo changes.
- **Known gaps / follow-ups:** If future bucket totals approach JS safe-integer limits inside non-ingest local aggregation paths, consider switching any remaining `Number(...)` comparisons in rollout dominance logic to direct bigint comparison.

## Screenshots / Logs (optional)

- Live manual verify highlights:
  - `sync --drain` -> `Uploaded: 49 inserted, 0 skipped`
  - live Hermes `max_total_tokens = 12629847`
