### PR TITLE
feat(parser): dedupSkipped metric + Claude duplicate spike warning (Phase A3)

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -132,7 +132,7 @@ async function cmdSync(argv) {
       : { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
 
     const claudeFiles = await listClaudeProjectFiles(claudeProjectsDir);
-    let claudeResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    let claudeResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0, dedupSkipped: 0 };
     if (claudeFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(
@@ -155,6 +155,7 @@ async function cmdSync(argv) {
         },
         source: "claude",
       });
+      await maybeWarnClaudeDedupSpike({ trackerDir, claudeResult });
     }
 
     const geminiFiles = await listGeminiSessionFiles(geminiTmpDir);
@@ -590,6 +591,33 @@ async function parseOpenclawSanitizedLedger({ trackerDir, cursors, queuePath }) 
     eventsAggregated,
     bucketsQueued,
   };
+}
+
+// Claude Code occasionally writes the same assistant message multiple times to
+// its session .jsonl (same message.id, different outer uuid). Parser dedup
+// silently skips the dup rows, but a sudden spike in the dedup-skipped ratio
+// usually means an upstream change that deserves human attention. Emit a
+// debug.jsonl line when the ratio crosses 50% so vibeusage doctor / retro
+// reviewers can find it; intentionally non-blocking.
+async function maybeWarnClaudeDedupSpike({ trackerDir, claudeResult }) {
+  const events = Number(claudeResult?.eventsAggregated || 0);
+  const skipped = Number(claudeResult?.dedupSkipped || 0);
+  const total = events + skipped;
+  if (total === 0) return;
+  const ratio = skipped / total;
+  if (ratio <= 0.5) return;
+  const line =
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      event: "claude_dedup_spike",
+      source: "claude",
+      events_aggregated: events,
+      dedup_skipped: skipped,
+      ratio: Number(ratio.toFixed(3)),
+      hint: "Unusual duplicate rate from ~/.claude/projects jsonl; run `vibeusage doctor --audit-tokens` to compare local vs DB totals.",
+    }) + "\n";
+  const logPath = path.join(trackerDir, "notify.debug.jsonl");
+  await fs.appendFile(logPath, line, "utf8").catch(() => {});
 }
 
 async function safeStatSize(p) {

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -214,6 +214,7 @@ async function parseClaudeIncremental({
   await ensureDir(path.dirname(queuePath));
   let filesProcessed = 0;
   let eventsAggregated = 0;
+  let dedupSkipped = 0;
 
   const cb = typeof onProgress === "function" ? onProgress : null;
   const files = Array.isArray(projectFiles) ? projectFiles : [];
@@ -283,6 +284,7 @@ async function parseClaudeIncremental({
 
     filesProcessed += 1;
     eventsAggregated += result.eventsAggregated;
+    dedupSkipped += result.dedupSkipped || 0;
 
     if (cb) {
       cb({
@@ -307,7 +309,13 @@ async function parseClaudeIncremental({
     cursors.projectHourly = projectState;
   }
 
-  return { filesProcessed, eventsAggregated, bucketsQueued, projectBucketsQueued };
+  return {
+    filesProcessed,
+    eventsAggregated,
+    bucketsQueued,
+    projectBucketsQueued,
+    dedupSkipped,
+  };
 }
 
 async function parseGeminiIncremental({
@@ -801,16 +809,18 @@ async function parseClaudeFile({
 
   const st = await fs.stat(filePath).catch(() => null);
   if (!st || !st.isFile()) {
-    return { endOffset: startOffset, eventsAggregated: 0, seenIds: seenOrder };
+    return { endOffset: startOffset, eventsAggregated: 0, dedupSkipped: 0, seenIds: seenOrder };
   }
 
   const endOffset = st.size;
-  if (startOffset >= endOffset) return { endOffset, eventsAggregated: 0, seenIds: seenOrder };
+  if (startOffset >= endOffset)
+    return { endOffset, eventsAggregated: 0, dedupSkipped: 0, seenIds: seenOrder };
 
   const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
   let eventsAggregated = 0;
+  let dedupSkipped = 0;
   for await (const line of rl) {
     if (!line || !line.includes('\"usage\"')) continue;
     let obj;
@@ -827,7 +837,10 @@ async function parseClaudeFile({
     // (same `message.id` / `requestId`, different outer `uuid`). Aggregate once per
     // upstream Anthropic response to avoid multi-counting token usage.
     const dedupeId = obj?.message?.id || obj?.requestId || null;
-    if (dedupeId && seenSet.has(dedupeId)) continue;
+    if (dedupeId && seenSet.has(dedupeId)) {
+      dedupSkipped += 1;
+      continue;
+    }
 
     const model = normalizeModelInput(obj?.message?.model || obj?.model) || DEFAULT_MODEL;
     const tokenTimestamp = typeof obj?.timestamp === "string" ? obj.timestamp : null;
@@ -866,7 +879,7 @@ async function parseClaudeFile({
     seenOrder.length > CLAUDE_SEEN_IDS_LIMIT
       ? seenOrder.slice(seenOrder.length - CLAUDE_SEEN_IDS_LIMIT)
       : seenOrder;
-  return { endOffset, eventsAggregated, seenIds: trimmedSeenIds };
+  return { endOffset, eventsAggregated, dedupSkipped, seenIds: trimmedSeenIds };
 }
 
 async function parseKimiFile({

--- a/test/rollout-claude-dedup-metric.test.js
+++ b/test/rollout-claude-dedup-metric.test.js
@@ -1,0 +1,85 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { parseClaudeIncremental } = require("../src/lib/rollout");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-claude-metric-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function assistantLine({ ts, messageId, uuid, input = 1, cc = 0, cr = 0, output = 1 }) {
+  return JSON.stringify({
+    parentUuid: null,
+    uuid: uuid || `u-${messageId}-${Math.random().toString(36).slice(2)}`,
+    timestamp: ts,
+    type: "assistant",
+    requestId: `req-${messageId}`,
+    message: {
+      id: messageId,
+      role: "assistant",
+      model: "claude-sonnet-4.5",
+      usage: {
+        input_tokens: input,
+        cache_creation_input_tokens: cc,
+        cache_read_input_tokens: cr,
+        output_tokens: output,
+      },
+    },
+  });
+}
+
+test("parseClaudeIncremental reports dedupSkipped alongside eventsAggregated", async () => {
+  await withTempDir(async (dir) => {
+    const jsonl = path.join(dir, "session.jsonl");
+    const lines = [
+      // 2 unique messages...
+      assistantLine({ ts: "2026-04-24T10:00:00Z", messageId: "A", uuid: "u1" }),
+      assistantLine({ ts: "2026-04-24T10:00:05Z", messageId: "B", uuid: "u2" }),
+      // ...plus 3 duplicates of A and 1 duplicate of B (4 dedup skips)
+      assistantLine({ ts: "2026-04-24T10:00:06Z", messageId: "A", uuid: "u3" }),
+      assistantLine({ ts: "2026-04-24T10:00:07Z", messageId: "A", uuid: "u4" }),
+      assistantLine({ ts: "2026-04-24T10:00:08Z", messageId: "A", uuid: "u5" }),
+      assistantLine({ ts: "2026-04-24T10:00:09Z", messageId: "B", uuid: "u6" }),
+    ];
+    await fs.writeFile(jsonl, `${lines.join("\n")}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const result = await parseClaudeIncremental({
+      projectFiles: [jsonl],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 2, "unique messages counted once");
+    assert.equal(result.dedupSkipped, 4, "duplicates counted as skipped");
+  });
+});
+
+test("parseClaudeIncremental reports zero dedupSkipped when there are no duplicates", async () => {
+  await withTempDir(async (dir) => {
+    const jsonl = path.join(dir, "session.jsonl");
+    const lines = [
+      assistantLine({ ts: "2026-04-24T09:00:00Z", messageId: "X", uuid: "u1" }),
+      assistantLine({ ts: "2026-04-24T09:00:01Z", messageId: "Y", uuid: "u2" }),
+    ];
+    await fs.writeFile(jsonl, `${lines.join("\n")}\n`, "utf8");
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const result = await parseClaudeIncremental({
+      projectFiles: [jsonl],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 2);
+    assert.equal(result.dedupSkipped, 0);
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Promotes the Claude dedup counter from a silent implementation detail into a first-class metric. parseClaudeFile / parseClaudeIncremental now return dedupSkipped alongside eventsAggregated; sync.js writes a claude_dedup_spike record to notify.debug.jsonl when the skip-ratio crosses 50%. Next time Claude Code changes its session-log write pattern (the same failure mode that caused the April 2026 incident), the user's own sync run leaves a breadcrumb before anyone has to investigate.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/rollout.js parseClaudeFile: counts duplicate message.id (or requestId) lines that are already in the cursor's seenIds set and returns dedupSkipped in the result object.
- src/lib/rollout.js parseClaudeIncremental: sums per-file dedupSkipped into a single number that callers can read from its return value.
- src/commands/sync.js: new non-blocking maybeWarnClaudeDedupSpike helper that appends a structured claude_dedup_spike entry to ~/.vibeusage/tracker/notify.debug.jsonl when events+skips ≥ 1 and skips/total > 0.5. Preserves existing sync.js control flow; pure observability.
- test/rollout-claude-dedup-metric.test.js: two cases pinning the new metric (populated on duplicates, zero without).

## Affected Modules / Contracts

- Modules touched: src/lib/rollout.js, src/commands/sync.js, test/rollout-claude-dedup-metric.test.js (new).
- Dependencies / contracts touched: parseClaudeFile / parseClaudeIncremental return-value schema gains the optional dedupSkipped field. Backward compatible (existing readers ignore unknown keys). notify.debug.jsonl gains a new event type; existing readers that filter by event name are unaffected.
- Repo sitemap evidence: not required (additive metric inside existing module boundary).

## Validation

### Automated

- npm test -> 769/769 pass locally, including the two new dedup-metric cases and all existing claude parser / dedup tests.

### Manual / smoke

- Verified by running parseClaudeIncremental against a synthetic session where two unique messages each appear with 3 and 1 duplicates: eventsAggregated=2, dedupSkipped=4. Zero-duplicate fixtures confirm skipped=0.

### Uncovered scope

- Warning threshold is a fixed 50%; not yet configurable via env var. If real-world data shows chronic high-duplicate Claude sessions we can expose VIBEUSAGE_CLAUDE_DEDUP_WARN_PCT later.
- Equivalent metric not yet added for OpenCode / Kimi / others. Same pattern can extend to them when their parsers gain dedup logic.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: keep the warning sink (notify.debug.jsonl) and the audit CLI (doctor --audit-tokens) in sync — this PR emits the breadcrumb, A2 gives the user a way to act on it.
- Delta since last review: n/a
- Depends on: Phase A1 (PR #155) and Phase A2 (PR #156) already merged.
- Known gaps / follow-ups: Phase A4 (AGENTS.md new-source checklist) next; also the suggested token-conservation CI property test.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `dedupSkipped` metric to Claude parser and emit dedup spike warning to debug log
> - `parseClaudeFile` now increments a `dedupSkipped` counter when a duplicate `dedupeId` is encountered; `parseClaudeIncremental` aggregates this across files and returns it alongside existing metrics.
> - `cmdSync` calls new `maybeWarnClaudeDedupSpike` after parsing: if `dedupSkipped / (eventsAggregated + dedupSkipped) > 0.5`, a `claude_dedup_spike` JSON line is appended to `notify.debug.jsonl` in the tracker directory.
> - Errors from the file append are silently swallowed; the warning is non-blocking and has no effect on sync behavior.
> - Two tests in [rollout-claude-dedup-metric.test.js](https://github.com/victorGPT/vibeusage/pull/157/files#diff-ac7170782655078356a5ed06a58bf4cbf55d04f17c564d5b7f419e711ac2d7a9) verify `dedupSkipped` is reported correctly with and without duplicates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cabed4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->