### PR TITLE
chore(ci): bump workflow Node from 18 to 20 (EOL cleanup)

### DIFF
--- a/.github/workflows/deploy-preflight.yml
+++ b/.github/workflows/deploy-preflight.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
# What does this PR do?

- Moves three remaining Node 18 workflow jobs (deploy-preflight, guardrails, release preflight) onto Node 20. Node 18 hit EOL in April 2025; keeping it on the hosted runners is accumulated tech debt that will surface the day GitHub drops the toolchain image.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI / workflow
- [ ] Risk / contract change

## Changes Made

- .github/workflows/deploy-preflight.yml: node-version "18" -> "20"
- .github/workflows/guardrails.yml: node-version "18" -> "20"
- .github/workflows/release.yml preflight job: node-version "18" -> "20"

## Affected Modules / Contracts

- Modules touched: three workflow yaml files
- Dependencies / contracts touched: none (CI toolchain version only). package.json engines intentionally stays at "20.x" to avoid breaking any downstream user still on Node 18. release npm-publish job intentionally stays on Node 22 (Trusted Publishing requires npm >= 11.5.1).
- Repo sitemap evidence: not required (CI runtime bump)

## Validation

### Automated

- PR CI will exercise the bumped runners end to end; ci.yml and release ci-gate have been running under Node 20 successfully for many releases already, so this is aligning stragglers to a validated target.

### Manual / smoke

- Local npm ci + npm test pass under Node 20 on developer machine (same as existing ci-gate config).

### Uncovered scope

- Downstream Node 18 users are unaffected (engines unchanged); their install-time experience is the same.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: three 1-line yaml bumps; confirm the exception list (engines, release npm-publish) still makes sense to you.
- Delta since last review: n/a
- Depends on: none
- Known gaps / follow-ups: when Node 20 hits EOL (scheduled 2026-04), same-shape follow-up to 22.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump CI workflow Node.js version from 18 to 20
> Updates `actions/setup-node` to use Node.js 20 in the `deploy-preflight`, `guardrails`, and `release` workflows, replacing the EOL Node.js 18 runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f514f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->