### PR TITLE
followup: close SSOT surface gaps

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,7 +86,7 @@ npx --yes vibeusage init --link-code <code>
 | **Every Code** | 自动检测 | `notify` hook | `~/.code/sessions/**/rollout-*.jsonl` |
 | **Claude Code** | 自动检测 | `Stop` + `SessionEnd` hooks | 本地 hook 输出 |
 | **Gemini CLI** | 自动检测 | `SessionEnd` hook | `~/.gemini/tmp/**/chats/session-*.json` |
-| **OpenCode** | 自动检测 | plugin + 本地解析 | `~/.local/share/opencode/opencode.db`（旧 message 文件仅作 fallback） |
+| **OpenCode** | 自动检测 | plugin + 本地解析 | `~/.local/share/opencode/opencode.db`（SQLite 是唯一受支持的本地 accounting source） |
 | **OpenClaw** | 安装后自动检测 | session plugin | 本地 sanitized usage ledger |
 
 ### OpenClaw 说明

--- a/dashboard/src/hooks/use-recent-usage-data.test.tsx
+++ b/dashboard/src/hooks/use-recent-usage-data.test.tsx
@@ -163,4 +163,36 @@ describe("useRecentUsageData", () => {
     );
     expect(result.current.source).toBe("edge");
   });
+
+  it("clears the immediate snapshot override after a failed refresh and reports cache provenance honestly", async () => {
+    liveSnapshots.readDashboardLiveSnapshot.mockReturnValue({
+      rolling: { last_7d: { totals: { billable_total_tokens: "84" } } },
+      fetchedAt: "2026-03-07T00:00:00.000Z",
+    });
+    dashboardCache.readDashboardCache.mockReturnValue({
+      rolling: { last_7d: { totals: { billable_total_tokens: "63" } } },
+      fetchedAt: "2026-03-06T23:00:00.000Z",
+    });
+    vibeusageApi.getUsageSummary.mockRejectedValue(new Error("backend unavailable"));
+
+    const { result } = renderHook(() =>
+      useRecentUsageData({
+        baseUrl: "https://example.com",
+        accessToken: "token",
+        cacheKey: "user-1",
+        timeZone: "UTC",
+        tzOffsetMinutes: 0,
+        now: new Date("2026-03-07T00:00:00Z"),
+      }),
+    );
+
+    await waitFor(() => expect(vibeusageApi.getUsageSummary).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.source).toBe("cache");
+    expect(result.current.error).toBeNull();
+    expect(result.current.fetchedAt).toBe("2026-03-06T23:00:00.000Z");
+    expect(result.current.rolling).toEqual({
+      last_7d: { totals: { billable_total_tokens: "63" } },
+    });
+  });
 });

--- a/dashboard/src/hooks/use-recent-usage-data.test.tsx
+++ b/dashboard/src/hooks/use-recent-usage-data.test.tsx
@@ -15,6 +15,11 @@ const dashboardCache = vi.hoisted(() => ({
   writeDashboardCache: vi.fn(),
 }));
 
+const liveSnapshots = vi.hoisted(() => ({
+  readDashboardLiveSnapshot: vi.fn(() => null as any),
+  writeDashboardLiveSnapshot: vi.fn(),
+}));
+
 const mockData = vi.hoisted(() => ({
   isMockEnabled: vi.fn(() => false),
 }));
