### PR TITLE
fix(cli): align integration labels with official brand names

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -190,7 +190,7 @@ function renderWelcome() {
       DIVIDER,
       "",
       "This tool will:",
-      "  - Analyze your local AI CLI configurations (Codex, Every Code, Claude, Gemini, Kimi, Opencode, Hermes, OpenClaw)",
+      "  - Analyze your local AI CLI configurations (Codex, Every Code, Claude Code, Gemini, Kimi, Hermes, OpenCode, OpenClaw)",
       "  - Set up lightweight hooks to track your flow state",
       "  - Link your device to your VibeScore account",
       "",

--- a/src/lib/integrations/claude.js
+++ b/src/lib/integrations/claude.js
@@ -8,7 +8,7 @@ const { isDir, isFile } = require("./utils");
 
 module.exports = {
   name: "claude",
-  summaryLabel: "Claude",
+  summaryLabel: "Claude Code",
   statusLabel: "Claude plugin",
   async probe(ctx) {
     const hasConfigDir = await isDir(ctx.claude.configDir);

--- a/src/lib/integrations/opencode.js
+++ b/src/lib/integrations/opencode.js
@@ -3,8 +3,8 @@ const { isDir } = require("./utils");
 
 module.exports = {
   name: "opencode",
-  summaryLabel: "Opencode Plugin",
-  statusLabel: "Opencode plugin",
+  summaryLabel: "OpenCode Plugin",
+  statusLabel: "OpenCode plugin",
   async probe(ctx) {
     const hasConfigDir = await isDir(ctx.opencode.configDir);
     if (!hasConfigDir) {

--- a/test/init-dry-run.test.js
+++ b/test/init-dry-run.test.js
@@ -40,7 +40,7 @@ test("dry-run preview reports opencode install when config is missing", async ()
     ]);
 
     const clean = stripAnsi(output);
-    assert.match(clean, /Opencode Plugin/);
+    assert.match(clean, /OpenCode Plugin/);
     assert.match(clean, /\[Will install plugin\]/);
 
     const pluginPath = path.join(


### PR DESCRIPTION
# What does this PR do?

- Fixes the \`vibeusage init\` Integration Status list so the printed CLI names match the official brand casing instead of vibeusage internal slugs. Two labels drifted: Claude should read \`Claude Code\` (Anthropic's product name) and Opencode should read \`OpenCode\`. Also nudges the welcome banner to advertise the clients in the same canonical order the status list prints.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/integrations/claude.js: summaryLabel "Claude" -> "Claude Code".
- src/lib/integrations/opencode.js: summaryLabel "Opencode Plugin" -> "OpenCode Plugin", statusLabel "Opencode plugin" -> "OpenCode plugin".
- src/commands/init.js: welcome banner client list reordered + renamed to match (Codex, Every Code, Claude Code, Gemini, Kimi, Hermes, OpenCode, OpenClaw).
- test/init-dry-run.test.js: assertion updated to /OpenCode Plugin/ to match the new label.

## Affected Modules / Contracts

- Modules touched: src/lib/integrations/claude.js, src/lib/integrations/opencode.js, src/commands/init.js, test/init-dry-run.test.js
- Dependencies / contracts touched: Label strings only. No API, no storage, no probe/install behavior change. The internal integration \`name\` slugs (\`claude\`, \`opencode\`) remain unchanged, so all status bookkeeping, hook filenames, and source-enum routing stay backward compatible.
- Repo sitemap evidence: not required (cosmetic label fix)

## Validation

### Automated

- npm test -> 758/758 pass, including the updated init-dry-run expectation.

### Manual / smoke

- Eyeballed the dry-run output locally; Integration Status now reads "Claude Code" and "OpenCode Plugin" as expected.

### Uncovered scope

- No automated snapshot of the init UI so visual changes rely on the single matched substring in init-dry-run.test.js.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: confirm Claude Code vs Claude branding matches how Anthropic names the CLI, and that no other place grep-matches the old "Opencode Plugin" string.
- Delta since last review: n/a
- Depends on: none
- Known gaps / follow-ups: may want to also rename the statusLabel "Claude plugin" -> "Claude Code plugin" in a future pass for full consistency.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix integration brand names to use 'Claude Code' and 'OpenCode' in CLI output
> Corrects capitalization and naming of two integrations across labels and the init welcome screen. `summaryLabel` for the Claude integration changes from `'Claude'` to `'Claude Code'`, and the OpenCode integration labels change from `'Opencode'` to `'OpenCode'`. The ordering in the welcome message is also adjusted so Hermes precedes OpenCode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 779021a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->