### PR TITLE
feat(dashboard): surface Hermes agent in client logos and landing copy

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -22,7 +22,7 @@ landing.handle.special,landing,LandingPage,LandingPage,handle_special,"VOLT",,ac
 landing.hero.title_primary,landing,LandingPage,LandingPage,hero_title_primary,"MORE_TOKENS.",,active
 landing.hero.title_secondary,landing,LandingPage,LandingPage,hero_title_secondary,"MORE_VIBE.",,active
 landing.hero.tagline,landing,LandingPage,LandingPage,hero_tagline,"AI AGENT TOKEN TRACKER",,active
-landing.hero.subtagline,landing,LandingPage,LandingPage,hero_subtagline,"Track Codex, Claude Code, OpenCode, Gemini, Kimi, and OpenClaw with minimal data collection and auditable metrics.",,active
+landing.hero.subtagline,landing,LandingPage,LandingPage,hero_subtagline,"Track Codex, Claude Code, OpenCode, Gemini, Kimi, Hermes, and OpenClaw with minimal data collection and auditable metrics.",,active
 landing.screenshot.alt,landing,LandingPage,LandingPage,screenshot_alt,"VibeUsage dashboard screenshot",,active
 landing.screenshot.title,landing,LandingPage,LandingPage,screenshot_title,"DASHBOARD PREVIEW",,active
 landing.nav.login,landing,LandingPage,LandingPage,nav_login,"LOGIN",,active
@@ -30,7 +30,7 @@ landing.nav.signup,landing,LandingPage,LandingPage,nav_signup,"SIGN UP",,active
 landing.nav.login_signup,landing,LandingPage,LandingPage,nav_login_signup,"SIGN IN / SIGN UP",,active
 landing.seo.title,landing,LandingPage,LandingPage,seo_title,"Secure Token Usage Tracking for AI Agent Clients",,active
 landing.features.title,landing,LandingPage,LandingPage,features_title,"FEATURE BRIEF",,active
-landing.seo.summary,landing,LandingPage,LandingPage,seo_summary,"VibeUsage tracks token usage across AI agent clients (Codex, Claude Code, OpenCode, Gemini, Kimi, OpenClaw) with minimal data collection and auditable metrics.",,active
+landing.seo.summary,landing,LandingPage,LandingPage,seo_summary,"VibeUsage tracks token usage across AI agent clients (Codex, Claude Code, OpenCode, Gemini, Kimi, Hermes, OpenClaw) with minimal data collection and auditable metrics.",,active
 landing.install.title,landing,LandingPage,LandingPage,install_title,"INSTALL IN ONE COMMAND",,active
 landing.install.prompt,landing,LandingPage,LandingPage,install_prompt,"Run this in your terminal:",,active
 landing.install.command,landing,LandingPage,LandingPage,install_command,"npx --yes vibeusage init",,active
@@ -60,7 +60,7 @@ share.meta.twitter_card,share,SharePage,Meta,twitter_card,"summary_large_image",
 landing.seo.point1,landing,LandingPage,LandingPage,seo_point_1,"Auto-track AI CLI token usage with zero manual steps.",,active
 landing.seo.point2,landing,LandingPage,LandingPage,seo_point_2,"Matrix-style interface that highlights the signals you care about.",,active
 landing.seo.point3,landing,LandingPage,LandingPage,seo_point_3,"Universal AI CLI leaderboard to compare usage and rank.",,active
-landing.seo.roadmap,landing,LandingPage,LandingPage,seo_roadmap,"Native support for Codex, Claude Code, Gemini, and Kimi CLI.",,active
+landing.seo.roadmap,landing,LandingPage,LandingPage,seo_roadmap,"Native support for Codex, Claude Code, Gemini, Kimi, and Hermes CLI.",,active
 landing.signal.identity_probe,landing,LandingPage,SignalBox,title,"Identity_Probe",,active
 landing.signal.live_sniffer,landing,LandingPage,SignalBox,title,"LIVE_SNIFFER",,active
 landing.handle.label,landing,LandingPage,LandingPage,handle_label,"Set_Handle",,active

--- a/dashboard/src/ui/matrix-a/components/ClientLogos.jsx
+++ b/dashboard/src/ui/matrix-a/components/ClientLogos.jsx
@@ -119,12 +119,32 @@ export function KimiIcon({ className = "w-5 h-5" }) {
   );
 }
 
+/**
+ * Hermes Logo (winged disc + H glyph)
+ * Hermes the messenger: winged motif flanking a central disc
+ */
+export function HermesIcon({ className = "w-5 h-5" }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      {/* Left wing */}
+      <path d="M3 8c2-2 4.5-2 7-0.5C8 9 5.5 10 3 8z"/>
+      {/* Right wing */}
+      <path d="M21 8c-2-2-4.5-2-7-0.5C16 9 18.5 10 21 8z"/>
+      {/* Central disc */}
+      <circle cx="12" cy="13" r="4.2"/>
+      {/* H glyph */}
+      <path fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" d="M10.3 11.3v3.4M13.7 11.3v3.4M10.3 13h3.4"/>
+    </svg>
+  );
+}
+
 // Client logo data
 export const CLIENTS = [
   { id: "codex", name: "Codex", Icon: OpenAIIcon },
   { id: "claude", name: "Claude Code", Icon: ClaudeIcon },
   { id: "gemini", name: "Gemini", Icon: GeminiIcon },
   { id: "kimi", name: "Kimi", Icon: KimiIcon },
+  { id: "hermes", name: "Hermes", Icon: HermesIcon },
   { id: "opencode", name: "OpenCode", Icon: OpenCodeIcon },
   { id: "openclaw", name: "OpenClaw", Icon: OpenClawIcon },
 ];

