### PR TITLE
feat: add Kimi CLI support and release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-23
+
+### Added
+
+- Kimi CLI integration: `vibeusage init` now writes a managed `[[hooks]]` block (SessionEnd / Stop) into `~/.kimi/config.toml`, routing events through the existing `notify.cjs` + `sync --auto` pipeline.
+- Incremental Kimi session parser reads `~/.kimi/sessions/<project>/<session>/wire.jsonl`, maps `StatusUpdate.token_usage` (`input_other`, `input_cache_read`, `input_cache_creation`, `output`) into hourly buckets tagged `source=kimi`.
+- Dashboard Kimi client entry: `KimiIcon` added to `CLIENTS` in `ClientLogos.jsx` so `source=kimi` rows render with a dedicated logo.
+
+### Notes
+
+- Backend `vibeusage_tracker_hourly.source` remains a free-form `text` column with no CHECK constraint; accepting `kimi` required no schema or edge-function changes.
+- Kimi's `StatusUpdate` payload does not include a model field, so buckets are recorded with `model=unknown`.
+
 ## [0.3.0] - 2026-04-02
 
 ### Changed

--- a/dashboard/src/ui/matrix-a/components/ClientLogos.jsx
+++ b/dashboard/src/ui/matrix-a/components/ClientLogos.jsx
@@ -104,11 +104,27 @@ export function OpenClawIcon({ className = "w-5 h-5" }) {
   );
 }
 
