### PR TITLE
feat(doctor): --audit-tokens subcommand wraps the Claude ground-truth audit (Phase A2)

### DIFF
--- a/scripts/ops/compare-claude-ground-truth.cjs
+++ b/scripts/ops/compare-claude-ground-truth.cjs
@@ -3,44 +3,8 @@
 /**
  * compare-claude-ground-truth.cjs
  *
- * Walk the local `~/.claude/projects/<project>/*.jsonl` files, compute the
- * ground-truth Claude Code token totals the way vibeusage SHOULD have reported
- * them (dedup by message.id, count all four channels: input, cache_creation,
- * cache_read, output), and compare against DB totals pulled from
- * vibeusage_tracker_hourly.
- *
- * Why this exists:
- *   April 2026 incident had vibeusage reporting ~5-15% of actual Claude
- *   consumption. A quick local-vs-DB comparison would have caught the drift
- *   instantly. This script is the first-class way to run that comparison on a
- *   maintainer box.
- *
- * Usage (two modes):
- *
- *   1. Auto mode (requires `insforge` CLI linked to the vibeusage workspace)
- *      node scripts/ops/compare-claude-ground-truth.cjs
- *      node scripts/ops/compare-claude-ground-truth.cjs --days 30 --threshold 15
- *
- *   2. BYO DB data (for CI or when `insforge` CLI is not available)
- *      insforge --json db query "SELECT DATE(hour_start) day, SUM(total_tokens) tokens
- *        FROM vibeusage_tracker_hourly
- *        WHERE source='claude' AND user_id='<you>' AND hour_start >= '2026-04-10'
- *        GROUP BY DATE(hour_start)" > /tmp/db.json
- *      node scripts/ops/compare-claude-ground-truth.cjs --db-json /tmp/db.json
- *
- * Flags:
- *   --days N          lookback window in days (default 14)
- *   --threshold PCT   drift ratio above which the script exits non-zero (default 25)
- *   --user-id UUID    vibeusage user_id filter (auto mode; inferred if omitted
- *                     via `vibeusage_tracker_devices` where device_id = local)
- *   --db-json PATH    read pre-computed DB totals from this JSON file instead
- *                     of invoking `insforge db query`
- *   --json            emit machine-readable JSON instead of the table
- *
- * Exit codes:
- *   0  drift within threshold
- *   1  drift exceeds threshold on at least one day
- *   2  cannot run (missing data source, no local sessions, etc.)
+ * CLI wrapper around src/lib/ops/audit-claude.js. See
+ * `node scripts/ops/compare-claude-ground-truth.cjs --help`.
  */
 
 "use strict";
@@ -48,28 +12,30 @@
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { spawnSync } = require("node:child_process");
 