--- a/test/client-logos-kimi.test.js
+++ b/test/client-logos-kimi.test.js
@@ -30,9 +30,20 @@ test("ClientLogos exports a KimiIcon component", () => {
 test("CLIENTS source ids stay kebab/lowercase to match backend source field", () => {
   const src = fs.readFileSync(LOGOS_PATH, "utf8");
   const ids = Array.from(src.matchAll(/\{\s*id:\s*"([^"]+)"/g)).map((m) => m[1]);
-  assert.ok(ids.length >= 6, "should have at least 6 CLIENTS entries");
+  assert.ok(ids.length >= 7, "should have at least 7 CLIENTS entries");
   for (const id of ids) {
     assert.match(id, /^[a-z][a-z0-9-]*$/, `id "${id}" should be lowercase kebab-case`);
   }
   assert.ok(ids.includes("kimi"), "expected kimi among CLIENTS ids");
+  assert.ok(ids.includes("hermes"), "expected hermes among CLIENTS ids");
+});
+
+test("ClientLogos registers a Hermes entry in CLIENTS", () => {
+  const src = fs.readFileSync(LOGOS_PATH, "utf8");
+  assert.match(
+    src,
+    /\{\s*id:\s*"hermes"\s*,\s*name:\s*"Hermes"\s*,\s*Icon:\s*HermesIcon\s*\}/,
+    "expected CLIENTS to contain a hermes entry wired to HermesIcon",
+  );
+  assert.match(src, /export\s+function\s+HermesIcon\s*\(/, "expected HermesIcon export");
 });


### PR DESCRIPTION
# What does this PR do?

- Lands Hermes Agent on the dashboard surfaces that the backend integration has been quietly supporting for a while. Adds a HermesIcon to the CLIENTS registry consumed by ClientLogoRow and updates the three landing-copy strings that enumerate supported clients so new visitors see Hermes alongside Codex / Claude Code / Gemini / Kimi / OpenCode / OpenClaw.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- dashboard/src/ui/matrix-a/components/ClientLogos.jsx: add HermesIcon (winged disc + H glyph) following the existing single-color SVG style; register CLIENTS entry id "hermes" placed between kimi and opencode.
- dashboard/src/content/copy.csv: append Hermes in landing.hero.subtagline, landing.seo.summary, and landing.seo.roadmap. Oxford comma preserved.
- test/client-logos-kimi.test.js: extend CLIENTS id invariant to require >= 7 entries and hermes id; add a dedicated Hermes registration test; keep Kimi assertions.

## Affected Modules / Contracts

- Modules touched: dashboard/src/ui/matrix-a/components/ClientLogos.jsx, dashboard/src/content/copy.csv, test/client-logos-kimi.test.js.
- Dependencies / contracts touched: none. Backend integration (src/lib/integrations/hermes.js, hermes-config.js, hermes-usage-ledger.js, vibeusage_tracker_hourly) is already live; this PR is dashboard-side surfacing only.
- Repo sitemap evidence: not required (additive copy + icon inside existing module boundaries).

## Validation

### Automated

- node --test test/client-logos-kimi.test.js -> 4/4 pass (kimi + hermes entries + id invariant + icon export).
- npm run validate:copy -> Copy registry ok.

### Manual / smoke

- ClientLogoRow iterates the CLIENTS array in-order, so Hermes renders automatically on the landing page without any JSX call-site change.
- Icon verified to follow the same currentColor + w-5 h-5 sizing convention as siblings so it inherits text-ink-primary coloring in context.

### Uncovered scope

- No automated visual regression across the updated CLIENTS row; relying on quick manual eyeball after Vercel redeploys main.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: the HermesIcon SVG path aesthetics and the ordering of Hermes in the CLIENTS array (chosen to place Moonshot-family adjacent and keep OpenCode / OpenClaw trailing as the long-standing ordering).
- Delta since last review: n/a
- Depends on: none
- Known gaps / follow-ups: README / marketing site still enumerates clients in free prose and can be refreshed in a separate pass.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Hermes agent to client logos list and landing copy
> Adds a new `HermesIcon` SVG component to [ClientLogos.jsx](https://github.com/victorGPT/vibeusage/pull/150/files#diff-300a202bba9035349f0816278ad2e720ed8a9804c5f3fe7f29a680807ecc1953) and appends a Hermes entry to the `CLIENTS` constant. Updates [copy.csv](https://github.com/victorGPT/vibeusage/pull/150/files#diff-fe0ec575ca6384212b820dbb469f59415bf3130857416c03c60da63ba87e4446) with related landing copy changes. Tests are updated to expect at least 7 `CLIENTS` entries and assert the presence of the Hermes entry and icon export.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cb9bc6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->