### PR TITLE
fix(parser): dedupe Claude Code usage by message.id (was 2.3x over-count)

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -246,6 +246,8 @@ async function parseClaudeIncremental({
     const prev = cursors.files[key] || null;
     const inode = st.ino || 0;
     const startOffset = prev && prev.inode === inode ? prev.offset || 0 : 0;
+    const priorSeenIds =
+      prev && prev.inode === inode && Array.isArray(prev.seenIds) ? prev.seenIds : [];
 
     const projectContext = projectEnabled
       ? await resolveProjectContextForFile({
@@ -269,11 +271,13 @@ async function parseClaudeIncremental({
       projectTouchedBuckets,
       projectRef,
       projectKey,
+      priorSeenIds,
     });
 
     cursors.files[key] = {
       inode,
       offset: result.endOffset,
+      seenIds: result.seenIds,
       updatedAt: new Date().toISOString(),
     };
 
@@ -778,6 +782,8 @@ async function parseRolloutFile({
   return { endOffset, lastTotal: totals, lastModel: model, eventsAggregated };
 }
 
+const CLAUDE_SEEN_IDS_LIMIT = 500;
+
 async function parseClaudeFile({
   filePath,
   startOffset,
@@ -788,12 +794,18 @@ async function parseClaudeFile({
   projectTouchedBuckets,
   projectRef,
   projectKey,
+  priorSeenIds,
 }) {
+  const seenOrder = Array.isArray(priorSeenIds) ? priorSeenIds.slice() : [];
+  const seenSet = new Set(seenOrder);
+
   const st = await fs.stat(filePath).catch(() => null);
-  if (!st || !st.isFile()) return { endOffset: startOffset, eventsAggregated: 0 };
+  if (!st || !st.isFile()) {
+    return { endOffset: startOffset, eventsAggregated: 0, seenIds: seenOrder };
+  }
 
   const endOffset = st.size;
-  if (startOffset >= endOffset) return { endOffset, eventsAggregated: 0 };
+  if (startOffset >= endOffset) return { endOffset, eventsAggregated: 0, seenIds: seenOrder };
 
   const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
@@ -810,6 +822,12 @@ async function parseClaudeFile({
 
     const usage = obj?.message?.usage || obj?.usage;
     if (!usage || typeof usage !== "object") continue;
+
+    // Claude Code writes the same assistant message multiple times in the session log
+    // (same `message.id` / `requestId`, different outer `uuid`). Aggregate once per
+    // upstream Anthropic response to avoid multi-counting token usage.
+    const dedupeId = obj?.message?.id || obj?.requestId || null;
+    if (dedupeId && seenSet.has(dedupeId)) continue;
 
     const model = normalizeModelInput(obj?.message?.model || obj?.model) || DEFAULT_MODEL;
     const tokenTimestamp = typeof obj?.timestamp === "string" ? obj.timestamp : null;
@@ -835,12 +853,20 @@ async function parseClaudeFile({
       addTotals(projectBucket.totals, delta);
       projectTouchedBuckets.add(projectBucketKey(projectKey, source, bucketStart));
     }
+    if (dedupeId) {
+      seenSet.add(dedupeId);
+      seenOrder.push(dedupeId);
+    }
     eventsAggregated += 1;
   }
 
   rl.close();
   stream.close?.();
-  return { endOffset, eventsAggregated };
+  const trimmedSeenIds =
+    seenOrder.length > CLAUDE_SEEN_IDS_LIMIT
+      ? seenOrder.slice(seenOrder.length - CLAUDE_SEEN_IDS_LIMIT)
+      : seenOrder;
+  return { endOffset, eventsAggregated, seenIds: trimmedSeenIds };
 }
 
 async function parseKimiFile({

--- a/test/rollout-claude-dedupe.test.js
+++ b/test/rollout-claude-dedupe.test.js
@@ -1,0 +1,252 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { parseClaudeIncremental } = require("../src/lib/rollout");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-claude-dedupe-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function assistantLine({
+  ts,
+  messageId,
+  requestId,
+  uuid,
+  model = "claude-sonnet-4.5",
+  input = 10,
+  cacheCreation = 0,
+  cacheRead = 0,
+  output = 5,
+}) {
+  return JSON.stringify({
+    parentUuid: null,
+    uuid: uuid || `uuid-${Math.random().toString(36).slice(2)}`,
+    timestamp: ts,
+    type: "assistant",
+    requestId,
+    message: {
+      id: messageId,
+      role: "assistant",
+      model,
+      usage: {
+        input_tokens: input,
+        cache_creation_input_tokens: cacheCreation,
+        cache_read_input_tokens: cacheRead,
+        output_tokens: output,
+      },
+    },
+  });
+}
+
+async function readJsonLines(filePath) {
+  const text = await fs.readFile(filePath, "utf8").catch(() => "");
+  if (!text.trim()) return [];
+  return text.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+}
+
+test("parseClaudeIncremental deduplicates repeated message.id within one file", async () => {
+  await withTempDir(async (dir) => {
+    const jsonl = path.join(dir, "session.jsonl");
+    // Claude Code sometimes writes the same assistant message twice
+    // (different outer uuid, identical message.id + requestId).
+    const lines = [
+      assistantLine({
+        ts: "2026-04-14T14:46:38.491Z",
+        messageId: "msg_A",
+        requestId: "req_A",
+        uuid: "u1",
+        input: 3,
+        cacheCreation: 17229,
+        cacheRead: 12958,
+        output: 492,
+      }),
+      assistantLine({
+        ts: "2026-04-14T14:46:43.299Z",
+        messageId: "msg_A", // duplicate
+        requestId: "req_A",
+        uuid: "u2",
+        input: 3,
+        cacheCreation: 17229,
+        cacheRead: 12958,
+        output: 492,
+      }),
+      assistantLine({
+        ts: "2026-04-14T14:46:45.000Z",
+        messageId: "msg_B", // new message
+        requestId: "req_B",
+        uuid: "u3",
+        input: 1,
+        cacheCreation: 100,
+        cacheRead: 50,
+        output: 20,
+      }),
+    ];
+    await fs.writeFile(jsonl, `${lines.join("\n")}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const result = await parseClaudeIncremental({
+      projectFiles: [jsonl],
+      cursors,
+      queuePath,
+    });
+
+    // 2 unique messages aggregated (msg_A once, msg_B once) — not 3.
+    assert.equal(result.eventsAggregated, 2);
+
+    const queued = await readJsonLines(queuePath);
+    const totalInput = queued.reduce((s, b) => s + Number(b.input_tokens || 0), 0);
+    const totalOutput = queued.reduce((s, b) => s + Number(b.output_tokens || 0), 0);
+    const totalCached = queued.reduce((s, b) => s + Number(b.cached_input_tokens || 0), 0);
+    // msg_A: input(3) + cache_creation(17229) = 17232; msg_B: 1 + 100 = 101
+    assert.equal(totalInput, 17232 + 101);
+    // msg_A output 492 + msg_B output 20
+    assert.equal(totalOutput, 492 + 20);
+    // cached = cache_read_input_tokens; msg_A 12958 + msg_B 50
+    assert.equal(totalCached, 12958 + 50);
+
+    // Cursor persisted seenIds
+    const saved = cursors.files[jsonl];
+    assert.ok(Array.isArray(saved.seenIds), "cursor should persist seenIds");
+    assert.ok(saved.seenIds.includes("msg_A"));
+    assert.ok(saved.seenIds.includes("msg_B"));
+  });
+});
+
+test("parseClaudeIncremental deduplicates across sync invocations via cursor", async () => {
+  await withTempDir(async (dir) => {
+    const jsonl = path.join(dir, "session.jsonl");
+    const first = assistantLine({
+      ts: "2026-04-14T14:00:00Z",
+      messageId: "msg_X",
+      requestId: "req_X",
+      uuid: "u1",
+      input: 10,
+      output: 5,
+    });
+    await fs.writeFile(jsonl, `${first}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const r1 = await parseClaudeIncremental({ projectFiles: [jsonl], cursors, queuePath });
+    assert.equal(r1.eventsAggregated, 1);
+
+    // Appending the same message.id (Claude Code replaying the event) + a new one.
+    const replay = assistantLine({
+      ts: "2026-04-14T14:00:02Z",
+      messageId: "msg_X", // same id
+      requestId: "req_X",
+      uuid: "u2",
+      input: 10,
+      output: 5,
+    });
+    const next = assistantLine({
+      ts: "2026-04-14T14:00:05Z",
+      messageId: "msg_Y",
+      requestId: "req_Y",
+      uuid: "u3",
+      input: 3,
+      output: 2,
+    });
+    await fs.appendFile(jsonl, `${replay}\n${next}\n`, "utf8");
+
+    const r2 = await parseClaudeIncremental({ projectFiles: [jsonl], cursors, queuePath });
+    // Only msg_Y is new
+    assert.equal(r2.eventsAggregated, 1);
+  });
+});
+
+test("parseClaudeIncremental falls back to requestId when message.id is missing", async () => {
+  await withTempDir(async (dir) => {
+    const jsonl = path.join(dir, "session.jsonl");
+    const base = {
+      parentUuid: null,
+      timestamp: "2026-04-14T14:00:00Z",
+      type: "assistant",
+      requestId: "req_FALLBACK",
+      message: {
+        role: "assistant",
+        model: "claude-sonnet-4.5",
+        // no id
+        usage: {
+          input_tokens: 7,
+          output_tokens: 3,
+        },
+      },
+    };
+    const line1 = JSON.stringify({ ...base, uuid: "u1" });
+    const line2 = JSON.stringify({ ...base, uuid: "u2" }); // same requestId, dup
+    await fs.writeFile(jsonl, `${line1}\n${line2}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const r = await parseClaudeIncremental({ projectFiles: [jsonl], cursors, queuePath });
+    assert.equal(r.eventsAggregated, 1);
+  });
+});
+
+test("parseClaudeIncremental caps cursor seenIds to ~500 entries", async () => {
+  await withTempDir(async (dir) => {
+    const jsonl = path.join(dir, "session.jsonl");
+    const lines = [];
+    for (let i = 0; i < 650; i++) {
+      lines.push(
+        assistantLine({
+          ts: `2026-04-14T14:00:${String(i % 60).padStart(2, "0")}Z`,
+          messageId: `msg_${i}`,
+          requestId: `req_${i}`,
+          uuid: `u${i}`,
+          input: 1,
+          output: 1,
+        }),
+      );
+    }
+    await fs.writeFile(jsonl, `${lines.join("\n")}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const r = await parseClaudeIncremental({ projectFiles: [jsonl], cursors, queuePath });
+    assert.equal(r.eventsAggregated, 650);
+
+    const saved = cursors.files[jsonl];
+    assert.ok(saved.seenIds.length <= 500, `expected <= 500 ids, got ${saved.seenIds.length}`);
+    // FIFO semantics: last 500 ids preserved (msg_150..msg_649).
+    assert.equal(saved.seenIds[saved.seenIds.length - 1], "msg_649");
+    assert.equal(saved.seenIds[0], "msg_150");
+  });
+});
+
+test("parseClaudeIncremental still counts lines that have no dedupe key", async () => {
+  await withTempDir(async (dir) => {
+    const jsonl = path.join(dir, "session.jsonl");
+    // No message.id, no requestId — legacy or partial event shape.
+    const base = {
+      parentUuid: null,
+      timestamp: "2026-04-14T14:00:00Z",
+      type: "assistant",
+      message: {
+        role: "assistant",
+        model: "claude-sonnet-4.5",
+        usage: { input_tokens: 4, output_tokens: 1 },
+      },
+    };
+    const line1 = JSON.stringify({ ...base, uuid: "u1" });
+    const line2 = JSON.stringify({ ...base, uuid: "u2" });
+    await fs.writeFile(jsonl, `${line1}\n${line2}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const r = await parseClaudeIncremental({ projectFiles: [jsonl], cursors, queuePath });
+    // Without a dedupe key, both lines are counted (preserves prior behavior
+    // for unknown/partial event shapes — we only skip when we are confident of a duplicate).
+    assert.equal(r.eventsAggregated, 2);
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Stops vibeusage from double-counting Claude Code token usage. Claude Code writes the same assistant message to its session .jsonl several times (same message.id / requestId, different outer uuid). A live survey on the maintainer's 192 Claude session files found 35,163 usage records mapping to only 15,046 unique message.ids — a 2.337x multiplier, or ~134% over-report. Some assistant turns appeared up to 14 times. This PR keys parseClaudeFile on message.id (with requestId fallback) and skips aggregated-once ids both within a run and across sync invocations via a bounded cursor FIFO.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/rollout.js parseClaudeFile: extract `obj.message.id || obj.requestId` as the dedupe key, maintain a Set+ordered-array pair seeded from cursor, skip lines whose id is already seen, and return the (trimmed to 500 most-recent) seenIds along with endOffset.
- src/lib/rollout.js parseClaudeIncremental: read priorSeenIds from cursor entry, pass into parseClaudeFile, persist the returned seenIds back into cursors.files[key].
- test/rollout-claude-dedupe.test.js (new): 5 cases — intra-file dup, cross-sync dup via cursor, requestId fallback, 500-entry FIFO cap, no-key-fallback still counts.

## Affected Modules / Contracts

- Modules touched: src/lib/rollout.js, test/rollout-claude-dedupe.test.js.
- Dependencies / contracts touched: cursors.files[<claude-file>] schema gains an optional seenIds string array. Backward compatible: missing seenIds is treated as empty on first run; cursor readers are tolerant of extra fields.
- Repo sitemap evidence: not required (localized parser fix inside existing module).

## Validation

### Automated

- node --test test/rollout-claude-dedupe.test.js -> 5/5 pass.
- npm test -> 763/763 pass (758 existing + 5 new). Prior Claude parser tests all still green — semantics unchanged for the happy path.

### Manual / smoke

- Live probe on the maintainer's ~/.claude/projects tree (192 session files, 35,163 usage records) confirmed the 2.337x dedupe ratio and identified representative duplicate pairs (different uuid, same message.id / requestId, same usage payload, seconds apart).

### Uncovered scope

- Buckets already written to vibeusage_tracker_hourly reflect the old over-counted totals. This PR only fixes future sync runs. A follow-up needs to decide between:
  1. leave historical data as-is (accept "past high, future accurate"); or
  2. rewind cursors for source=claude and re-ingest, which requires ingest-side idempotency on (device_id, source, model, bucket) to avoid re-insert noise.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: confirm the dedupe key priority (message.id > requestId > count-every-line) matches your intent; confirm 500-entry FIFO is sufficient headroom for the worst-case inter-sync replay window.
- Delta since last review: n/a (new PR)
- Depends on: none
- Known gaps / follow-ups: decide on historical bucket cleanup; dashboard may want to advertise the correction in CHANGELOG for the next release bump.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 2.3x over-count in Claude Code usage by deduplicating lines on `message.id`
> - `parseClaudeFile` now deduplicates usage lines by `message.id` (falling back to `requestId`), skipping lines whose key was already seen within or across runs.
> - `parseClaudeIncremental` persists a rolling `seenIds` list (capped at 500 via `CLAUDE_SEEN_IDS_LIMIT`) in cursor state per file, keyed by inode, so deduplication survives across invocations.
> - Lines with no dedupe key are still counted normally.
> - New test suite in [rollout-claude-dedupe.test.js](https://github.com/victorGPT/vibeusage/pull/152/files#diff-8a86d4ad49ab97e3706fdb14215c1b2d99d2363105428a0fb0ae8b3a40921ff7) covers within-file dedupe, cross-invocation dedupe, `requestId` fallback, FIFO cap semantics, and no-key lines.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f7d176.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->