### PR TITLE
ci: use npx for npm publish under Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,8 +107,6 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
-      - name: Upgrade npm for Trusted Publishing
-        run: npm install --global npm@latest
       - name: Install dependencies
         run: npm ci
       - name: Read package metadata
@@ -128,7 +126,9 @@ jobs:
           fi
       - name: Publish to npm
         if: steps.npm.outputs.exists != 'true'
-        run: npm publish
+        # Use npx to invoke the latest npm CLI directly (Trusted Publishing requires
+        # npm >= 11.5.1; global install corrupts bundled node_modules on self-upgrade).
+        run: npx --yes npm@latest publish
       - name: Skip publish (version exists)
         if: steps.npm.outputs.exists == 'true'
         run: echo "Version already published; skipping."


### PR DESCRIPTION
# What does this PR do?

- Replaces the self-destructive `npm install --global npm@latest` step with `npx --yes npm@latest publish`. The previous run (PR #145) failed because the global install corrupted the bundled node_modules on the GitHub runner (Cannot find module 'promise-retry'), blocking 0.4.0 publish again. `npx` pulls a Trusted-Publishing-capable npm CLI without mutating the system install.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI / workflow
- [ ] Risk / contract change

## Changes Made

- .github/workflows/release.yml: drops the Upgrade npm step; changes the publish step to `npx --yes npm@latest publish`. Permissions block, node-version 22, and removed NODE_AUTH_TOKEN from PR #145 are preserved.

## Affected Modules / Contracts

- Modules touched: .github/workflows/release.yml
- Dependencies / contracts touched: none (CI only)
- Repo sitemap evidence: not required (CI-only follow-up to PR #145)

## Validation

### Automated

- yaml structural diff reviewed; single step replaced

### Manual / smoke

- Failure log from run 24824456737 confirmed root cause: npm self-upgrade on the runner left its own deps unresolvable (MODULE_NOT_FOUND promise-retry at install.js:rebuild.js)
- npx approach is documented as the safe path to run a newer npm for OIDC publishing without touching bundled node_modules

### Uncovered scope

- If npx download itself is blocked by registry outage, publish will still fail; mitigated by existing retry on next push

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: the two-line yaml delta
- Delta since last review: follow-up to PR #145
- Depends on: PR #145 already merged (Trusted Publisher + permissions block)
- Known gaps / follow-ups: delete legacy NPM_TOKEN secret after successful OIDC publish

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `npx` to run `npm publish` in the release workflow
> Removes the global `npm install --global npm@latest` step and replaces `npm publish` with `npx --yes npm@latest publish` in [release.yml](.github/workflows/release.yml). This ensures the latest npm version is used at publish time without modifying the global environment, which is required for compatibility with Trusted Publishing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc45672.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->