### PR TITLE
fix(parser): include cache_read in Claude/OpenCode total_tokens (was under-counting 80-95%)

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -2181,7 +2181,10 @@ function normalizeOpencodeTokens(tokens) {
   const cached = toNonNegativeInt(tokens.cache?.read);
   const cacheWrite = toNonNegativeInt(tokens.cache?.write);
   const inputTokens = input + cacheWrite;
-  const total = inputTokens + output + reasoning;
+  // Include cache-read tokens in the total so OpenCode sessions do not
+  // under-count the way Claude did before the parallel fix; cache-read is
+  // real spend the user pays for on every turn.
+  const total = inputTokens + cached + output + reasoning;
 
   return {
     input_tokens: inputTokens,
@@ -2304,12 +2307,19 @@ function normalizeUsage(u) {
 function normalizeClaudeUsage(u) {
   const inputTokens =
     toNonNegativeInt(u?.input_tokens) + toNonNegativeInt(u?.cache_creation_input_tokens);
+  const cachedInputTokens = toNonNegativeInt(u?.cache_read_input_tokens);
   const outputTokens = toNonNegativeInt(u?.output_tokens);
   const hasTotal = u && Object.prototype.hasOwnProperty.call(u, "total_tokens");
-  const totalTokens = hasTotal ? toNonNegativeInt(u?.total_tokens) : inputTokens + outputTokens;
+  // Claude's Messages API does not emit `total_tokens`. When absent, compose it
+  // from all four channels (input / cache_creation / cache_read / output). The
+  // old formula omitted cache_read, which is ~99% of token spend on long
+  // Claude Opus sessions and was the main driver of user-visible under-counts.
+  const totalTokens = hasTotal
+    ? toNonNegativeInt(u?.total_tokens)
+    : inputTokens + cachedInputTokens + outputTokens;
   return {
     input_tokens: inputTokens,
-    cached_input_tokens: toNonNegativeInt(u?.cache_read_input_tokens),
+    cached_input_tokens: cachedInputTokens,
     output_tokens: outputTokens,
     reasoning_output_tokens: 0,
     total_tokens: totalTokens,

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -874,7 +874,8 @@ test("parseOpencodeIncremental ingests sqlite rows when message files are absent
     assert.equal(queued.length, 1);
     assert.equal(queued[0].source, "opencode");
     assert.equal(queued[0].model, "gpt-5");
-    assert.equal(queued[0].total_tokens, 18);
+    // total = input(10) + cacheWrite(5) + cached(3) + output(2) + reasoning(1)
+    assert.equal(queued[0].total_tokens, 21);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -1800,7 +1801,47 @@ test("parseClaudeIncremental counts cache creation as input and cache read separ
     assert.equal(queued[0].input_tokens, 8);
     assert.equal(queued[0].cached_input_tokens, 4);
     assert.equal(queued[0].output_tokens, 2);
-    assert.equal(queued[0].total_tokens, 10);
+    // total includes cache-read so long Claude sessions do not under-count
+    // (input 5 + cache_creation 3 + cache_read 4 + output 2 = 14).
+    assert.equal(queued[0].total_tokens, 14);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseClaudeIncremental total_tokens includes cache_read (Opus long-session regression)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibescore-claude-"));
+  try {
+    const claudePath = path.join(tmp, "agent-claude.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    // Realistic Claude Opus bucket: tiny input, huge cache_read, modest output.
+    // Prior parser computed total = input + cache_creation + output and missed
+    // the ~99% cache-read slice, causing dashboards to under-count by ~95%.
+    const lines = [
+      buildClaudeUsageLine({
+        ts: "2026-04-23T11:00:00.000Z",
+        input: 321906,
+        output: 224178,
+        cacheCreation: 923000,
+        cacheRead: 97255588,
+      }),
+    ];
+    await fs.writeFile(claudePath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parseClaudeIncremental({
+      projectFiles: [{ path: claudePath, source: "claude" }],
+      cursors,
+      queuePath,
+    });
+    assert.equal(res.filesProcessed, 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].cached_input_tokens, 97255588);
+    // Expected total: input(321906) + cache_creation(923000) + cache_read(97255588) + output(224178)
+    assert.equal(queued[0].total_tokens, 321906 + 923000 + 97255588 + 224178);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
# What does this PR do?

- Stops vibeusage from systematically under-reporting Claude Code (and OpenCode) token usage. normalizeClaudeUsage was composing total_tokens as \`input + cache_creation + output\` when the upstream payload lacked total_tokens — which Anthropic's Messages API always does — leaving out \`cache_read_input_tokens\`. On long Claude Opus sessions cache_read is ~99% of token spend, so dashboards showed 4–40x less than reality. Same bug existed in normalizeOpencodeTokens.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/rollout.js normalizeClaudeUsage: when no upstream total_tokens, total = input + cache_creation + cache_read + output instead of dropping cache_read.
- src/lib/rollout.js normalizeOpencodeTokens: total = input + cache.write + cache.read + output + reasoning, fixing the same under-count pattern for OpenCode sessions.
- test/rollout-parser.test.js: two legacy assertions updated to the corrected totals (Claude 10->14, OpenCode 18->21); new regression test pins a realistic Claude Opus bucket (321,906 input + 923k cache_creation + 97.2M cache_read + 224k output) to the now-correct 98.7M total.

## Affected Modules / Contracts

- Modules touched: src/lib/rollout.js, test/rollout-parser.test.js.
- Dependencies / contracts touched: none on the wire. The emitted bucket keeps the same 5 columns (input_tokens / cached_input_tokens / output_tokens / reasoning_output_tokens / total_tokens). Only total_tokens is semantically corrected; input/cached stay split the same way.
- Repo sitemap evidence: not required (localized parser fix).

## Validation

### Automated

- npm test -> 759/759 pass locally (includes the new Opus-bucket regression case).

### Manual / smoke

- Ground-truth comparison against ~/.claude/projects on the maintainer's machine: after dedupe by message.id, 7-day actual token totals vs DB totals showed 84-95% under-report. Examples (real Claude dedup vs vibeusage DB):
    - 2026-04-17: 78,340,535 vs 12,235,673 (missing 84.4%)
    - 2026-04-22: 448,169,592 vs 29,542,821 (missing 93.4%)
    - 2026-04-23: 483,941,862 vs 23,720,371 (missing 95.1%)
- Bucket-level detail: a single 2026-04-23T11:00 bucket shows cached_input_tokens=97,255,588 but total_tokens=546,084 in the DB — the exact shape the fix corrects.

### Uncovered scope

- Historical buckets in vibeusage_tracker_hourly still reflect the old under-count. Separate decision: accept historical gap, or rewind cursors + re-ingest (needs the dedupe fix from PR #152 first, plus ingest-side idempotency to avoid inserting duplicates).
- OpenCode runtime not verified with a live session sample; relies on the unit-test update plus matching bug-shape with the Claude fix.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: confirm total_tokens should include cache_read (yes — Anthropic bills cache-read at 0.1x base rate, it is real spend the user pays for). Confirm OpenCode total addition does not double-count anything in the dashboard's billable_total_tokens pipeline.
- Delta since last review: n/a (new PR)
- Depends on: independent of PR #152 (dedup). Both fixes complementary — dedup alone keeps under-counting by ~18x; cache_read alone keeps multi-counting by ~2.3x; merging both yields accurate totals going forward.
- Known gaps / follow-ups: dashboard surfaces that display \`billable_total_tokens\` should be re-verified after this lands — the pricing pipeline may already have its own cache_read handling that could now layer with the corrected total_tokens.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `cache_read` tokens excluded from Claude and OpenCode `total_tokens` counts
> - `normalizeOpencodeTokens` in [rollout.js](https://github.com/victorGPT/vibeusage/pull/153/files#diff-bd217868ab0b41951b41e41e804085a15920373940bc47982eee84a424edd3e9) now adds `cached` (cache-read) tokens to `total_tokens`, which previously only summed input + cacheWrite + output + reasoning.
> - `normalizeClaudeUsage` now includes `cache_read_input_tokens` when computing a fallback `total_tokens`, fixing under-counts of 80–95% in long sessions with high cache-read usage.
> - Two existing tests have updated expected `total_tokens` values, and a new regression test covers the high cache-read scenario (Opus long-session).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 703622a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->