### PR TITLE
ci: switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,15 +94,21 @@ jobs:
         (needs.changes.outputs.functions == 'false' && needs.mcp-skip.result == 'success')
       )
     timeout-minutes: 10
+    # Required for npm Trusted Publishing (OIDC).
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install --global npm@latest
       - name: Install dependencies
         run: npm ci
       - name: Read package metadata
@@ -122,8 +128,6 @@ jobs:
           fi
       - name: Publish to npm
         if: steps.npm.outputs.exists != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish
       - name: Skip publish (version exists)
         if: steps.npm.outputs.exists == 'true'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.4.0",
   "description": "Codex CLI token usage tracker (macOS-first, notify-driven).",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/victorGPT/vibeusage.git"
+  },
+  "bugs": {
+    "url": "https://github.com/victorGPT/vibeusage/issues"
+  },
+  "homepage": "https://github.com/victorGPT/vibeusage#readme",
   "bin": {
     "tracker": "bin/tracker.js",
     "vibeusage": "bin/tracker.js",


### PR DESCRIPTION
# What does this PR do?

- Wires the npm-publish GitHub Actions job to publish via OpenID Connect (Trusted Publisher) instead of a long-lived NPM_TOKEN. Mirrors the Trusted Publisher configuration already set on npmjs.com for the vibeusage package (publisher=GitHub Actions, org=victorGPT, repo=vibeusage, workflow=release.yml, no environment). Fixes the npm 404 / auth failure that blocked 0.4.0 from publishing.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI / workflow
- [ ] Risk / contract change

## Changes Made

- .github/workflows/release.yml npm-publish job grants id-token:write + contents:read, bumps node-version 18 -> 22 (npm CLI >= 11.5.1 required for Trusted Publishing), adds npm install --global npm@latest as a belt-and-suspenders step, and removes NODE_AUTH_TOKEN from the publish step
- package.json adds repository / bugs / homepage pointing at github.com/victorGPT/vibeusage so the npm registry can match the package origin against the trusted publisher config

## Affected Modules / Contracts

- Modules touched: .github/workflows/release.yml, package.json
- Dependencies / contracts touched: Release pipeline authentication only. Runtime code unchanged; tarball contents unchanged beyond the new metadata fields.
- Repo sitemap evidence: not required (CI/pipeline-only change confined to existing release workflow)

## Validation

### Automated

- yaml structural diff reviewed manually; no changes beyond the documented additions
- package metadata validated locally: repository/bugs/homepage fields parse via node -e check

### Manual / smoke

- Trusted Publisher configured on npmjs.com: GitHub Actions -> victorGPT/vibeusage -> release.yml (no environment). Package publishing-access switched to Require 2FA and disallow tokens so the old NPM_TOKEN path is closed.
- Post-merge expectation: push to main retriggers Release workflow; npm-publish job mints an OIDC token and publishes vibeusage@0.4.0.

### Uncovered scope

- NPM_TOKEN GitHub Secret can be deleted after the first successful OIDC publish; not removed in this PR to keep the rollback path open.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: yaml permissions block correctness and node-version bump; confirm Trusted Publisher workflow filename matches (release.yml).
- Delta since last review: n/a (new PR)
- Depends on: Trusted Publisher record on npmjs.com (already configured by maintainer)
- Known gaps / follow-ups: remove NPM_TOKEN secret from repo after first successful OIDC publish

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch npm publish to Trusted Publishing (OIDC) in release workflow
> - Adds `id-token: write` and `contents: read` permissions to the release job so the workflow can authenticate to npm via OIDC instead of a stored `NODE_AUTH_TOKEN` secret.
> - Upgrades Node.js from 18 to 22 and adds a step to install the latest npm before publishing.
> - Adds `repository`, `bugs`, and `homepage` fields to [package.json](https://github.com/victorGPT/vibeusage/pull/145/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63498bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->