@@ -30,6 +35,7 @@ const vibeusageApi = vi.hoisted(() => ({
 
 vi.mock("../lib/auth-token", () => authToken);
 vi.mock("../lib/dashboard-cache", () => dashboardCache);
+vi.mock("../lib/dashboard-live-snapshot", () => liveSnapshots);
 vi.mock("../lib/mock-data", () => mockData);
 vi.mock("../lib/timezone", () => timezone);
 vi.mock("../lib/vibeusage-api", () => vibeusageApi);
@@ -47,6 +53,9 @@ describe("useRecentUsageData", () => {
     dashboardCache.readDashboardCache.mockReset();
     dashboardCache.readDashboardCache.mockReturnValue(null);
     dashboardCache.writeDashboardCache.mockReset();
+    liveSnapshots.readDashboardLiveSnapshot.mockReset();
+    liveSnapshots.readDashboardLiveSnapshot.mockReturnValue(null);
+    liveSnapshots.writeDashboardLiveSnapshot.mockReset();
 
     mockData.isMockEnabled.mockReset();
     mockData.isMockEnabled.mockReturnValue(false);
@@ -104,5 +113,54 @@ describe("useRecentUsageData", () => {
     expect(result.current.rolling).toEqual({
       last_7d: { totals: { billable_total_tokens: "42" } },
     });
+  });
+
+  it("hydrates a resolved recent-usage snapshot immediately while refreshing in the background", async () => {
+    liveSnapshots.readDashboardLiveSnapshot.mockReturnValue({
+      rolling: { last_7d: { totals: { billable_total_tokens: "84" } } },
+      fetchedAt: "2026-03-07T00:00:00.000Z",
+    });
+
+    let resolveSummary: ((value: any) => void) | null = null;
+    vibeusageApi.getUsageSummary.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSummary = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useRecentUsageData({
+        baseUrl: "https://example.com",
+        accessToken: "token",
+        cacheKey: "user-1",
+        timeZone: "UTC",
+        tzOffsetMinutes: 0,
+        now: new Date("2026-03-07T00:00:00Z"),
+      }),
+    );
+
+    await waitFor(() => expect(vibeusageApi.getUsageSummary).toHaveBeenCalledTimes(1));
+    expect(result.current.source).toBe("edge");
+    expect(result.current.fetchedAt).toBe("2026-03-07T00:00:00.000Z");
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.rolling).toEqual({
+      last_7d: { totals: { billable_total_tokens: "84" } },
+    });
+
+    await act(async () => {
+      resolveSummary?.({
+        totals: null,
+        rolling: { last_7d: { totals: { billable_total_tokens: "126" } } },
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.rolling).toEqual({
+        last_7d: { totals: { billable_total_tokens: "126" } },
+      }),
+    );
+    expect(result.current.source).toBe("edge");
   });
 });

--- a/dashboard/src/hooks/use-recent-usage-data.ts
+++ b/dashboard/src/hooks/use-recent-usage-data.ts
@@ -113,6 +113,7 @@ export function useRecentUsageData({
       }
     } catch (e) {
       if (signal?.aborted || (e as any)?.name === "AbortError") return;
+      immediateSnapshotVisibleRef.current = false;
       if (cacheAllowed) {
         const cached = readCache();
         if (cached?.rolling) {

--- a/dashboard/src/hooks/use-recent-usage-data.ts
+++ b/dashboard/src/hooks/use-recent-usage-data.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isAccessTokenReady, resolveAuthAccessToken } from "../lib/auth-token";
 import {
   buildDashboardCacheKey,
@@ -6,6 +6,11 @@ import {
   readDashboardCache,
   writeDashboardCache,
 } from "../lib/dashboard-cache";
+import {
+  deleteDashboardLiveSnapshot,
+  readDashboardLiveSnapshot,
+  writeDashboardLiveSnapshot,
+} from "../lib/dashboard-live-snapshot";
 import { isMockEnabled } from "../lib/mock-data";
 import { getLocalDayKey, getTimeZoneCacheKey } from "../lib/timezone";
 import { getUsageSummary } from "../lib/vibeusage-api";
@@ -43,6 +48,8 @@ export function useRecentUsageData({
     baseUrl,
     segments: [anchorDay, getTimeZoneCacheKey({ timeZone, offsetMinutes: tzOffsetMinutes })],
   });
+  const liveSnapshot = readDashboardLiveSnapshot("recentUsage", storageKey);
+  const hasImmediateSnapshot = Boolean(liveSnapshot?.rolling);
 
   const readCache = useCallback(() => {
     return readDashboardCache(storageKey, (parsed) => Boolean(parsed?.rolling));
@@ -59,7 +66,16 @@ export function useRecentUsageData({
     clearDashboardCache(storageKey);
   }, [storageKey]);
 
-  const refresh = useCallback(async ({ signal }: any = {}) => {
+  const immediateSnapshotVisibleRef = useRef(false);
+  const deferToImmediateSnapshot = hasImmediateSnapshot && immediateSnapshotVisibleRef.current;
+  const visibleRolling = deferToImmediateSnapshot ? liveSnapshot?.rolling || null : rolling;
+  const visibleFetchedAt = deferToImmediateSnapshot ? liveSnapshot?.fetchedAt || null : fetchedAt;
+  const visibleSource = deferToImmediateSnapshot ? "edge" : source;
+  const visibleLoading = deferToImmediateSnapshot ? false : loading;
+  const visibleError = deferToImmediateSnapshot ? null : error;
+
+  const refresh = useCallback(async ({ signal, preferImmediateSnapshot = false }: any = {}) => {
+    if (!preferImmediateSnapshot) immediateSnapshotVisibleRef.current = false;
     const resolvedToken = await resolveAuthAccessToken(accessToken);
     if (!resolvedToken && !mockEnabled) return;
     if (signal?.aborted) return;
@@ -83,6 +99,12 @@ export function useRecentUsageData({
       setRolling(nextRolling);
       setFetchedAt(nowIso);
       setSource("edge");
+      immediateSnapshotVisibleRef.current = false;
+      deleteDashboardLiveSnapshot("recentUsage", storageKey);
+      writeDashboardLiveSnapshot("recentUsage", storageKey, {
+        rolling: nextRolling,
+        fetchedAt: nowIso,
+      });
 
       if (nextRolling && cacheAllowed) {
         writeCache({ rolling: nextRolling, fetchedAt: nowIso });
@@ -140,8 +162,9 @@ export function useRecentUsageData({
     if (!cacheAllowed) clearCache();
     setError(null);
     setSource("edge");
+    immediateSnapshotVisibleRef.current = hasImmediateSnapshot;
     const controller = new AbortController();
-    refresh({ signal: controller.signal });
+    refresh({ signal: controller.signal, preferImmediateSnapshot: hasImmediateSnapshot });
     return () => {
       controller.abort();
     };
@@ -150,11 +173,11 @@ export function useRecentUsageData({
   const normalizedSource = mockEnabled ? "mock" : source;
 
   return {
-    rolling,
-    source: normalizedSource,
-    fetchedAt,
-    loading,
-    error,
+    rolling: visibleRolling,
+    source: mockEnabled ? "mock" : visibleSource,
+    fetchedAt: visibleFetchedAt,
+    loading: visibleLoading,
+    error: visibleError,
     refresh,
   };
 }

--- a/dashboard/src/lib/dashboard-live-snapshot.ts
+++ b/dashboard/src/lib/dashboard-live-snapshot.ts
@@ -1,4 +1,4 @@
-type SnapshotScope = "usage" | "trend" | "modelBreakdown";
+type SnapshotScope = "usage" | "trend" | "modelBreakdown" | "recentUsage";
 
 const snapshotScopes = new Map<SnapshotScope, Map<string, any>>();
 
@@ -23,6 +23,11 @@ export function writeDashboardLiveSnapshot(
 ) {
   if (!key) return;
   getScopeStore(scope).set(key, snapshot);
+}
+
+export function deleteDashboardLiveSnapshot(scope: SnapshotScope, key?: string | null) {
+  if (!key) return;
+  getScopeStore(scope).delete(key);
 }
 
 export function clearDashboardLiveSnapshotsForTests() {

--- a/openspec/changes/archive/2026-04-12-2026-04-12-refactor-data-source-ssot-boundaries/design.md
+++ b/openspec/changes/archive/2026-04-12-2026-04-12-refactor-data-source-ssot-boundaries/design.md
@@ -1,0 +1,72 @@
+# Design: Data-source SSOT boundaries
+
+## Context
+
+The current repository already states strong SSOT principles, but three public-facing fact domains still permit multiple read paths or multiple provenance interpretations:
+
+1. `vibeusage-leaderboard` reads snapshots first but still falls back to `_current` views and synthesizes `generated_at` from request time.
+2. OpenCode sync still passes both `messageFiles` and `opencodeDbPath` into local accounting, so `opencode.db` is not yet the only operational truth.
+3. Dashboard usage hooks already distinguish `edge` and `cache`, but the spec does not yet make immediate snapshot reuse vs cache fallback explicit enough to prevent provenance drift.
+
+## GitHub / OpenSpec guidance used
+
+GitHub research against the official `Fission-AI/OpenSpec` docs reinforces three points that shape this update:
+
+- `openspec/specs/` is the source of truth for current behavior, while `openspec/changes/` holds reviewable proposed modifications.
+- Active changes can evolve freely; updating artifacts or adding a new focused change is allowed when intent or scope becomes clearer.
+- `## MODIFIED Requirements` replaces existing behavior, while `## REMOVED Requirements` is the right tool when an old fallback path must disappear completely.
+
+## Why this is a new change package
+
+This work is intentionally a new change package instead of reopening `2026-03-24-refactor-ssot-foundations`:
+
+- the older SSOT umbrella already converged many shared helpers and cache protocols,
+- its remaining unchecked work is not the same problem as these hard-cut data-source boundaries,
+- and this package needs clean review around breaking removal of multi-source read paths.
+
+## Fact-domain matrix
+
+| Domain | Authoritative source | Allowed derived layer | Forbidden second truth |
+| --- | --- | --- | --- |
+| Leaderboard list/profile reads | `public.vibeusage_leaderboard_snapshots` | async refresh materializes the snapshot | `_current` leaderboard views used at request time |
+| Leaderboard `generated_at` | snapshot row `generated_at` | none | request-time synthesis |
+| OpenCode local accounting | `OPENCODE_HOME/opencode.db` | SQLite reader health surfaced through diagnostics/status | legacy message JSON accounting |
+| Dashboard live provenance | successful backend response | prior successful backend snapshot for the same params while refresh is in flight | cache/local state presented as fresh backend truth |
+| Dashboard degraded provenance | browser cache after failed backend request | stale label + last-updated timestamp | `edge` label on cache-only state |
+
+## Decisions
+
+### 1. Snapshot-only leaderboard read contract
+
+Leaderboard list and profile endpoints must resolve from the same snapshot-backed store. If the requested snapshot is missing or stale, the endpoint should return an explicit not-ready response rather than silently switching to `_current` views.
+
+### 2. Snapshot `generated_at` is materialization time, not request time
+
+`generated_at` must describe when the authoritative leaderboard snapshot was produced. It must never be synthesized with `new Date().toISOString()` during a fallback read path.
+
+### 3. OpenCode accounting becomes SQLite-only
+
+`opencode.db` becomes the only supported local accounting source for OpenCode truth. Legacy message files may still exist on disk, but they are no longer an accounting input, no longer a fallback, and no longer part of diagnostics truth.
+
+### 4. Dashboard provenance must describe derivation honestly
+
+The dashboard may keep continuity UX, but its labels must match the actual derivation path:
+
+- `edge` = current backend response, or a reused snapshot from a previous successful backend response for the same request.
+- `cache` = browser-local fallback shown only after a backend request fails.
+- `mock` = mock data only.
+
+### 5. Regression guards must encode the contract
+
+The implementation should add regression coverage that specifically prevents:
+
+- leaderboard `_current` fallback reintroduction,
+- request-time `generated_at` synthesis,
+- OpenCode message-file accounting from reappearing,
+- and dashboard cache states being mislabeled as live backend truth.
+
+## Non-goals
+
+- No new compatibility bridge or third storage path.
+- No silent migration period with permanent dual-read behavior.
+- No client-local recomputation presented as backend truth.

--- a/openspec/changes/archive/2026-04-12-2026-04-12-refactor-data-source-ssot-boundaries/proposal.md
+++ b/openspec/changes/archive/2026-04-12-2026-04-12-refactor-data-source-ssot-boundaries/proposal.md
@@ -1,0 +1,19 @@
+# Change: Refactor data-source SSOT boundaries
+
+## Why
+
+VibeUsage still has a few user-visible fact contracts that can answer from two stores or two provenance stories. The biggest remaining cases are leaderboard list reads (snapshot rows vs `_current` views), OpenCode local accounting (`opencode.db` vs legacy message JSON files), and dashboard continuity labels (live backend truth vs local continuity helpers). This ambiguity makes production debugging non-deterministic and violates the repository's single-source-of-truth rule.
+
+## What Changes
+
+- Hard-cut leaderboard read contracts to snapshot-backed rows only and remove `_current` fallback reads.
+- Make leaderboard freshness explicit: missing or stale snapshots return an explicit not-ready response instead of synthesizing `generated_at` at request time.
+- Hard-cut OpenCode local accounting to `OPENCODE_HOME/opencode.db` and remove legacy message-file accounting from sync, audit, status, and diagnostics truth.
+- Tighten dashboard provenance semantics so backend success is the only live truth; prior backend snapshot reuse is continuity only; cache after failure is a degraded fallback.
+- Add regression guard requirements so a second truth source cannot reappear silently.
+
+## Impact
+
+- Affected specs: `vibeusage-tracker`
+- Affected code: `insforge-src/functions-esm/vibeusage-leaderboard.js`, `insforge-src/functions-esm/vibeusage-leaderboard-profile.js`, `insforge-src/functions-esm/vibeusage-leaderboard-refresh.js`, `src/commands/sync.js`, `src/lib/rollout.js`, `src/lib/opencode-usage-audit.js`, `src/commands/status.js`, `src/lib/diagnostics.js`, `dashboard/src/hooks/use-usage-data.ts`, `dashboard/src/hooks/use-trend-data.ts`, `dashboard/src/hooks/use-usage-model-breakdown.ts`, `dashboard/src/lib/dashboard-live-snapshot.ts`, `dashboard/src/lib/dashboard-cache.ts`, `README.md`, `README.zh-CN.md`, `test/edge-functions.test.js`, `test/rollout-parser.test.js`, `test/opencode-usage-audit.test.js`, `test/ssot-foundations.test.js`
+- Related changes: narrows the remaining unresolved data-source boundaries left after `2026-03-24-refactor-ssot-foundations`, and intentionally supersedes the permissive OpenCode coexistence rule currently present in the stable `vibeusage-tracker` spec.

--- a/openspec/changes/archive/2026-04-12-2026-04-12-refactor-data-source-ssot-boundaries/specs/vibeusage-tracker/spec.md
+++ b/openspec/changes/archive/2026-04-12-2026-04-12-refactor-data-source-ssot-boundaries/specs/vibeusage-tracker/spec.md
@@ -1,0 +1,89 @@
+## MODIFIED Requirements
+
+### Requirement: Leaderboard response includes generation timestamp
+
+The leaderboard endpoint SHALL include a `generated_at` timestamp from the authoritative snapshot row used to answer the request. Request handlers MUST NOT synthesize `generated_at` from request time when no snapshot row was used.
+
+#### Scenario: Response includes snapshot generated_at
+
+- **GIVEN** a snapshot exists for `period=week` with `generated_at`
+- **WHEN** the user calls `GET /functions/vibeusage-leaderboard?period=week&metric=all`
+- **THEN** the response SHALL include that snapshot `generated_at`
+- **AND** the value SHALL describe snapshot materialization time, not request time
+
+### Requirement: Dashboard retains last-known data during backend failures
+
+The dashboard MUST treat successful backend responses as the only live usage truth. A previously resolved backend snapshot for the same request MAY be reused immediately while a new request is in flight, but cache fallback after a failed request MUST be labeled cached/stale with a last-updated timestamp.
+
+#### Scenario: Resolved backend snapshot is reused during refresh
+
+- **GIVEN** the user has previously loaded usage data successfully for the same request parameters
+- **WHEN** the dashboard starts a new refresh for those same parameters
+- **THEN** it MAY continue rendering the prior backend-derived snapshot while the refresh is in flight
+- **AND** it SHALL NOT present browser cache as the current source unless the refresh fails
+
+#### Scenario: Backend unavailable after prior success
+
+- **GIVEN** the user has previously loaded usage data successfully
+- **WHEN** subsequent backend requests fail (network error or 5xx)
+- **THEN** the dashboard SHALL continue to display the last-known usage summary, daily totals, and heatmap
+- **AND** the UI SHALL label the data as cached/stale and show the last-updated timestamp
+
+### Requirement: Dashboard shows data source indicator
+
+The dashboard SHALL display a data source label (`edge|cache|mock`) for usage and activity panels with these semantics: `edge` means a successful backend response or a reused snapshot from a previous successful backend response for the same request; `cache` means browser-local fallback shown only after a failed backend request; `mock` means local mock data. Client-derived-only continuity state MUST NOT be labeled `edge`.
+
+#### Scenario: Immediate snapshot reuse remains backend-derived
+
+- **GIVEN** the dashboard has a prior successful backend snapshot for the same request
+- **WHEN** the next refresh starts and the UI reuses that snapshot before the network response resolves
+- **THEN** the UI SHALL show `DATA_SOURCE: EDGE`
+- **AND** it SHALL preserve the snapshot's last-updated timestamp
+
+#### Scenario: Cache fallback is explicit
+
+- **GIVEN** the user is signed in and cached data is used due to a fetch failure
+- **WHEN** the dashboard renders usage or activity panels
+- **THEN** the UI SHALL show `DATA_SOURCE: CACHE`
+
+### Requirement: OpenCode local usage parsing is SQLite-first
+
+The CLI SHALL treat `~/.local/share/opencode/opencode.db` (or `OPENCODE_HOME/opencode.db`) as the only authoritative OpenCode local usage source for sync, audit, status, and diagnostics truth. Legacy message JSON files MUST NOT be parsed, merged, or used as fallback accounting input.
+
+#### Scenario: Sync reads OpenCode SQLite data without legacy message files
+
+- **GIVEN** an OpenCode home that contains `opencode.db`
+- **AND** the legacy message JSON directory is empty or absent
+- **WHEN** a user runs `npx vibeusage sync`
+- **THEN** the CLI SHALL still parse OpenCode local usage from SQLite
+- **AND** it SHALL aggregate tokens using the same half-hour bucket model as other local sources
+
+#### Scenario: SQLite degradation is explicit
+
+- **GIVEN** `opencode.db` is missing or unreadable
+- **WHEN** a user runs `npx vibeusage sync` or an OpenCode diagnostic command
+- **THEN** the CLI SHALL report degraded or missing OpenCode SQLite support
+- **AND** it SHALL NOT substitute legacy message-file totals as OpenCode usage truth
+
+### Requirement: Leaderboard is served from precomputed snapshots
+
+The system SHALL serve leaderboard list and profile data from `public.vibeusage_leaderboard_snapshots` for the requested `period`. Read endpoints MUST NOT fall back to `_current` views or any second read store for the same leaderboard contract.
+
+#### Scenario: Leaderboard reads from latest snapshot
+
+- **GIVEN** a snapshot exists for `period=week` with `generated_at`
+- **WHEN** a signed-in user calls `GET /functions/vibeusage-leaderboard?period=week&metric=all`
+- **THEN** the response SHALL reflect the latest snapshot totals (`gpt_tokens`, `claude_tokens`, `total_tokens`)
+- **AND** the response SHALL include the snapshot `generated_at`
+- **AND** leaderboard list and profile reads SHALL follow the same snapshot-backed freshness semantics
+
+#### Scenario: Snapshot unavailable is explicit
+
+- **GIVEN** no snapshot exists or the snapshot is stale for the requested period
+- **WHEN** a signed-in user calls `GET /functions/vibeusage-leaderboard?period=week&metric=all`
+- **THEN** the endpoint SHALL return a structured non-success response that identifies snapshot unavailability
+- **AND** it SHALL NOT fall back to `_current` views
+- **AND** it SHALL NOT synthesize a fresh `generated_at` at request time
+
+## REMOVED Requirements
+

--- a/openspec/changes/archive/2026-04-12-2026-04-12-refactor-data-source-ssot-boundaries/tasks.md
+++ b/openspec/changes/archive/2026-04-12-2026-04-12-refactor-data-source-ssot-boundaries/tasks.md
@@ -1,0 +1,30 @@
+## 1. Spec freeze
+
+- [x] 1.1 Replace leaderboard fallback-read requirements with snapshot-only read requirements.
+- [x] 1.2 Modify the OpenCode local usage requirement so `opencode.db` becomes the only supported accounting source.
+- [x] 1.3 Tighten dashboard provenance requirements for live snapshot reuse vs cache fallback.
+
+## 2. Leaderboard hard-cut
+
+- [x] 2.1 Remove `_current` fallback reads and request-time `generated_at` synthesis from `insforge-src/functions-esm/vibeusage-leaderboard.js`.
+- [x] 2.2 Keep leaderboard list/profile freshness semantics aligned on the same snapshot contract.
+- [x] 2.3 Update leaderboard regression tests and `test/ssot-foundations.test.js`.
+
+## 3. OpenCode hard-cut
+
+- [x] 3.1 Remove legacy message-file accounting from `src/commands/sync.js`, `src/lib/rollout.js`, and `src/lib/opencode-usage-audit.js`.
+- [x] 3.2 Keep diagnostics/status/doctor focused on SQLite reader health without using legacy message files as fallback truth.
+- [x] 3.3 Update OpenCode parsing and audit regression tests plus README documentation.
+
+## 4. Dashboard provenance audit
+
+- [x] 4.1 Ensure usage/trend/model-breakdown hooks treat prior backend snapshots as continuity helpers, not a second live source.
+- [x] 4.2 Ensure cache fallback appears only after backend failure and is labeled `cache` with a truthful last-updated timestamp.
+- [x] 4.3 Add regression coverage for provenance labels and continuity semantics.
+
+## 5. Verification
+
+- [x] 5.1 Run `node --test --test-concurrency=1 test/edge-functions.test.js test/ssot-foundations.test.js`.
+- [x] 5.2 Run `node --test --test-concurrency=1 test/rollout-parser.test.js test/opencode-usage-audit.test.js test/ssot-foundations.test.js`.
+- [x] 5.3 Run `npm test -- --run src/hooks/use-usage-data.test.tsx src/hooks/use-trend-data.test.ts src/hooks/use-usage-model-breakdown.test.ts src/hooks/use-activity-heatmap.test.ts`.
+- [x] 5.4 Run `npm run ci:local`.

--- a/openspec/specs/vibeusage-tracker/spec.md
+++ b/openspec/specs/vibeusage-tracker/spec.md
@@ -433,13 +433,14 @@ Model family matching:
 
 ### Requirement: Leaderboard response includes generation timestamp
 
-The leaderboard endpoint SHALL include a `generated_at` timestamp indicating when the leaderboard data was produced.
+The leaderboard endpoint SHALL include a `generated_at` timestamp from the authoritative snapshot row used to answer the request. Request handlers MUST NOT synthesize `generated_at` from request time when no snapshot row was used.
 
-#### Scenario: Response includes generated_at
+#### Scenario: Response includes snapshot generated_at
 
-- **GIVEN** a user is signed in and has a valid `user_jwt`
+- **GIVEN** a snapshot exists for `period=week` with `generated_at`
 - **WHEN** the user calls `GET /functions/vibeusage-leaderboard?period=week&metric=all`
-- **THEN** the response SHALL include `generated_at` as an ISO timestamp
+- **THEN** the response SHALL include that snapshot `generated_at`
+- **AND** the value SHALL describe snapshot materialization time, not request time
 
 ### Requirement: Leaderboard response includes `me`
 
@@ -686,7 +687,14 @@ The system SHALL keep Edge Function author sources under `insforge-src/functions
 
 ### Requirement: Dashboard retains last-known data during backend failures
 
-The dashboard MUST retain and display the most recent successful usage data when backend requests fail, and MUST indicate the data is cached/stale with a last-updated timestamp.
+The dashboard MUST treat successful backend responses as the only live usage truth. A previously resolved backend snapshot for the same request MAY be reused immediately while a new request is in flight, but cache fallback after a failed request MUST be labeled cached/stale with a last-updated timestamp.
+
+#### Scenario: Resolved backend snapshot is reused during refresh
+
+- **GIVEN** the user has previously loaded usage data successfully for the same request parameters
+- **WHEN** the dashboard starts a new refresh for those same parameters
+- **THEN** it MAY continue rendering the prior backend-derived snapshot while the refresh is in flight
+- **AND** it SHALL NOT present browser cache as the current source unless the refresh fails
 
 #### Scenario: Backend unavailable after prior success
 
@@ -694,12 +702,6 @@ The dashboard MUST retain and display the most recent successful usage data when
 - **WHEN** subsequent backend requests fail (network error or 5xx)
 - **THEN** the dashboard SHALL continue to display the last-known usage summary, daily totals, and heatmap
 - **AND** the UI SHALL label the data as cached/stale and show the last-updated timestamp
-
-#### Scenario: Backend unavailable with no cache
-
-- **GIVEN** the user has no cached usage data
-- **WHEN** backend requests fail
-- **THEN** the dashboard SHALL show the existing empty-state or error messaging (no stale data)
 
 ### Requirement: Web UI copy is managed by a registry
 
@@ -717,25 +719,20 @@ The system SHALL centralize all web UI text in a repository-hosted copy registry
 
 ### Requirement: Dashboard shows data source indicator
 
-The dashboard SHALL display a data source label (`edge|cache|mock`) for usage and activity panels so users can distinguish live data from cached or mocked data.
+The dashboard SHALL display a data source label (`edge|cache|mock`) for usage and activity panels with these semantics: `edge` means a successful backend response or a reused snapshot from a previous successful backend response for the same request; `cache` means browser-local fallback shown only after a failed backend request; `mock` means local mock data. Client-derived-only continuity state MUST NOT be labeled `edge`.
 
-#### Scenario: Mock mode is explicit
+#### Scenario: Immediate snapshot reuse remains backend-derived
 
-- **GIVEN** mock mode is enabled via `VITE_VIBEUSAGE_MOCK=1` or `?mock=1`
-- **WHEN** the dashboard renders
-- **THEN** the UI SHALL show `DATA_SOURCE: MOCK`
+- **GIVEN** the dashboard has a prior successful backend snapshot for the same request
+- **WHEN** the next refresh starts and the UI reuses that snapshot before the network response resolves
+- **THEN** the UI SHALL show `DATA_SOURCE: EDGE`
+- **AND** it SHALL preserve the snapshot's last-updated timestamp
 
 #### Scenario: Cache fallback is explicit
 
 - **GIVEN** the user is signed in and cached data is used due to a fetch failure
-- **WHEN** the dashboard renders usage or heatmap panels
+- **WHEN** the dashboard renders usage or activity panels
 - **THEN** the UI SHALL show `DATA_SOURCE: CACHE`
-
-#### Scenario: Live data is explicit
-
-- **GIVEN** the user is signed in and backend requests succeed
-- **WHEN** the dashboard renders usage or heatmap panels
-- **THEN** the UI SHALL show `DATA_SOURCE: EDGE`
 
 ### Requirement: User JWT validation resolves users reliably
 
@@ -1021,31 +1018,6 @@ When ingesting with service-role credentials, the system MUST avoid a pre-read o
 - **THEN** the server SHALL attempt an `on_conflict` insert with `ignore-duplicates`
 - **AND** fall back to the legacy path only if upsert is unsupported
 
-### Requirement: Leaderboard fallback query SHALL apply pagination at source
-
-The system SHALL apply the requested `limit` and `offset` when querying the leaderboard view in the non-snapshot fallback path, so only the requested page rows are fetched (plus `me` when needed).
-
-#### Scenario: Limit enforced at query
-
-- **WHEN** a user requests `GET /functions/vibeusage-leaderboard?period=week&metric=all&limit=20&offset=40`
-- **THEN** the backend SHALL query only the requested page rows (rank `41..60`)
-- **AND** the response payload SHALL remain unchanged
-
-### Requirement: Leaderboard fallback SHOULD use single query when possible
-
-The system SHALL attempt a single-query fallback to fetch both Top N entries and the current user's row, and SHALL fall back to the legacy double-query flow if the single query fails.
-
-#### Scenario: Single query succeeds
-
-- **WHEN** a signed-in user requests the leaderboard
-- **THEN** the backend SHALL fetch rows matching `rank between offset+1 and offset+limit OR is_me = true` in one query
-- **AND** the response payload SHALL remain unchanged
-
-#### Scenario: Single query fails
-
-- **WHEN** the single-query attempt fails
-- **THEN** the backend SHALL fall back to the legacy `entries + me` queries
-
 ### Requirement: Matrix rain rendering is GPU-budgeted
 
 The UI SHALL render the Matrix rain animation with a capped update rate and reduced internal render resolution, and SHALL pause rendering when the document is hidden, so steady-state GPU usage remains below 2% on the reference device.
@@ -1179,7 +1151,7 @@ When daily rows are already fetched (i.e., `period!=total`), the dashboard MUST 
 
 ### Requirement: OpenCode local usage parsing is SQLite-first
 
-The CLI SHALL treat `~/.local/share/opencode/opencode.db` (or `OPENCODE_HOME/opencode.db`) as the current authoritative OpenCode local usage source. Legacy message JSON files MAY still be parsed when present, but SQLite-backed usage MUST be included when the database exists.
+The CLI SHALL treat `~/.local/share/opencode/opencode.db` (or `OPENCODE_HOME/opencode.db`) as the only authoritative OpenCode local usage source for sync, audit, status, and diagnostics truth. Legacy message JSON files MUST NOT be parsed, merged, or used as fallback accounting input.
 
 #### Scenario: Sync reads OpenCode SQLite data without legacy message files
 
@@ -1189,12 +1161,12 @@ The CLI SHALL treat `~/.local/share/opencode/opencode.db` (or `OPENCODE_HOME/ope
 - **THEN** the CLI SHALL still parse OpenCode local usage from SQLite
 - **AND** it SHALL aggregate tokens using the same half-hour bucket model as other local sources
 
-#### Scenario: OpenCode project attribution uses project worktree
+#### Scenario: SQLite degradation is explicit
 
-- **GIVEN** an OpenCode SQLite message row linked through `session.project_id`
-- **WHEN** the tracker attributes project-scoped usage
-- **THEN** it SHALL resolve the project path from `project.worktree`
-- **AND** it SHALL NOT infer the project path from legacy message file locations
+- **GIVEN** `opencode.db` is missing or unreadable
+- **WHEN** a user runs `npx vibeusage sync` or an OpenCode diagnostic command
+- **THEN** the CLI SHALL report degraded or missing OpenCode SQLite support
+- **AND** it SHALL NOT substitute legacy message-file totals as OpenCode usage truth
 
 ### Requirement: Auto sync health is diagnosable
 
@@ -1340,7 +1312,7 @@ The dashboard UI SHALL default the DETAILS table date/time sorting to newest-fir
 
 ### Requirement: Leaderboard is served from precomputed snapshots
 
-The system SHALL compute leaderboard rankings from a precomputed snapshot that is refreshed asynchronously.
+The system SHALL serve leaderboard list and profile data from `public.vibeusage_leaderboard_snapshots` for the requested `period`. Read endpoints MUST NOT fall back to `_current` views or any second read store for the same leaderboard contract.
 
 #### Scenario: Leaderboard reads from latest snapshot
 
@@ -1348,6 +1320,15 @@ The system SHALL compute leaderboard rankings from a precomputed snapshot that i
 - **WHEN** a signed-in user calls `GET /functions/vibeusage-leaderboard?period=week&metric=all`
 - **THEN** the response SHALL reflect the latest snapshot totals (`gpt_tokens`, `claude_tokens`, `total_tokens`)
 - **AND** the response SHALL include the snapshot `generated_at`
+- **AND** leaderboard list and profile reads SHALL follow the same snapshot-backed freshness semantics
+
+#### Scenario: Snapshot unavailable is explicit
+
+- **GIVEN** no snapshot exists or the snapshot is stale for the requested period
+- **WHEN** a signed-in user calls `GET /functions/vibeusage-leaderboard?period=week&metric=all`
+- **THEN** the endpoint SHALL return a structured non-success response that identifies snapshot unavailability
+- **AND** it SHALL NOT fall back to `_current` views
+- **AND** it SHALL NOT synthesize a fresh `generated_at` at request time
 
 ### Requirement: Leaderboard snapshots are refreshable by authorized automation
 


### PR DESCRIPTION
## What does this PR do?
Follow-up cleanup after PR #137 to close the remaining SSOT surface gaps in stable specs, parser shape, and dashboard provenance consistency.

## Type of Change
- [x] Refactor
- [x] Docs / spec update
- [x] Test update
- [ ] Feature
- [ ] Bugfix
- [ ] Breaking change

## Changes Made
- archive the merged SSOT boundary change into stable OpenSpec truth and align README.zh-CN wording
- remove the remaining OpenCode legacy parser shell from `parseOpencodeIncremental`
- align `useRecentUsageData` with the dashboard's snapshot-first provenance semantics

## Affected Modules / Contracts
- `openspec/specs/vibeusage-tracker/spec.md`
- `openspec/changes/archive/2026-04-12-2026-04-12-refactor-data-source-ssot-boundaries/`
- `README.zh-CN.md`
- `src/lib/rollout.js`
- `test/rollout-parser.test.js`
- `dashboard/src/lib/dashboard-live-snapshot.ts`
- `dashboard/src/hooks/use-recent-usage-data.ts`
- `dashboard/src/hooks/use-recent-usage-data.test.tsx`

## Validation
### Automated
- `node --test --test-concurrency=1 test/rollout-parser.test.js`
- `npm test -- --run src/hooks/use-recent-usage-data.test.tsx`
- `npm test -- --run src/hooks/use-recent-usage-data.test.tsx src/hooks/use-usage-data.test.tsx src/hooks/use-trend-data.test.ts src/hooks/use-usage-model-breakdown.test.ts src/hooks/use-activity-heatmap.test.ts`

### Manual / smoke
- verified scoped clean worktree contains only the intended SSOT follow-up files before commit
- confirmed the recent-usage snapshot regression now switches from immediate snapshot visibility to fresh state after refresh completion

### Uncovered scope
- did not run repo-wide CI in the clean worktree because that worktree lacks unrelated dev dependencies (`esbuild`, `@insforge/sdk`) needed by many broader tests
- did not validate unrelated dirty-worktree changes from the main local checkout

## Risk Flags
- [ ] DB schema / migration
- [ ] Auth / permission boundary
- [ ] Public exposure / share links / unauthenticated access
- [ ] Background job / cron / queue semantics
- [x] Cross-module contract / data-flow change
- [ ] Breaking change for external users

## Risk Addendum
### Rules / Invariants
- leaderboard stable spec must remain snapshot-only with no `_current` fallback contract
- OpenCode local accounting must remain SQLite-only at runtime and in parser shape
- dashboard recent usage must treat prior backend-derived snapshots as `edge`, not `cache`

### Boundary Matrix
- OpenSpec stable spec ↔ archived change package ↔ README.zh-CN wording
- OpenCode parser API shape ↔ rollout tests
- dashboard live snapshot helper ↔ recent usage hook ↔ hook regression tests

### Evidence
- focused Node rollout parser regression passed
- focused recent-usage hook regression passed
- focused dashboard provenance hook bundle passed

## Reviewer Context
- This is a follow-up cleanup branch after PR #137 merged. It intentionally avoids the unrelated dirty worktree changes in the main local checkout.