-const DEFAULT_DAYS = 14;
-const DEFAULT_THRESHOLD_PCT = 25;
+const {
+  DEFAULT_DAYS,
+  DEFAULT_THRESHOLD_PCT,
+  runAudit,
+} = require("../../src/lib/ops/audit-claude");
 
 function parseArgs(argv) {
   const out = {
     days: DEFAULT_DAYS,
-    json: false,
     threshold: DEFAULT_THRESHOLD_PCT,
     userId: null,
     dbJson: null,
+    json: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === "--days") {
       const n = Number(argv[++i]);
-      if (!Number.isFinite(n) || n <= 0) bail(`--days expects a positive number, got ${argv[i]}`);
+      if (!Number.isFinite(n) || n <= 0) bail(`--days expects a positive number`);
       out.days = Math.floor(n);
     } else if (a === "--threshold") {
       const n = Number(argv[++i]);
-      if (!Number.isFinite(n) || n < 0) bail(`--threshold expects a non-negative number, got ${argv[i]}`);
+      if (!Number.isFinite(n) || n < 0) bail(`--threshold expects a non-negative number`);
       out.threshold = n;
     } else if (a === "--user-id") {
       out.userId = String(argv[++i] || "").trim() || null;
@@ -123,145 +89,6 @@ function readTrackerConfig() {
   return {};
 }
 
-function listClaudeJsonl() {
-  const projectsDir = path.join(os.homedir(), ".claude", "projects");
-  if (!fs.existsSync(projectsDir)) return [];
-  const out = [];
-  for (const entry of fs.readdirSync(projectsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const dir = path.join(projectsDir, entry.name);
-    for (const f of fs.readdirSync(dir, { withFileTypes: true })) {
-      if (!f.isFile()) continue;
-      if (!f.name.endsWith(".jsonl")) continue;
-      out.push(path.join(dir, f.name));
-    }
-  }
-  return out;
-}
-
-function isoDay(ts) {
-  if (typeof ts !== "string") return null;
-  const m = ts.match(/^(\d{4}-\d{2}-\d{2})/);
-  return m ? m[1] : null;
-}
-
-function nonneg(v) {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.floor(n);
-}
-
-function computeLocalTotals({ files, windowStartIso }) {
-  const byDay = new Map();
-  const seen = new Set();
-  let scanned = 0;
-  let skippedDup = 0;
-  for (const filePath of files) {
-    let text;
-    try {
-      text = fs.readFileSync(filePath, "utf8");
-    } catch (_err) {
-      continue;
-    }
-    for (const line of text.split("\n")) {
-      if (!line || !line.includes('"usage"')) continue;
-      let obj;
-      try {
-        obj = JSON.parse(line);
-      } catch (_err) {
-        continue;
-      }
-      const ts = typeof obj?.timestamp === "string" ? obj.timestamp : null;
-      if (!ts || ts < windowStartIso) continue;
-      const day = isoDay(ts);
-      if (!day) continue;
-      const msg = obj?.message || {};
-      const usage = msg.usage || obj.usage;
-      if (!usage || typeof usage !== "object") continue;
-      const dedupeId = msg.id || obj.requestId || null;
-      scanned += 1;
-      if (dedupeId && seen.has(dedupeId)) {
-        skippedDup += 1;
-        continue;
-      }
-      if (dedupeId) seen.add(dedupeId);
-
-      const input = nonneg(usage.input_tokens);
-      const cacheCreation = nonneg(usage.cache_creation_input_tokens);
-      const cacheRead = nonneg(usage.cache_read_input_tokens);
-      const output = nonneg(usage.output_tokens);
-      const total = input + cacheCreation + cacheRead + output;
-      if (total === 0) continue;
-
-      let row = byDay.get(day);
-      if (!row) {
-        row = { total: 0, input: 0, cache_creation: 0, cache_read: 0, output: 0, messages: 0 };
-        byDay.set(day, row);
-      }
-      row.total += total;
-      row.input += input;
-      row.cache_creation += cacheCreation;
-      row.cache_read += cacheRead;
-      row.output += output;
-      row.messages += 1;
-    }
-  }
-  return { byDay, scanned, skippedDup, uniqueMessages: seen.size };
-}
-
-function resolveUserId({ explicitUserId, deviceId }) {
-  if (explicitUserId) return explicitUserId;
-  if (!deviceId) return null;
-  const r = spawnSync(
-    "insforge",
-    [
-      "db",
-      "query",
-      `SELECT user_id FROM vibeusage_tracker_devices WHERE id='${deviceId}' LIMIT 1`,
-    ],
-    { encoding: "utf8" },
-  );
-  if (r.status !== 0) return null;
-  const m = r.stdout.match(/\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i);
-  return m ? m[1] : null;
-}
-
-function queryDbTotalsViaInsforge({ userId, windowStartIso }) {
-  const sql =
-    `SELECT DATE(hour_start) AS day, SUM(total_tokens) AS tokens ` +
-    `FROM vibeusage_tracker_hourly ` +
-    `WHERE source='claude' AND user_id='${userId}' AND hour_start >= '${windowStartIso}' ` +
-    `GROUP BY DATE(hour_start) ORDER BY day`;
-  const r = spawnSync("insforge", ["--json", "db", "query", sql], { encoding: "utf8" });
-  if (r.status !== 0) {
-    bail(
-      `\`insforge db query\` failed (${r.status}). Run \`insforge current\` to confirm the ` +
-        `CLI is linked to the vibeusage workspace, or use --db-json PATH to feed data directly.`,
-    );
-  }
-  return parseInsforgeJson(r.stdout);
-}
-
-function parseInsforgeJson(blob) {
-  let parsed;
-  try {
-    parsed = JSON.parse(blob);
-  } catch (err) {
-    bail(`cannot parse DB JSON: ${err?.message || err}`);
-  }
-  const rows = Array.isArray(parsed) ? parsed : Array.isArray(parsed?.rows) ? parsed.rows : Array.isArray(parsed?.data) ? parsed.data : null;
-  if (!rows) bail(`DB JSON shape unexpected (need array of {day, tokens}); got ${Object.keys(parsed || {}).join(",") || "(empty)"}`);
-  const byDay = new Map();
-  for (const row of rows) {
-    const rawDay = row?.day ?? row?.date ?? row?.bucket_day;
-    const day = typeof rawDay === "string" ? rawDay.slice(0, 10) : null;
-    if (!day) continue;
-    const total = nonneg(row.tokens ?? row.total_tokens ?? row.total);
-    byDay.set(day, total);
-  }
-  return byDay;
-}
-
 function formatNumber(n) {
   return Number(n).toLocaleString("en-US");
 }
@@ -270,72 +97,39 @@ function main() {
   const args = parseArgs(process.argv.slice(2));
   const config = readTrackerConfig();
 
-  const now = new Date();
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  start.setUTCDate(start.getUTCDate() - (args.days - 1));
-  const windowStartIso = start.toISOString();
-
-  const files = listClaudeJsonl();
-  if (files.length === 0) {
-    bail("no Claude Code session files under ~/.claude/projects");
-  }
-  const local = computeLocalTotals({ files, windowStartIso });
-
-  let backend;
-  if (args.dbJson) {
-    const blob = fs.readFileSync(args.dbJson, "utf8");
-    backend = parseInsforgeJson(blob);
-  } else {
-    const userId = resolveUserId({ explicitUserId: args.userId, deviceId: config.deviceId });
-    if (!userId) {
-      bail(
-        "cannot resolve user_id. Pass --user-id UUID explicitly, or make sure `insforge` CLI " +
-          "is linked to the vibeusage workspace and config.deviceId is set.",
-      );
-    }
-    backend = queryDbTotalsViaInsforge({ userId, windowStartIso });
+  let result;
+  try {
+    result = runAudit({
+      days: args.days,
+      threshold: args.threshold,
+      userId: args.userId,
+      deviceId: config.deviceId || null,
+      dbJsonPath: args.dbJson || null,
+    });
+  } catch (err) {
+    bail(err?.message || String(err));
   }
 
-  const days = Array.from(new Set([...local.byDay.keys(), ...backend.keys()])).sort();
-  const rows = [];
-  let maxDriftPct = 0;
-  for (const day of days) {
-    const truth = (local.byDay.get(day) || { total: 0 }).total;
-    const dbTotal = backend.get(day) || 0;
-    const ratio = truth > 0 ? dbTotal / truth : null;
-    const drift = ratio == null ? null : Math.abs(ratio - 1) * 100;
-    if (drift != null && drift > maxDriftPct) maxDriftPct = drift;
-    rows.push({ day, truth, db: dbTotal, ratio, driftPct: drift });
+  if (!result.ok) {
+    bail(result.message || result.error || "audit failed");
   }
-
-  const summary = {
-    window_start: windowStartIso,
-    days: args.days,
-    threshold_pct: args.threshold,
-    local_files_scanned: files.length,
-    local_usage_lines: local.scanned,
-    local_unique_messages: local.uniqueMessages,
-    local_duplicates_skipped: local.skippedDup,
-    max_drift_pct: Number(maxDriftPct.toFixed(2)),
-    rows,
-  };
 
   if (args.json) {
-    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   } else {
     process.stdout.write(
-      `Claude Code local vs vibeusage DB (last ${args.days} days, window >= ${windowStartIso})\n`,
+      `Claude Code local vs vibeusage DB (last ${result.days} days, window >= ${result.windowStartIso})\n`,
     );
     process.stdout.write(
-      `Scanned ${files.length} .jsonl files, ${formatNumber(local.scanned)} usage lines, ` +
-        `${formatNumber(local.uniqueMessages)} unique message.ids, ` +
-        `${formatNumber(local.skippedDup)} duplicates skipped.\n\n`,
+      `Scanned ${result.filesScanned} .jsonl files, ${formatNumber(result.usageLines)} usage lines, ` +
+        `${formatNumber(result.uniqueMessages)} unique message.ids, ` +
+        `${formatNumber(result.duplicatesSkipped)} duplicates skipped.\n\n`,
     );
     process.stdout.write(
       `${"day".padEnd(12)}  ${"truth".padStart(15)}  ${"db".padStart(15)}  ${"ratio".padStart(8)}  ${"drift".padStart(8)}\n`,
     );
     process.stdout.write(`${"-".repeat(66)}\n`);
-    for (const r of rows) {
+    for (const r of result.rows) {
       const ratio = r.ratio == null ? "—" : `${r.ratio.toFixed(3)}x`;
       const drift = r.driftPct == null ? "—" : `${r.driftPct.toFixed(1)}%`;
       process.stdout.write(
@@ -343,13 +137,15 @@ function main() {
           `${formatNumber(r.db).padStart(15)}  ${ratio.padStart(8)}  ${drift.padStart(8)}\n`,
       );
     }
-    process.stdout.write(`\nMax drift: ${maxDriftPct.toFixed(2)}% (threshold ${args.threshold}%).\n`);
+    process.stdout.write(
+      `\nMax drift: ${result.maxDriftPct.toFixed(2)}% (threshold ${result.thresholdPct}%).\n`,
+    );
   }
 
-  if (maxDriftPct > args.threshold) {
+  if (result.exceedsThreshold) {
     if (!args.json) {
       process.stderr.write(
-        `\nFAIL drift ${maxDriftPct.toFixed(2)}% exceeds threshold ${args.threshold}%.\n` +
+        `\nFAIL drift ${result.maxDriftPct.toFixed(2)}% exceeds threshold ${result.thresholdPct}%.\n` +
           `If the parser is up to date (vibeusage >= 0.5.0), scrub the Claude/OpenCode cursor\n` +
           `block in ~/.vibeusage/tracker/cursors.json and rerun \`vibeusage sync --drain\`.\n`,
       );

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -6,6 +6,11 @@ const { resolveTrackerPaths } = require("../lib/tracker-paths");
 const { collectTrackerDiagnostics } = require("../lib/diagnostics");
 const { resolveRuntimeConfig } = require("../lib/runtime-config");
 const { buildDoctorReport } = require("../lib/doctor");
+const {
+  DEFAULT_DAYS: AUDIT_DEFAULT_DAYS,
+  DEFAULT_THRESHOLD_PCT: AUDIT_DEFAULT_THRESHOLD,
+  runAudit: runClaudeAudit,
+} = require("../lib/ops/audit-claude");
 
 async function cmdDoctor(argv = []) {
   const opts = parseArgs(argv);
@@ -16,6 +21,11 @@ async function cmdDoctor(argv = []) {
   const configStatus = await readJsonStrict(configPath);
   const config =
     configStatus.status === "ok" && isPlainObject(configStatus.value) ? configStatus.value : {};
+
+  if (opts.auditTokens) {
+    return runAuditTokens({ opts, config });
+  }
+
   const runtime = resolveRuntimeConfig({
     cli: { baseUrl: opts.baseUrl },
     config,
@@ -56,13 +66,98 @@ async function cmdDoctor(argv = []) {
   }
 }
 
+function runAuditTokens({ opts, config }) {
+  let result;
+  try {
+    result = runClaudeAudit({
+      days: opts.auditDays,
+      threshold: opts.auditThreshold,
+      deviceId: config.deviceId || null,
+      dbJsonPath: opts.auditDbJson || null,
+    });
+  } catch (err) {
+    const message = err?.message || String(err);
+    if (opts.json) {
+      process.stdout.write(`${JSON.stringify({ ok: false, error: "audit-error", message })}\n`);
+    } else {
+      process.stderr.write(`doctor --audit-tokens: ${message}\n`);
+    }
+    process.exitCode = 2;
+    return;
+  }
+
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.ok) process.exitCode = 2;
+    else if (result.exceedsThreshold) process.exitCode = 1;
+    return;
+  }
+
+  if (!result.ok) {
+    process.stderr.write(`doctor --audit-tokens: ${result.message || result.error}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  process.stdout.write(
+    `Claude token audit (last ${result.days} days, window >= ${result.windowStartIso})\n`,
+  );
+  process.stdout.write(
+    `Scanned ${result.filesScanned} .jsonl files, ${formatNumber(result.usageLines)} usage lines, ` +
+      `${formatNumber(result.uniqueMessages)} unique message.ids, ` +
+      `${formatNumber(result.duplicatesSkipped)} duplicates skipped.\n\n`,
+  );
+  process.stdout.write(
+    `${"day".padEnd(12)}  ${"truth".padStart(15)}  ${"db".padStart(15)}  ${"ratio".padStart(8)}  ${"drift".padStart(8)}\n`,
+  );
+  process.stdout.write(`${"-".repeat(66)}\n`);
+  for (const r of result.rows) {
+    const ratio = r.ratio == null ? "—" : `${r.ratio.toFixed(3)}x`;
+    const drift = r.driftPct == null ? "—" : `${r.driftPct.toFixed(1)}%`;
+    process.stdout.write(
+      `${r.day.padEnd(12)}  ${formatNumber(r.truth).padStart(15)}  ` +
+        `${formatNumber(r.db).padStart(15)}  ${ratio.padStart(8)}  ${drift.padStart(8)}\n`,
+    );
+  }
+  process.stdout.write(
+    `\nMax drift: ${result.maxDriftPct.toFixed(2)}% (threshold ${result.thresholdPct}%).\n`,
+  );
+
+  if (result.exceedsThreshold) {
+    process.stderr.write(
+      `\nFAIL drift ${result.maxDriftPct.toFixed(2)}% exceeds threshold ${result.thresholdPct}%.\n` +
+        `If vibeusage >= 0.5.0, scrub the Claude/OpenCode cursor block in\n` +
+        `~/.vibeusage/tracker/cursors.json and rerun \`vibeusage sync --drain\`.\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
 function parseArgs(argv) {
-  const out = { json: false, out: null, baseUrl: null };
+  const out = {
+    json: false,
+    out: null,
+    baseUrl: null,
+    auditTokens: false,
+    auditDays: AUDIT_DEFAULT_DAYS,
+    auditThreshold: AUDIT_DEFAULT_THRESHOLD,
+    auditDbJson: null,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--json") out.json = true;
     else if (arg === "--out") out.out = argv[++i] || null;
     else if (arg === "--base-url") out.baseUrl = argv[++i] || null;
+    else if (arg === "--audit-tokens") out.auditTokens = true;
+    else if (arg === "--days") {
+      const n = Number(argv[++i]);
+      if (!Number.isFinite(n) || n <= 0) throw new Error(`--days expects a positive number`);
+      out.auditDays = Math.floor(n);
+    } else if (arg === "--threshold") {
+      const n = Number(argv[++i]);
+      if (!Number.isFinite(n) || n < 0) throw new Error(`--threshold expects a non-negative number`);
+      out.auditThreshold = n;
+    } else if (arg === "--db-json") out.auditDbJson = argv[++i] || null;
     else throw new Error(`Unknown option: ${arg}`);
   }
   return out;
@@ -87,6 +182,10 @@ function formatCheckLine(check = {}) {
   const status = String(check.status || "unknown").toUpperCase();
   const detail = check.detail ? ` - ${check.detail}` : "";
   return `- [${status}] ${check.id || "unknown"}${detail}`;
+}
+
+function formatNumber(n) {
+  return Number(n).toLocaleString("en-US");
 }
 
 function isPlainObject(value) {

--- a/src/lib/ops/audit-claude.js
+++ b/src/lib/ops/audit-claude.js
@@ -1,0 +1,285 @@
+"use strict";
+
+/**
+ * audit-claude.js
+ *
+ * Reusable core for the Claude Code ground-truth audit. Walks local
+ * ~/.claude/projects/*.jsonl (dedup by message.id, sum all 4 channels) and
+ * compares against vibeusage_tracker_hourly totals pulled either from a
+ * caller-supplied JSON blob or via the `insforge` CLI.
+ *
+ * Consumers:
+ *   - scripts/ops/compare-claude-ground-truth.cjs (ops CLI wrapper)
+ *   - src/commands/doctor.js   (`vibeusage doctor --audit-tokens`)
+ */
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const DEFAULT_DAYS = 14;
+const DEFAULT_THRESHOLD_PCT = 25;
+
+function runAudit({
+  days = DEFAULT_DAYS,
+  threshold = DEFAULT_THRESHOLD_PCT,
+  userId = null,
+  deviceId = null,
+  dbJsonPath = null,
+  dbJson = null,
+  projectsDir = path.join(os.homedir(), ".claude", "projects"),
+} = {}) {
+  if (!Number.isFinite(days) || days <= 0) {
+    throw new Error(`days must be a positive number, got ${days}`);
+  }
+  if (!Number.isFinite(threshold) || threshold < 0) {
+    throw new Error(`threshold must be non-negative, got ${threshold}`);
+  }
+
+  const files = listClaudeJsonl(projectsDir);
+  if (files.length === 0) {
+    return {
+      ok: false,
+      error: "no-local-sessions",
+      message: `no Claude Code session files under ${projectsDir}`,
+      rows: [],
+      maxDriftPct: 0,
+    };
+  }
+
+  const now = new Date();
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+  const windowStartIso = start.toISOString();
+
+  const local = computeLocalTotals({ files, windowStartIso });
+
+  let backend;
+  if (dbJson) {
+    backend = parseDbJson(dbJson);
+  } else if (dbJsonPath) {
+    let blob;
+    try {
+      blob = fs.readFileSync(dbJsonPath, "utf8");
+    } catch (err) {
+      return {
+        ok: false,
+        error: "db-json-read-failed",
+        message: `cannot read --db-json ${dbJsonPath}: ${err?.message || err}`,
+        rows: [],
+        maxDriftPct: 0,
+      };
+    }
+    backend = parseDbJson(blob);
+  } else {
+    const resolvedUserId = userId || resolveUserIdViaInsforge({ deviceId });
+    if (!resolvedUserId) {
+      return {
+        ok: false,
+        error: "cannot-resolve-user-id",
+        message:
+          "cannot resolve user_id; pass userId explicitly, supply dbJson, or make sure `insforge` CLI is linked to the vibeusage workspace and config.deviceId is set",
+        rows: [],
+        maxDriftPct: 0,
+      };
+    }
+    const queryRes = queryDbTotalsViaInsforge({
+      userId: resolvedUserId,
+      windowStartIso,
+    });
+    if (!queryRes.ok) {
+      return { ...queryRes, rows: [], maxDriftPct: 0 };
+    }
+    backend = queryRes.byDay;
+  }
+
+  const dayKeys = Array.from(new Set([...local.byDay.keys(), ...backend.keys()])).sort();
+  const rows = [];
+  let maxDriftPct = 0;
+  for (const day of dayKeys) {
+    const truth = (local.byDay.get(day) || { total: 0 }).total;
+    const dbTotal = backend.get(day) || 0;
+    const ratio = truth > 0 ? dbTotal / truth : null;
+    const drift = ratio == null ? null : Math.abs(ratio - 1) * 100;
+    if (drift != null && drift > maxDriftPct) maxDriftPct = drift;
+    rows.push({ day, truth, db: dbTotal, ratio, driftPct: drift });
+  }
+
+  return {
+    ok: true,
+    windowStartIso,
+    days,
+    thresholdPct: threshold,
+    filesScanned: files.length,
+    usageLines: local.scanned,
+    uniqueMessages: local.uniqueMessages,
+    duplicatesSkipped: local.skippedDup,
+    rows,
+    maxDriftPct: Number(maxDriftPct.toFixed(2)),
+    exceedsThreshold: maxDriftPct > threshold,
+  };
+}
+
+function listClaudeJsonl(projectsDir) {
+  if (!fs.existsSync(projectsDir)) return [];
+  const out = [];
+  for (const entry of fs.readdirSync(projectsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = path.join(projectsDir, entry.name);
+    for (const f of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!f.isFile()) continue;
+      if (!f.name.endsWith(".jsonl")) continue;
+      out.push(path.join(dir, f.name));
+    }
+  }
+  return out;
+}
+
+function computeLocalTotals({ files, windowStartIso }) {
+  const byDay = new Map();
+  const seen = new Set();
+  let scanned = 0;
+  let skippedDup = 0;
+  for (const filePath of files) {
+    let text;
+    try {
+      text = fs.readFileSync(filePath, "utf8");
+    } catch (_err) {
+      continue;
+    }
+    for (const line of text.split("\n")) {
+      if (!line || !line.includes('"usage"')) continue;
+      let obj;
+      try {
+        obj = JSON.parse(line);
+      } catch (_err) {
+        continue;
+      }
+      const ts = typeof obj?.timestamp === "string" ? obj.timestamp : null;
+      if (!ts || ts < windowStartIso) continue;
+      const day = isoDay(ts);
+      if (!day) continue;
+      const msg = obj?.message || {};
+      const usage = msg.usage || obj.usage;
+      if (!usage || typeof usage !== "object") continue;
+      const dedupeId = msg.id || obj.requestId || null;
+      scanned += 1;
+      if (dedupeId && seen.has(dedupeId)) {
+        skippedDup += 1;
+        continue;
+      }
+      if (dedupeId) seen.add(dedupeId);
+
+      const input = nonneg(usage.input_tokens);
+      const cacheCreation = nonneg(usage.cache_creation_input_tokens);
+      const cacheRead = nonneg(usage.cache_read_input_tokens);
+      const output = nonneg(usage.output_tokens);
+      const total = input + cacheCreation + cacheRead + output;
+      if (total === 0) continue;
+
+      let row = byDay.get(day);
+      if (!row) {
+        row = { total: 0, input: 0, cache_creation: 0, cache_read: 0, output: 0, messages: 0 };
+        byDay.set(day, row);
+      }
+      row.total += total;
+      row.input += input;
+      row.cache_creation += cacheCreation;
+      row.cache_read += cacheRead;
+      row.output += output;
+      row.messages += 1;
+    }
+  }
+  return { byDay, scanned, skippedDup, uniqueMessages: seen.size };
+}
+
+function isoDay(ts) {
+  const m = ts.match(/^(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : null;
+}
+
+function nonneg(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+function resolveUserIdViaInsforge({ deviceId }) {
+  if (!deviceId) return null;
+  const r = spawnSync(
+    "insforge",
+    [
+      "db",
+      "query",
+      `SELECT user_id FROM vibeusage_tracker_devices WHERE id='${deviceId}' LIMIT 1`,
+    ],
+    { encoding: "utf8" },
+  );
+  if (r.status !== 0) return null;
+  const m = (r.stdout || "").match(
+    /\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i,
+  );
+  return m ? m[1] : null;
+}
+
+function queryDbTotalsViaInsforge({ userId, windowStartIso }) {
+  const sql =
+    `SELECT DATE(hour_start) AS day, SUM(total_tokens) AS tokens ` +
+    `FROM vibeusage_tracker_hourly ` +
+    `WHERE source='claude' AND user_id='${userId}' AND hour_start >= '${windowStartIso}' ` +
+    `GROUP BY DATE(hour_start) ORDER BY day`;
+  const r = spawnSync("insforge", ["--json", "db", "query", sql], { encoding: "utf8" });
+  if (r.status !== 0) {
+    return {
+      ok: false,
+      error: "insforge-db-query-failed",
+      message:
+        `\`insforge db query\` failed (${r.status}). Run \`insforge current\` to confirm ` +
+        `the CLI is linked to the vibeusage workspace, or pass dbJson directly.`,
+    };
+  }
+  return { ok: true, byDay: parseDbJson(r.stdout) };
+}
+
+function parseDbJson(blob) {
+  let parsed;
+  if (typeof blob === "object" && blob !== null) {
+    parsed = blob;
+  } else {
+    try {
+      parsed = JSON.parse(blob);
+    } catch (err) {
+      throw new Error(`cannot parse DB JSON: ${err?.message || err}`);
+    }
+  }
+  const rows = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : Array.isArray(parsed?.data)
+        ? parsed.data
+        : null;
+  if (!rows) {
+    throw new Error(
+      `DB JSON shape unexpected (need array of {day, tokens}); got ${
+        Object.keys(parsed || {}).join(",") || "(empty)"
+      }`,
+    );
+  }
+  const byDay = new Map();
+  for (const row of rows) {
+    const rawDay = row?.day ?? row?.date ?? row?.bucket_day;
+    const day = typeof rawDay === "string" ? rawDay.slice(0, 10) : null;
+    if (!day) continue;
+    const total = nonneg(row.tokens ?? row.total_tokens ?? row.total);
+    byDay.set(day, total);
+  }
+  return byDay;
+}
+
+module.exports = {
+  DEFAULT_DAYS,
+  DEFAULT_THRESHOLD_PCT,
+  runAudit,
+};

--- a/test/doctor-audit-tokens.test.js
+++ b/test/doctor-audit-tokens.test.js
@@ -1,0 +1,124 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { runAudit } = require("../src/lib/ops/audit-claude");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-audit-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function assistantLine({ ts, messageId, input = 0, cc = 0, cr = 0, output = 0 }) {
+  return JSON.stringify({
+    timestamp: ts,
+    type: "assistant",
+    uuid: `u-${messageId}-${Math.random().toString(36).slice(2)}`,
+    requestId: `req-${messageId}`,
+    message: {
+      id: messageId,
+      role: "assistant",
+      model: "claude-opus-4-7",
+      usage: {
+        input_tokens: input,
+        cache_creation_input_tokens: cc,
+        cache_read_input_tokens: cr,
+        output_tokens: output,
+      },
+    },
+  });
+}
+
+test("runAudit dedupes message.id and sums all four token channels", async () => {
+  await withTempDir(async (dir) => {
+    const projects = path.join(dir, "projects");
+    const session = path.join(projects, "proj");
+    await fs.mkdir(session, { recursive: true });
+    const jsonl = path.join(session, "session.jsonl");
+
+    // yesterday (UTC). runAudit default windows the last `days` days inclusive,
+    // so any day inside the window is eligible.
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yIso = `${y.toISOString().slice(0, 10)}T10:00:00.000Z`;
+    const day = yIso.slice(0, 10);
+
+    const lines = [
+      // msg_A counted once with i=10, cc=20, cr=30, out=5 -> total 65
+      assistantLine({ ts: yIso, messageId: "msg_A", input: 10, cc: 20, cr: 30, output: 5 }),
+      // duplicate of msg_A — should be skipped
+      assistantLine({ ts: yIso, messageId: "msg_A", input: 10, cc: 20, cr: 30, output: 5 }),
+      // msg_B counted once with i=1, cc=2, cr=3, out=4 -> total 10
+      assistantLine({ ts: yIso, messageId: "msg_B", input: 1, cc: 2, cr: 3, output: 4 }),
+    ];
+    await fs.writeFile(jsonl, `${lines.join("\n")}\n`, "utf8");
+
+    // DB JSON matching the expected truth -> drift 0%
+    const dbJson = JSON.stringify([{ day, tokens: 75 }]);
+
+    const res = runAudit({
+      days: 3,
+      threshold: 5,
+      dbJson,
+      projectsDir: projects,
+    });
+
+    assert.equal(res.ok, true);
+    assert.equal(res.usageLines, 3, "three usage lines in the file");
+    assert.equal(res.uniqueMessages, 2);
+    assert.equal(res.duplicatesSkipped, 1);
+    const row = res.rows.find((r) => r.day === day);
+    assert.ok(row, "day row present");
+    assert.equal(row.truth, 75); // 65 + 10
+    assert.equal(row.db, 75);
+    assert.equal(res.exceedsThreshold, false);
+  });
+});
+
+test("runAudit flags drift when DB totals disagree with local ground truth", async () => {
+  await withTempDir(async (dir) => {
+    const projects = path.join(dir, "projects");
+    const session = path.join(projects, "proj");
+    await fs.mkdir(session, { recursive: true });
+    const jsonl = path.join(session, "session.jsonl");
+
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yIso = `${y.toISOString().slice(0, 10)}T10:00:00.000Z`;
+    const day = yIso.slice(0, 10);
+
+    const line = assistantLine({ ts: yIso, messageId: "m1", input: 100, cr: 900, output: 10 });
+    // truth = 1010; DB says 100 -> drift ~90% (what the April 2026 bug looked like)
+    await fs.writeFile(jsonl, `${line}\n`, "utf8");
+    const dbJson = JSON.stringify([{ day, tokens: 100 }]);
+
+    const res = runAudit({
+      days: 3,
+      threshold: 10,
+      dbJson,
+      projectsDir: projects,
+    });
+    assert.equal(res.ok, true);
+    assert.equal(res.exceedsThreshold, true);
+    assert.ok(res.maxDriftPct > 80, `expected >80% drift, got ${res.maxDriftPct}`);
+  });
+});
+
+test("runAudit returns an error shape when no sessions are available", async () => {
+  await withTempDir(async (dir) => {
+    const res = runAudit({
+      days: 3,
+      threshold: 25,
+      dbJson: "[]",
+      projectsDir: path.join(dir, "does-not-exist"),
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.error, "no-local-sessions");
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Ships \`vibeusage doctor --audit-tokens\` so users on the installed CLI can run the Claude Code ground-truth audit shipped in PR #155 without needing the ops script or the insforge CLI. Refactors the audit core out of the script into a reusable lib (\`src/lib/ops/audit-claude.js\`) that both surfaces share. Exits non-zero when drift > threshold so it can be chained into shell-level checks.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/ops/audit-claude.js (new): reusable \`runAudit({ days, threshold, userId, deviceId, dbJsonPath, dbJson, projectsDir })\` that walks local ~/.claude/projects/*.jsonl (dedup by message.id, sum all four token channels), then compares against vibeusage_tracker_hourly totals fed either via dbJson, dbJsonPath, or an \`insforge db query\` subprocess. Returns a structured result with ok/error + per-day rows + maxDriftPct.
- src/commands/doctor.js: new --audit-tokens branch with --days, --threshold, --db-json flags. Human and --json output. Exit 0 within threshold, 1 over threshold, 2 on environment errors.
- scripts/ops/compare-claude-ground-truth.cjs: slimmed to a thin CLI wrapper around runAudit so behavior stays identical and both surfaces can't diverge.
- test/doctor-audit-tokens.test.js (new): three cases — dedup + 4-channel sum, drift detection matching the April 2026 bug shape, no-sessions error shape.

## Affected Modules / Contracts

- Modules touched: src/lib/ops/audit-claude.js (new), src/commands/doctor.js, scripts/ops/compare-claude-ground-truth.cjs, test/doctor-audit-tokens.test.js (new).
- Dependencies / contracts touched: none. runAudit only reads files and may spawn \`insforge\`. Existing \`doctor\` default path is unchanged; --audit-tokens is an additive branch.
- Repo sitemap evidence: not required (additive lib + command flag inside existing module boundary).

## Validation

### Automated

- npm test -> 767/767 pass locally, including the three new doctor-audit-tokens cases and the untouched existing doctor.test.js suite.
- Manual smoke: \`node bin/tracker.js doctor --audit-tokens --days 7\` on the maintainer machine reads 158 jsonl files, 10007 usage lines collapsing to 5427 unique ids, 4580 duplicates skipped. The 04-24 row currently shows 30.7% drift because the last batch has not been synced yet — exactly the kind of signal this command is meant to expose.

### Manual / smoke

- \`--json\` output verified to be machine-readable with the same schema as runAudit's return value.
- \`--db-json /tmp/db.json\` path exercised from both the ops script wrapper and the doctor entry point.

### Uncovered scope

- Not wired into \`npm run ci:local\` because CI runners do not have ~/.claude/projects. The audit lib is covered by the new unit tests which use an isolated temp projects dir.
- Script currently only audits source=claude; analogous OpenCode/Kimi audits can reuse the same scaffold later.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: the audit lib keeps dedup + channel-sum semantics in lock-step with src/lib/rollout.js normalizeClaudeUsage. If the parser formula changes the lib and its tests need to follow.
- Delta since last review: n/a
- Depends on: PR #155 already merged; 0.5.0 on npm.
- Known gaps / follow-ups: Phase A3 (parser dedupSkipped metric) and Phase A4 (AGENTS.md new-source checklist) come next.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--audit-tokens` subcommand to `doctor` that runs Claude token ground-truth audit
> - Extracts all audit logic into a new reusable module [`src/lib/ops/audit-claude.js`](https://github.com/victorGPT/vibeusage/pull/156/files#diff-4f39a6bb3185ca783f7f0b0229d32ee47ebfd379793744bc1c221a7e4ffe52e2) exposing `runAudit`, which scans `~/.claude/projects` `.jsonl` files, deduplicates by `message.id`, sums four token channels, and compares local totals against DB totals sourced from insforge or a supplied `--db-json` file.
> - Adds `--audit-tokens`, `--days`, `--threshold`, and `--db-json` flags to [`src/commands/doctor.js`](https://github.com/victorGPT/vibeusage/pull/156/files#diff-6c8875e6b05bb0a5d137333b4dbc8ceada96428ca327b553823f4cd2ee5ea072); when `--audit-tokens` is set the command delegates to `runAuditTokens` and exits early, bypassing the normal doctor report.
> - Refactors [`scripts/ops/compare-claude-ground-truth.cjs`](https://github.com/victorGPT/vibeusage/pull/156/files#diff-831bdd2b872ec5b7521b06ba76ceaa94d15c11ffcb22a5295f977b279dd6d163) to be a thin wrapper around `runAudit` instead of reimplementing audit logic locally.
> - Returns structured results with per-day drift rows, `maxDriftPct`, and `exceedsThreshold`; JSON output shape changes from a `summary` object to the full `runAudit` result.
> - Risk: the JSON output format of `compare-claude-ground-truth.cjs` is a breaking change for any consumers relying on the previous `summary` object shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a166a6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->