+/**
+ * Kimi Logo (Moonshot crescent + K glyph)
+ * Moonshot AI brand theme: lunar motif
+ */
+export function KimiIcon({ className = "w-5 h-5" }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      {/* Crescent moon */}
+      <path d="M20.5 14.5A8 8 0 1 1 9.5 3.5a6.5 6.5 0 0 0 11 11z"/>
+      {/* K glyph */}
+      <path fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" d="M8.5 9v6M8.5 12l3-3M8.5 12l3 3"/>
+    </svg>
+  );
+}
+
 // Client logo data
 export const CLIENTS = [
   { id: "codex", name: "Codex", Icon: OpenAIIcon },
   { id: "claude", name: "Claude Code", Icon: ClaudeIcon },
   { id: "gemini", name: "Gemini", Icon: GeminiIcon },
+  { id: "kimi", name: "Kimi", Icon: KimiIcon },
   { id: "opencode", name: "OpenCode", Icon: OpenCodeIcon },
   { id: "openclaw", name: "OpenClaw", Icon: OpenClawIcon },
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeusage",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "Codex CLI token usage tracker (macOS-first, notify-driven).",
   "license": "MIT",
   "bin": {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -190,7 +190,7 @@ function renderWelcome() {
       DIVIDER,
       "",
       "This tool will:",
-      "  - Analyze your local AI CLI configurations (Codex, Every Code, Claude, Gemini, Opencode, Hermes, OpenClaw)",
+      "  - Analyze your local AI CLI configurations (Codex, Every Code, Claude, Gemini, Kimi, Opencode, Hermes, OpenClaw)",
       "  - Set up lightweight hooks to track your flow state",
       "  - Link your device to your VibeScore account",
       "",
@@ -486,7 +486,7 @@ try {
   const originalPath =
     source === 'every-code'
       ? codeOriginalPath
-      : source === 'claude' || source === 'opencode' || source === 'gemini'
+      : source === 'claude' || source === 'opencode' || source === 'gemini' || source === 'kimi'
         ? null
         : codexOriginalPath;
   if (originalPath) {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -8,9 +8,11 @@ const {
   listRolloutFiles,
   listClaudeProjectFiles,
   listGeminiSessionFiles,
+  listKimiSessionFiles,
   parseRolloutIncremental,
   parseClaudeIncremental,
   parseGeminiIncremental,
+  parseKimiIncremental,
   parseOpencodeIncremental,
   normalizeHourlyState,
   getHourlyBucket,
@@ -71,6 +73,8 @@ async function cmdSync(argv) {
     const claudeProjectsDir = path.join(home, ".claude", "projects");
     const geminiHome = process.env.GEMINI_HOME || path.join(home, ".gemini");
     const geminiTmpDir = path.join(geminiHome, "tmp");
+    const kimiHome = process.env.KIMI_HOME || path.join(home, ".kimi");
+    const kimiSessionsDir = path.join(kimiHome, "sessions");
     const xdgDataHome = process.env.XDG_DATA_HOME || path.join(home, ".local", "share");
     const opencodeHome = process.env.OPENCODE_HOME || path.join(xdgDataHome, "opencode");
     const opencodeDbPath = path.join(opencodeHome, "opencode.db");
@@ -176,6 +180,32 @@ async function cmdSync(argv) {
           );
         },
         source: "gemini",
+      });
+    }
+
+    const kimiFiles = await listKimiSessionFiles(kimiSessionsDir);
+    let kimiResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    if (kimiFiles.length > 0) {
+      if (progress?.enabled) {
+        progress.start(
+          `Parsing Kimi ${renderBar(0)} 0/${formatNumber(kimiFiles.length)} files | buckets 0`,
+        );
+      }
+      kimiResult = await parseKimiIncremental({
+        sessionFiles: kimiFiles,
+        cursors,
+        queuePath,
+        projectQueuePath,
+        onProgress: (p) => {
+          if (!progress?.enabled) return;
+          const pct = p.total > 0 ? p.index / p.total : 1;
+          progress.update(
+            `Parsing Kimi ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} files | buckets ${formatNumber(
+              p.bucketsQueued,
+            )}`,
+          );
+        },
+        source: "kimi",
       });
     }
 
@@ -362,6 +392,7 @@ async function cmdSync(argv) {
         openclawResult.filesProcessed +
         claudeResult.filesProcessed +
         geminiResult.filesProcessed +
+        kimiResult.filesProcessed +
         opencodeResult.filesProcessed;
       const totalBuckets =
         parseResult.bucketsQueued +
@@ -369,6 +400,7 @@ async function cmdSync(argv) {
         openclawResult.bucketsQueued +
         claudeResult.bucketsQueued +
         geminiResult.bucketsQueued +
+        kimiResult.bucketsQueued +
         opencodeResult.bucketsQueued;
       process.stdout.write(
         [

--- a/src/lib/integrations/context.js
+++ b/src/lib/integrations/context.js
@@ -7,6 +7,11 @@ const {
   resolveGeminiSettingsPath,
   buildGeminiHookCommand,
 } = require("../gemini-config");
+const {
+  resolveKimiConfigDir,
+  resolveKimiConfigPath,
+  buildKimiHookCommand,
+} = require("../kimi-config");
 const { resolveOpencodeConfigDir } = require("../opencode-config");
 const { resolveOpenclawSessionPluginPaths } = require("../openclaw-session-plugin");
 const { resolveHermesPluginPaths } = require("../hermes-config");
@@ -25,6 +30,7 @@ async function createIntegrationContext({
   const codeHome = env.CODE_HOME || path.join(home, ".code");
   const claudeDir = path.join(home, ".claude");
   const geminiConfigDir = resolveGeminiConfigDir({ home, env });
+  const kimiConfigDir = resolveKimiConfigDir({ home, env });
   const opencodeConfigDir = resolveOpencodeConfigDir({ home, env });
 
   return {
@@ -54,6 +60,12 @@ async function createIntegrationContext({
       configDir: geminiConfigDir,
       settingsPath: resolveGeminiSettingsPath({ configDir: geminiConfigDir }),
       hookCommand: buildGeminiHookCommand(resolvedNotifyPath),
+    },
+    kimi: {
+      configDir: kimiConfigDir,
+      configPath: resolveKimiConfigPath({ configDir: kimiConfigDir }),
+      hookCommand: buildKimiHookCommand(resolvedNotifyPath),
+      sessionsDir: path.join(kimiConfigDir, "sessions"),
     },
     opencode: {
       configDir: opencodeConfigDir,

--- a/src/lib/integrations/index.js
+++ b/src/lib/integrations/index.js
@@ -3,6 +3,7 @@ const codex = require("./codex");
 const everyCode = require("./every-code");
 const claude = require("./claude");
 const gemini = require("./gemini");
+const kimi = require("./kimi");
 const opencode = require("./opencode");
 const hermes = require("./hermes");
 const openclawSession = require("./openclaw-session");
@@ -12,6 +13,7 @@ const INTEGRATIONS = [
   everyCode,
   claude,
   gemini,
+  kimi,
   opencode,
   hermes,
   openclawSession,

--- a/src/lib/integrations/kimi.js
+++ b/src/lib/integrations/kimi.js
@@ -1,0 +1,108 @@
+const {
+  isKimiHookConfigured,
+  upsertKimiHook,
+  removeKimiHook,
+  probeKimiHook,
+} = require("../kimi-config");
+const { isDir, isFile } = require("./utils");
+
+module.exports = {
+  name: "kimi",
+  summaryLabel: "Kimi",
+  statusLabel: "Kimi hooks",
+  async probe(ctx) {
+    const hasConfigDir = await isDir(ctx.kimi.configDir);
+    if (!hasConfigDir) {
+      return baseProbe(this, { status: "not_installed", detail: "Config not found" });
+    }
+    const hasConfigFile = await isFile(ctx.kimi.configPath);
+    if (!hasConfigFile) {
+      return baseProbe(this, {
+        status: "not_installed",
+        detail: "config.toml not found",
+      });
+    }
+    const state = await probeKimiHook({
+      configPath: ctx.kimi.configPath,
+      hookCommand: ctx.kimi.hookCommand,
+    });
+    if (state.configured) {
+      return baseProbe(this, {
+        status: "ready",
+        detail: "Hooks installed",
+        configured: true,
+      });
+    }
+    return baseProbe(this, {
+      status: state.drifted ? "drifted" : "not_installed",
+      detail: state.drifted
+        ? "Run vibeusage init to reconcile hooks"
+        : "Run vibeusage init to install hooks",
+    });
+  },
+  async install(ctx) {
+    if (!(await isDir(ctx.kimi.configDir))) {
+      return action(this, "skipped", false, "Config not found");
+    }
+    if (!(await isFile(ctx.kimi.configPath))) {
+      return action(this, "skipped", false, "config.toml not found");
+    }
+    const result = await upsertKimiHook({
+      configPath: ctx.kimi.configPath,
+      hookCommand: ctx.kimi.hookCommand,
+    });
+    return action(
+      this,
+      result.changed ? "installed" : "set",
+      Boolean(result.changed),
+      result.changed ? "Hooks installed" : "Hooks already installed",
+    );
+  },
+  async uninstall(ctx) {
+    if (!(await isDir(ctx.kimi.configDir))) {
+      return action(this, "skipped", false, "config dir not found");
+    }
+    if (!(await isFile(ctx.kimi.configPath))) {
+      return action(this, "skipped", false, "config.toml not found");
+    }
+    const result = await removeKimiHook({ configPath: ctx.kimi.configPath });
+    if (result.removed) {
+      return action(this, "removed", true, ctx.kimi.configPath);
+    }
+    if (result.skippedReason === "hook-missing") {
+      return action(this, "unchanged", false, "no change", {
+        skippedReason: result.skippedReason,
+      });
+    }
+    return action(this, "skipped", false, "config.toml not found");
+  },
+  renderStatusValue(probe) {
+    if (probe.status === "ready") return "set";
+    if (probe.status === "not_installed") return "unset";
+    return probe.status;
+  },
+};
+
+function baseProbe(descriptor, values) {
+  return {
+    name: descriptor.name,
+    summaryLabel: descriptor.summaryLabel,
+    statusLabel: descriptor.statusLabel,
+    configured: false,
+    ...values,
+  };
+}
+
+function action(descriptor, status, changed, detail, extras = {}) {
+  return {
+    name: descriptor.name,
+    label: descriptor.summaryLabel,
+    status,
+    changed,
+    detail,
+    ...extras,
+  };
+}
+
+// Expose for tests / diagnostics that want the probe-only check.
+module.exports.isKimiHookConfigured = isKimiHookConfigured;

--- a/src/lib/integrations/kimi.js
+++ b/src/lib/integrations/kimi.js
@@ -62,9 +62,6 @@ module.exports = {
     if (!(await isDir(ctx.kimi.configDir))) {
       return action(this, "skipped", false, "config dir not found");
     }
-    if (!(await isFile(ctx.kimi.configPath))) {
-      return action(this, "skipped", false, "config.toml not found");
-    }
     const result = await removeKimiHook({ configPath: ctx.kimi.configPath });
     if (result.removed) {
       return action(this, "removed", true, ctx.kimi.configPath);

--- a/src/lib/kimi-config.js
+++ b/src/lib/kimi-config.js
@@ -1,0 +1,221 @@
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+
+const { ensureDir } = require("./fs");
+
+const DEFAULT_EVENTS = ["SessionEnd", "Stop"];
+const DEFAULT_TIMEOUT = 30;
+const MANAGED_START = "# --- vibeusage Kimi hooks START (managed, do not edit) ---";
+const MANAGED_END = "# --- vibeusage Kimi hooks END ---";
+
+function resolveKimiConfigDir({ home = os.homedir(), env = process.env } = {}) {
+  const explicit = typeof env.KIMI_HOME === "string" ? env.KIMI_HOME.trim() : "";
+  if (explicit) return path.resolve(explicit);
+  return path.join(home, ".kimi");
+}
+
+function resolveKimiConfigPath({ configDir }) {
+  return path.join(configDir, "config.toml");
+}
+
+function buildKimiHookCommand(notifyPath) {
+  const cmd = typeof notifyPath === "string" ? notifyPath : "";
+  return `/usr/bin/env node ${quoteArg(cmd)} --source=kimi`;
+}
+
+async function upsertKimiHook({
+  configPath,
+  hookCommand,
+  events = DEFAULT_EVENTS,
+  timeout = DEFAULT_TIMEOUT,
+}) {
+  const existing = await readFileOrEmpty(configPath);
+  const normalizedEvents = normalizeEvents(events);
+  const nextBlock = buildManagedBlock({
+    hookCommand,
+    events: normalizedEvents,
+    timeout: normalizeTimeout(timeout),
+  });
+  const { content, changed } = replaceManagedBlock(existing, nextBlock);
+  if (!changed) return { changed: false, backupPath: null };
+  const backupPath = await writeWithBackup({ configPath, content });
+  return { changed: true, backupPath };
+}
+
+async function removeKimiHook({ configPath }) {
+  const existing = await readFileOrEmpty(configPath);
+  if (!existing) return { removed: false, skippedReason: "config-missing", backupPath: null };
+  const { content, changed } = stripManagedBlock(existing);
+  if (!changed) return { removed: false, skippedReason: "hook-missing", backupPath: null };
+  const backupPath = await writeWithBackup({ configPath, content });
+  return { removed: true, skippedReason: null, backupPath };
+}
+
+async function isKimiHookConfigured({
+  configPath,
+  hookCommand,
+  events = DEFAULT_EVENTS,
+  timeout = DEFAULT_TIMEOUT,
+}) {
+  const probe = await probeKimiHook({ configPath, hookCommand, events, timeout });
+  return probe.configured;
+}
+
+async function probeKimiHook({
+  configPath,
+  hookCommand,
+  events = DEFAULT_EVENTS,
+  timeout = DEFAULT_TIMEOUT,
+}) {
+  const existing = await readFileOrEmpty(configPath);
+  if (!existing) {
+    return { configured: false, anyPresent: false, drifted: false };
+  }
+  const block = extractManagedBlock(existing);
+  if (!block) {
+    return { configured: false, anyPresent: false, drifted: false };
+  }
+  const expected = buildManagedBlock({
+    hookCommand,
+    events: normalizeEvents(events),
+    timeout: normalizeTimeout(timeout),
+  });
+  return {
+    configured: block === expected,
+    anyPresent: true,
+    drifted: block !== expected,
+  };
+}
+
+function buildManagedBlock({ hookCommand, events, timeout }) {
+  const lines = [MANAGED_START];
+  for (const event of events) {
+    lines.push(
+      "[[hooks]]",
+      `event = ${tomlString(event)}`,
+      `command = ${tomlString(hookCommand)}`,
+      `timeout = ${timeout}`,
+    );
+    lines.push("");
+  }
+  lines.push(MANAGED_END);
+  return lines.join("\n");
+}
+
+function replaceManagedBlock(existing, nextBlock) {
+  const startIdx = existing.indexOf(MANAGED_START);
+  const endIdx = existing.indexOf(MANAGED_END);
+
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const blockEnd = endIdx + MANAGED_END.length;
+    const current = existing.slice(startIdx, blockEnd);
+    if (current === nextBlock) return { content: existing, changed: false };
+    const before = existing.slice(0, startIdx);
+    let after = existing.slice(blockEnd);
+    if (after.startsWith("\n")) after = after.slice(1);
+    const beforeTrimmed = before.replace(/\n+$/, "");
+    const prefix = beforeTrimmed.length > 0 ? `${beforeTrimmed}\n\n` : "";
+    const suffix = after.length > 0 ? `\n\n${after.replace(/^\n+/, "")}` : "\n";
+    return { content: `${prefix}${nextBlock}${suffix}`, changed: true };
+  }
+
+  const base = existing.replace(/\n+$/, "");
+  const prefix = base.length > 0 ? `${base}\n\n` : "";
+  return { content: `${prefix}${nextBlock}\n`, changed: true };
+}
+
+function stripManagedBlock(existing) {
+  const startIdx = existing.indexOf(MANAGED_START);
+  const endIdx = existing.indexOf(MANAGED_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+    return { content: existing, changed: false };
+  }
+  const blockEnd = endIdx + MANAGED_END.length;
+  const before = existing.slice(0, startIdx).replace(/\n+$/, "");
+  let after = existing.slice(blockEnd);
+  after = after.replace(/^\n+/, "");
+  if (before.length === 0 && after.length === 0) {
+    return { content: "", changed: true };
+  }
+  if (before.length === 0) return { content: `${after.endsWith("\n") ? after : `${after}\n`}`, changed: true };
+  if (after.length === 0) return { content: `${before}\n`, changed: true };
+  return { content: `${before}\n\n${after.endsWith("\n") ? after : `${after}\n`}`, changed: true };
+}
+
+function extractManagedBlock(existing) {
+  const startIdx = existing.indexOf(MANAGED_START);
+  const endIdx = existing.indexOf(MANAGED_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return null;
+  const blockEnd = endIdx + MANAGED_END.length;
+  return existing.slice(startIdx, blockEnd);
+}
+
+function normalizeEvents(raw) {
+  const values = Array.isArray(raw) ? raw : [raw];
+  const out = [];
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const normalized = value.trim();
+    if (!normalized || out.includes(normalized)) continue;
+    out.push(normalized);
+  }
+  return out.length > 0 ? out : DEFAULT_EVENTS.slice();
+}
+
+function normalizeTimeout(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_TIMEOUT;
+  return Math.floor(n);
+}
+
+function tomlString(value) {
+  const v = typeof value === "string" ? value : String(value ?? "");
+  return `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function quoteArg(value) {
+  const v = typeof value === "string" ? value : "";
+  if (!v) return '""';
+  if (/^[A-Za-z0-9_\-./:@]+$/.test(v)) return v;
+  return `"${v.replace(/"/g, '\\"')}"`;
+}
+
+async function readFileOrEmpty(filePath) {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if (err && err.code === "ENOENT") return "";
+    throw err;
+  }
+}
+
+async function writeWithBackup({ configPath, content }) {
+  await ensureDir(path.dirname(configPath));
+  let backupPath = null;
+  try {
+    const st = await fs.stat(configPath);
+    if (st && st.isFile()) {
+      backupPath = `${configPath}.bak.${new Date().toISOString().replace(/[:.]/g, "-")}`;
+      await fs.copyFile(configPath, backupPath);
+    }
+  } catch (_e) {
+    // no existing file
+  }
+  await fs.writeFile(configPath, content, "utf8");
+  return backupPath;
+}
+
+module.exports = {
+  DEFAULT_EVENTS,
+  DEFAULT_TIMEOUT,
+  MANAGED_START,
+  MANAGED_END,
+  resolveKimiConfigDir,
+  resolveKimiConfigPath,
+  buildKimiHookCommand,
+  upsertKimiHook,
+  removeKimiHook,
+  isKimiHookConfigured,
+  probeKimiHook,
+};

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -63,6 +63,25 @@ async function listGeminiSessionFiles(tmpDir) {
   return out;
 }
 
+async function listKimiSessionFiles(sessionsDir) {
+  const out = [];
+  const projects = await safeReadDir(sessionsDir);
+  for (const project of projects) {
+    if (!project.isDirectory()) continue;
+    const projectDir = path.join(sessionsDir, project.name);
+    const sessions = await safeReadDir(projectDir);
+    for (const session of sessions) {
+      if (!session.isDirectory()) continue;
+      const wirePath = path.join(projectDir, session.name, "wire.jsonl");
+      const st = await fs.stat(wirePath).catch(() => null);
+      if (!st || !st.isFile()) continue;
+      out.push(wirePath);
+    }
+  }
+  out.sort((a, b) => a.localeCompare(b));
+  return out;
+}
+
 async function listOpencodeMessageFiles(storageDir) {
   const out = [];
   const messageDir = path.join(storageDir, "message");
@@ -365,6 +384,110 @@ async function parseGeminiIncremental({
       lastIndex: result.lastIndex,
       lastTotals: result.lastTotals,
       lastModel: result.lastModel,
+      updatedAt: new Date().toISOString(),
+    };
+
+    filesProcessed += 1;
+    eventsAggregated += result.eventsAggregated;
+
+    if (cb) {
+      cb({
+        index: idx + 1,
+        total: totalFiles,
+        filePath,
+        filesProcessed,
+        eventsAggregated,
+        bucketsQueued: touchedBuckets.size,
+      });
+    }
+  }
+
+  const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
+  const projectBucketsQueued = projectEnabled
+    ? await enqueueTouchedProjectBuckets({ projectQueuePath, projectState, projectTouchedBuckets })
+    : 0;
+  hourlyState.updatedAt = new Date().toISOString();
+  cursors.hourly = hourlyState;
+  if (projectState) {
+    projectState.updatedAt = new Date().toISOString();
+    cursors.projectHourly = projectState;
+  }
+
+  return { filesProcessed, eventsAggregated, bucketsQueued, projectBucketsQueued };
+}
+
+async function parseKimiIncremental({
+  sessionFiles,
+  cursors,
+  queuePath,
+  projectQueuePath,
+  onProgress,
+  source,
+  publicRepoResolver,
+}) {
+  await ensureDir(path.dirname(queuePath));
+  let filesProcessed = 0;
+  let eventsAggregated = 0;
+
+  const cb = typeof onProgress === "function" ? onProgress : null;
+  const files = Array.isArray(sessionFiles) ? sessionFiles : [];
+  const totalFiles = files.length;
+  const hourlyState = normalizeHourlyState(cursors?.hourly);
+  const projectEnabled = typeof projectQueuePath === "string" && projectQueuePath.length > 0;
+  const projectState = projectEnabled ? normalizeProjectState(cursors?.projectHourly) : null;
+  const projectTouchedBuckets = projectEnabled ? new Set() : null;
+  const projectMetaCache = projectEnabled ? new Map() : null;
+  const publicRepoCache = projectEnabled ? new Map() : null;
+  const touchedBuckets = new Set();
+  const defaultSource = normalizeSourceInput(source) || "kimi";
+
+  if (!cursors.files || typeof cursors.files !== "object") {
+    cursors.files = {};
+  }
+
+  for (let idx = 0; idx < files.length; idx++) {
+    const entry = files[idx];
+    const filePath = typeof entry === "string" ? entry : entry?.path;
+    if (!filePath) continue;
+    const fileSource =
+      typeof entry === "string"
+        ? defaultSource
+        : normalizeSourceInput(entry?.source) || defaultSource;
+    const st = await fs.stat(filePath).catch(() => null);
+    if (!st || !st.isFile()) continue;
+
+    const key = filePath;
+    const prev = cursors.files[key] || null;
+    const inode = st.ino || 0;
+    const startOffset = prev && prev.inode === inode ? prev.offset || 0 : 0;
+
+    const projectContext = projectEnabled
+      ? await resolveProjectContextForFile({
+          filePath,
+          projectMetaCache,
+          publicRepoCache,
+          publicRepoResolver,
+          projectState,
+        })
+      : null;
+    const projectRef = projectContext?.projectRef || null;
+    const projectKey = projectContext?.projectKey || null;
+
+    const result = await parseKimiFile({
+      filePath,
+      startOffset,
+      hourlyState,
+      touchedBuckets,
+      source: fileSource,
+      projectState,
+      projectTouchedBuckets,
+      projectRef,
+      projectKey,
+    });
+
+    cursors.files[key] = {
+      inode,
+      offset: result.endOffset,
       updatedAt: new Date().toISOString(),
     };
 
@@ -796,6 +919,70 @@ async function parseClaudeFile({
     const bucketStart = toUtcHalfHourStart(tokenTimestamp);
     if (!bucketStart) continue;
 
+    const bucket = getHourlyBucket(hourlyState, source, model, bucketStart);
+    addTotals(bucket.totals, delta);
+    touchedBuckets.add(bucketKey(source, model, bucketStart));
+    if (projectKey && projectState && projectTouchedBuckets) {
+      const projectBucket = getProjectBucket(
+        projectState,
+        projectKey,
+        source,
+        bucketStart,
+        projectRef,
+      );
+      addTotals(projectBucket.totals, delta);
+      projectTouchedBuckets.add(projectBucketKey(projectKey, source, bucketStart));
+    }
+    eventsAggregated += 1;
+  }
+
+  rl.close();
+  stream.close?.();
+  return { endOffset, eventsAggregated };
+}
+
+async function parseKimiFile({
+  filePath,
+  startOffset,
+  hourlyState,
+  touchedBuckets,
+  source,
+  projectState,
+  projectTouchedBuckets,
+  projectRef,
+  projectKey,
+}) {
+  const st = await fs.stat(filePath).catch(() => null);
+  if (!st || !st.isFile()) return { endOffset: startOffset, eventsAggregated: 0 };
+
+  const endOffset = st.size;
+  if (startOffset >= endOffset) return { endOffset, eventsAggregated: 0 };
+
+  const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  let eventsAggregated = 0;
+  for await (const line of rl) {
+    if (!line || !line.includes("StatusUpdate")) continue;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch (_e) {
+      continue;
+    }
+    if (!obj || !obj.message || obj.message.type !== "StatusUpdate") continue;
+
+    const payload = obj.message.payload;
+    const delta = normalizeKimiUsage(payload?.token_usage);
+    if (!delta || isAllZeroUsage(delta)) continue;
+
+    const tsIso = kimiTimestampToIso(obj.timestamp);
+    if (!tsIso) continue;
+
+    const bucketStart = toUtcHalfHourStart(tsIso);
+    if (!bucketStart) continue;
+
+    const model = normalizeModelInput(payload?.model) || DEFAULT_MODEL;
     const bucket = getHourlyBucket(hourlyState, source, model, bucketStart);
     addTotals(bucket.totals, delta);
     touchedBuckets.add(bucketKey(source, model, bucketStart));
@@ -2058,6 +2245,32 @@ function normalizeGeminiTokens(tokens) {
   };
 }
 
+function normalizeKimiUsage(usage) {
+  if (!usage || typeof usage !== "object") return null;
+  const inputOther = toNonNegativeInt(usage.input_other);
+  const cacheCreation = toNonNegativeInt(usage.input_cache_creation);
+  const cacheRead = toNonNegativeInt(usage.input_cache_read);
+  const output = toNonNegativeInt(usage.output);
+  const inputTokens = inputOther + cacheCreation;
+  const total = inputTokens + cacheRead + output;
+  return {
+    input_tokens: inputTokens,
+    cached_input_tokens: cacheRead,
+    output_tokens: output,
+    reasoning_output_tokens: 0,
+    total_tokens: total,
+  };
+}
+
+function kimiTimestampToIso(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const ms = n < 1e12 ? Math.floor(n * 1000) : Math.floor(n);
+  const date = new Date(ms);
+  const iso = date.toISOString();
+  return iso;
+}
+
 function normalizeOpencodeTokens(tokens) {
   if (!tokens || typeof tokens !== "object") return null;
   const input = toNonNegativeInt(tokens.input);
@@ -2293,10 +2506,12 @@ module.exports = {
   listRolloutFiles,
   listClaudeProjectFiles,
   listGeminiSessionFiles,
+  listKimiSessionFiles,
   listOpencodeMessageFiles,
   parseRolloutIncremental,
   parseClaudeIncremental,
   parseGeminiIncremental,
+  parseKimiIncremental,
   parseOpencodeIncremental,
   normalizeHourlyState,
   getHourlyBucket,

--- a/test/client-logos-kimi.test.js
+++ b/test/client-logos-kimi.test.js
@@ -1,0 +1,38 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const LOGOS_PATH = path.join(
+  __dirname,
+  "../dashboard/src/ui/matrix-a/components/ClientLogos.jsx",
+);
+
+test("ClientLogos registers a Kimi entry in CLIENTS", () => {
+  const src = fs.readFileSync(LOGOS_PATH, "utf8");
+  assert.match(
+    src,
+    /\{\s*id:\s*"kimi"\s*,\s*name:\s*"Kimi"\s*,\s*Icon:\s*KimiIcon\s*\}/,
+    "expected CLIENTS to contain a kimi entry wired to KimiIcon",
+  );
+});
+
+test("ClientLogos exports a KimiIcon component", () => {
+  const src = fs.readFileSync(LOGOS_PATH, "utf8");
+  assert.match(
+    src,
+    /export\s+function\s+KimiIcon\s*\(/,
+    "expected a named KimiIcon export",
+  );
+  assert.match(src, /<svg[\s\S]*<\/svg>/, "KimiIcon must render an inline svg");
+});
+
+test("CLIENTS source ids stay kebab/lowercase to match backend source field", () => {
+  const src = fs.readFileSync(LOGOS_PATH, "utf8");
+  const ids = Array.from(src.matchAll(/\{\s*id:\s*"([^"]+)"/g)).map((m) => m[1]);
+  assert.ok(ids.length >= 6, "should have at least 6 CLIENTS entries");
+  for (const id of ids) {
+    assert.match(id, /^[a-z][a-z0-9-]*$/, `id "${id}" should be lowercase kebab-case`);
+  }
+  assert.ok(ids.includes("kimi"), "expected kimi among CLIENTS ids");
+});

--- a/test/kimi-config.test.js
+++ b/test/kimi-config.test.js
@@ -1,0 +1,181 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const {
+  MANAGED_START,
+  MANAGED_END,
+  DEFAULT_EVENTS,
+  buildKimiHookCommand,
+  resolveKimiConfigDir,
+  resolveKimiConfigPath,
+  upsertKimiHook,
+  removeKimiHook,
+  isKimiHookConfigured,
+  probeKimiHook,
+} = require("../src/lib/kimi-config");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-kimi-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+test("resolveKimiConfigDir honors KIMI_HOME and defaults to ~/.kimi", () => {
+  assert.equal(
+    resolveKimiConfigDir({ home: "/home/alice", env: {} }),
+    "/home/alice/.kimi",
+  );
+  assert.equal(
+    resolveKimiConfigDir({ home: "/home/alice", env: { KIMI_HOME: "/custom/kimi" } }),
+    "/custom/kimi",
+  );
+});
+
+test("buildKimiHookCommand produces a quoted node invocation", () => {
+  const cmd = buildKimiHookCommand("/home/alice/.vibeusage/bin/notify.cjs");
+  assert.match(cmd, /^\/usr\/bin\/env node /);
+  assert.ok(cmd.endsWith(" --source=kimi"));
+});
+
+test("upsertKimiHook appends a managed block to an existing config.toml", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "config.toml");
+    const hookCommand = buildKimiHookCommand("/tmp/notify.cjs");
+    await fs.writeFile(configPath, 'default_model = "kimi-k2"\n\n[services]\n', "utf8");
+
+    const result = await upsertKimiHook({ configPath, hookCommand });
+    assert.equal(result.changed, true);
+    assert.ok(result.backupPath);
+
+    const content = await fs.readFile(configPath, "utf8");
+    assert.ok(content.includes(MANAGED_START));
+    assert.ok(content.includes(MANAGED_END));
+    for (const event of DEFAULT_EVENTS) {
+      assert.ok(content.includes(`event = "${event}"`));
+    }
+    assert.ok(content.includes(hookCommand));
+    assert.ok(content.includes('default_model = "kimi-k2"'));
+  });
+});
+
+test("upsertKimiHook is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "config.toml");
+    const hookCommand = buildKimiHookCommand("/tmp/notify.cjs");
+    await fs.writeFile(configPath, "[services]\n", "utf8");
+
+    const first = await upsertKimiHook({ configPath, hookCommand });
+    assert.equal(first.changed, true);
+    const after = await fs.readFile(configPath, "utf8");
+
+    const second = await upsertKimiHook({ configPath, hookCommand });
+    assert.equal(second.changed, false);
+    const again = await fs.readFile(configPath, "utf8");
+    assert.equal(again, after);
+  });
+});
+
+test("upsertKimiHook replaces a drifted block rather than duplicating it", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "config.toml");
+    const oldCmd = "/usr/bin/env node /old/notify.cjs --source=kimi";
+    const newCmd = "/usr/bin/env node /new/notify.cjs --source=kimi";
+    const stale = [
+      "[services]",
+      "",
+      MANAGED_START,
+      "[[hooks]]",
+      'event = "Stop"',
+      `command = "${oldCmd}"`,
+      "timeout = 30",
+      "",
+      MANAGED_END,
+      "",
+    ].join("\n");
+    await fs.writeFile(configPath, stale, "utf8");
+
+    const result = await upsertKimiHook({ configPath, hookCommand: newCmd });
+    assert.equal(result.changed, true);
+    const content = await fs.readFile(configPath, "utf8");
+    assert.ok(content.includes(newCmd));
+    assert.ok(!content.includes(oldCmd));
+    assert.equal(content.indexOf(MANAGED_START), content.lastIndexOf(MANAGED_START));
+  });
+});
+
+test("probeKimiHook reports configured only when block matches exactly", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "config.toml");
+    const hookCommand = buildKimiHookCommand("/tmp/notify.cjs");
+    await fs.writeFile(configPath, "[services]\n", "utf8");
+
+    let probe = await probeKimiHook({ configPath, hookCommand });
+    assert.equal(probe.configured, false);
+    assert.equal(probe.anyPresent, false);
+
+    await upsertKimiHook({ configPath, hookCommand });
+    probe = await probeKimiHook({ configPath, hookCommand });
+    assert.equal(probe.configured, true);
+    assert.equal(probe.anyPresent, true);
+
+    const configuredShortcut = await isKimiHookConfigured({ configPath, hookCommand });
+    assert.equal(configuredShortcut, true);
+
+    const otherCmd = buildKimiHookCommand("/other/notify.cjs");
+    probe = await probeKimiHook({ configPath, hookCommand: otherCmd });
+    assert.equal(probe.configured, false);
+    assert.equal(probe.drifted, true);
+  });
+});
+
+test("removeKimiHook strips the managed block and preserves surrounding config", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "config.toml");
+    const hookCommand = buildKimiHookCommand("/tmp/notify.cjs");
+    const original = 'default_model = "kimi-k2"\n\n[services]\n';
+    await fs.writeFile(configPath, original, "utf8");
+
+    await upsertKimiHook({ configPath, hookCommand });
+    const withBlock = await fs.readFile(configPath, "utf8");
+    assert.ok(withBlock.includes(MANAGED_START));
+
+    const result = await removeKimiHook({ configPath });
+    assert.equal(result.removed, true);
+    const stripped = await fs.readFile(configPath, "utf8");
+    assert.ok(!stripped.includes(MANAGED_START));
+    assert.ok(stripped.includes('default_model = "kimi-k2"'));
+    assert.ok(stripped.includes("[services]"));
+  });
+});
+
+test("removeKimiHook is a no-op when no block is present", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "config.toml");
+    await fs.writeFile(configPath, "[services]\n", "utf8");
+    const result = await removeKimiHook({ configPath });
+    assert.equal(result.removed, false);
+    assert.equal(result.skippedReason, "hook-missing");
+  });
+});
+
+test("removeKimiHook reports config-missing when file absent", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "missing.toml");
+    const result = await removeKimiHook({ configPath });
+    assert.equal(result.removed, false);
+    assert.equal(result.skippedReason, "config-missing");
+  });
+});
+
+test("resolveKimiConfigPath joins config.toml under the dir", () => {
+  assert.equal(
+    resolveKimiConfigPath({ configDir: "/home/alice/.kimi" }),
+    "/home/alice/.kimi/config.toml",
+  );
+});

--- a/test/rollout-kimi.test.js
+++ b/test/rollout-kimi.test.js
@@ -1,0 +1,180 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { listKimiSessionFiles, parseKimiIncremental } = require("../src/lib/rollout");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-kimi-rollout-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function statusUpdateLine({ ts, tokenUsage, messageId = "chatcmpl-test" }) {
+  return JSON.stringify({
+    timestamp: ts,
+    message: {
+      type: "StatusUpdate",
+      payload: {
+        context_usage: 0.1,
+        token_usage: tokenUsage,
+        message_id: messageId,
+      },
+    },
+  });
+}
+
+async function readJsonLines(filePath) {
+  const text = await fs.readFile(filePath, "utf8").catch(() => "");
+  if (!text.trim()) return [];
+  return text.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+}
+
+test("listKimiSessionFiles walks <projectHash>/<sessionId>/wire.jsonl entries", async () => {
+  await withTempDir(async (dir) => {
+    const sessionsDir = path.join(dir, "sessions");
+    const projectDir = path.join(sessionsDir, "projecthash");
+    const sessionA = path.join(projectDir, "aaaa");
+    const sessionB = path.join(projectDir, "bbbb");
+    await fs.mkdir(sessionA, { recursive: true });
+    await fs.mkdir(sessionB, { recursive: true });
+    await fs.writeFile(path.join(sessionA, "wire.jsonl"), "");
+    await fs.writeFile(path.join(sessionB, "wire.jsonl"), "");
+    await fs.writeFile(path.join(sessionA, "context.jsonl"), "");
+
+    const files = await listKimiSessionFiles(sessionsDir);
+    assert.equal(files.length, 2);
+    assert.ok(files.every((p) => p.endsWith("/wire.jsonl")));
+    assert.ok(files.includes(path.join(sessionA, "wire.jsonl")));
+  });
+});
+
+test("listKimiSessionFiles returns empty array when sessions dir is missing", async () => {
+  await withTempDir(async (dir) => {
+    const files = await listKimiSessionFiles(path.join(dir, "missing"));
+    assert.deepEqual(files, []);
+  });
+});
+
+test("parseKimiIncremental aggregates StatusUpdate token_usage into hourly buckets", async () => {
+  await withTempDir(async (dir) => {
+    const sessionsDir = path.join(dir, "sessions");
+    const sessionDir = path.join(sessionsDir, "proj", "sess");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const wirePath = path.join(sessionDir, "wire.jsonl");
+    // 2026-04-01T00:10:00Z
+    const ts = 1775001000;
+    const lines = [
+      statusUpdateLine({
+        ts,
+        tokenUsage: {
+          input_other: 100,
+          input_cache_read: 50,
+          input_cache_creation: 10,
+          output: 20,
+        },
+      }),
+      statusUpdateLine({
+        ts: ts + 60,
+        tokenUsage: {
+          input_other: 5,
+          input_cache_read: 0,
+          input_cache_creation: 0,
+          output: 7,
+        },
+        messageId: "chatcmpl-2",
+      }),
+      // Non-StatusUpdate line must be ignored
+      JSON.stringify({ timestamp: ts + 1, message: { type: "TurnBegin", payload: {} } }),
+    ];
+    await fs.writeFile(wirePath, `${lines.join("\n")}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const result = await parseKimiIncremental({
+      sessionFiles: [wirePath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.filesProcessed, 1);
+    assert.equal(result.eventsAggregated, 2);
+    assert.equal(result.bucketsQueued, 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    const bucket = queued[0];
+    assert.equal(bucket.source, "kimi");
+    assert.equal(bucket.model, "unknown");
+    // input_tokens = input_other + input_cache_creation
+    assert.equal(bucket.input_tokens, 100 + 10 + 5 + 0);
+    assert.equal(bucket.cached_input_tokens, 50);
+    assert.equal(bucket.output_tokens, 20 + 7);
+    assert.equal(bucket.reasoning_output_tokens, 0);
+    // total_tokens = input_tokens + cached + output (= 115 + 50 + 27)
+    assert.equal(bucket.total_tokens, 115 + 50 + 27);
+  });
+});
+
+test("parseKimiIncremental resumes from cursor without double counting", async () => {
+  await withTempDir(async (dir) => {
+    const sessionsDir = path.join(dir, "sessions");
+    const sessionDir = path.join(sessionsDir, "proj", "sess");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const wirePath = path.join(sessionDir, "wire.jsonl");
+    const firstLine = statusUpdateLine({
+      ts: 1775001000,
+      tokenUsage: { input_other: 10, input_cache_read: 0, input_cache_creation: 0, output: 4 },
+    });
+    await fs.writeFile(wirePath, `${firstLine}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    await parseKimiIncremental({ sessionFiles: [wirePath], cursors, queuePath });
+
+    const secondLine = statusUpdateLine({
+      ts: 1775002000,
+      tokenUsage: { input_other: 2, input_cache_read: 1, input_cache_creation: 0, output: 3 },
+      messageId: "chatcmpl-2",
+    });
+    await fs.appendFile(wirePath, `${secondLine}\n`, "utf8");
+
+    const result = await parseKimiIncremental({ sessionFiles: [wirePath], cursors, queuePath });
+    assert.equal(result.eventsAggregated, 1);
+
+    const queued = await readJsonLines(queuePath);
+    // Two queued aggregation events (first run + incremental run) — both for same bucket
+    assert.ok(queued.length >= 2);
+    const totalInput = queued.reduce((sum, ev) => sum + Number(ev.input_tokens || 0), 0);
+    assert.equal(totalInput, 10 + 2);
+  });
+});
+
+test("parseKimiIncremental ignores lines without token_usage", async () => {
+  await withTempDir(async (dir) => {
+    const sessionsDir = path.join(dir, "sessions");
+    const sessionDir = path.join(sessionsDir, "proj", "sess");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const wirePath = path.join(sessionDir, "wire.jsonl");
+    const lines = [
+      JSON.stringify({ timestamp: 1775001000, message: { type: "TurnBegin", payload: {} } }),
+      JSON.stringify({ timestamp: 1775001001, message: { type: "StatusUpdate", payload: {} } }),
+      "not-json",
+      statusUpdateLine({
+        ts: 1775001002,
+        tokenUsage: { input_other: 0, input_cache_read: 0, input_cache_creation: 0, output: 0 },
+      }),
+    ];
+    await fs.writeFile(wirePath, `${lines.join("\n")}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const result = await parseKimiIncremental({ sessionFiles: [wirePath], cursors, queuePath });
+    assert.equal(result.eventsAggregated, 0);
+    assert.equal(result.bucketsQueued, 0);
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Adds first-class support for Kimi CLI in vibeusage: writes SessionEnd/Stop hooks into `~/.kimi/config.toml`, parses `wire.jsonl` `StatusUpdate.token_usage` into the existing hourly-bucket pipeline as `source=kimi`, and surfaces a Kimi logo in the dashboard client registry. Bumps version to 0.4.0 so the release workflow publishes on merge.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- New `src/lib/kimi-config.js` with idempotent TOML managed-block upsert/remove/probe helpers (no TOML dependency required)
- New `src/lib/integrations/kimi.js` descriptor (probe/install/uninstall) registered in `src/lib/integrations/index.js`; context injected via `src/lib/integrations/context.js`
- `src/lib/rollout.js` gains `listKimiSessionFiles` + `parseKimiIncremental` + `parseKimiFile` + `normalizeKimiUsage`
- `src/commands/sync.js` fans Kimi session scan into the existing sync loop; `src/commands/init.js` updates the welcome banner and whitelists `--source=kimi` in the notify handler
- Dashboard `KimiIcon` + CLIENTS entry in `dashboard/src/ui/matrix-a/components/ClientLogos.jsx`
- `package.json` 0.3.5 → 0.4.0; CHANGELOG entry; follow-up cleanup removes the redundant `isFile` preflight in `kimi.uninstall`

## Affected Modules / Contracts

- **Modules touched:** `src/lib/integrations/*` (kimi, context, index), `src/lib/kimi-config.js`, `src/lib/rollout.js`, `src/commands/init.js`, `src/commands/sync.js`, `dashboard/src/ui/matrix-a/components/ClientLogos.jsx`
- **Dependencies / contracts touched:** None. Backend `vibeusage_tracker_hourly.source` is free-form `text` with no CHECK constraint (verified via `insforge db query`); no edge-function or schema change required.
- **Repo sitemap evidence:** `not required` — additive integration inside existing module boundaries

## Validation

### Automated

- `npm run ci:local` green locally: 761 node tests + 6 architecture guardrails + dashboard build + copy/ui-hardcode/guardrails validators
- New unit tests: `test/kimi-config.test.js` (10 cases), `test/rollout-kimi.test.js` (5 cases), `test/client-logos-kimi.test.js` (3 cases)

### Manual / smoke

- Real Kimi install on developer machine: managed block written into `~/.kimi/config.toml`, hook fired on SessionEnd, `notify.cjs --source=kimi` executed, `sync --auto` ran
- Backend smoke via `insforge db query`: `SELECT source, COUNT(*) FROM vibeusage_tracker_hourly GROUP BY source` confirms 1 row with `source=kimi, model=unknown` — end-to-end CLI → ingest → DB path verified

### Uncovered scope

- Kimi StatusUpdate has no model field so buckets land as `model=unknown`; parser will pick up `payload.model` automatically if Moonshot adds it later
- No dashboard visual regression suite covers the CLIENTS icon grid

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- **Access rules:**
- **Exposed fields:**
- **Avatar / image policy:**
- **Regression coverage:**

## Reviewer Context (optional)

- **Review focus:** Kimi hook managed-block serialization and wire.jsonl parser behavior
- **Delta since last review:** commit ff74856d drops the redundant isFile preflight in kimi.uninstall so the previously-unreachable skipped branch becomes the legitimate config-missing path
- **Depends on:** None
- **Known gaps / follow-ups:** None beyond Uncovered scope

## Screenshots / Logs (optional)

-