### PR TITLE
docs(AGENTS): new AI CLI source intake checklist (Phase A4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,37 @@ Keep this managed block so 'openspec update' can refresh the instructions.
   - `npm run ci:local`
 - 若 GitHub Actions 的 `CI` 工作流未通过，不得标记“发布完成”。
 
+# 新 AI CLI Source 接入 Checklist（强制）
+
+> 来源：2026-04-24 Claude Usage Parser Severe Under-Counting 复盘。
+> 适用：新增任何 AI CLI token usage source 的 PR（`src/lib/integrations/*.js` + `src/lib/rollout.js` 内 `normalize<Source>Usage` + `parse<Source>*` 家族）。
+
+任何新 source 接入 PR 必须同时满足以下三项，缺一不通过评审：
+
+1. **定义去重键（Dedupe Key）**
+   - parser 必须能识别同一 upstream 请求/响应的重复写入，按稳定 id 去重（优先顺序：上游 `message.id` → `request_id` → 其它跨机器唯一值）。
+   - cursor 端持久化最近 N 个已处理 id（默认 500），覆盖跨 sync 切片的重复。
+   - 没有 upstream 唯一 id 的 source，必须在 PR 描述里显式声明"无去重键"并论证为何安全（例如：源数据本身就是 append-once、或每行已是独立事件）。
+
+2. **`total_tokens` 含所有 token 通道**
+   - `normalize<Source>Usage` 返回的 `total_tokens` 必须等于 `input_tokens + cached_input_tokens + output_tokens + reasoning_output_tokens`（按 source 有的那几项求和，不能遗漏 cache_read / cache_creation / reasoning 这些"非主通道"）。
+   - 若 upstream payload 直接给 total，可 trust it；否则 fallback 公式必须覆盖全部通道。参考正例：`normalizeKimiUsage`（`src/lib/rollout.js`）。
+   - 反例（已修复）：`normalizeClaudeUsage` 与 `normalizeOpencodeTokens` 曾漏 cache_read，导致 dashboard 显示 ~5–15% 的真实消耗。
+
+3. **Real-session fixture 回归测试**
+   - 提交 `test/rollout-<source>-*.test.js` 至少覆盖三类 case：
+     - 单条消息的 total 与分通道分别正确（显式断言 `input_tokens / cached_input_tokens / output_tokens / total_tokens`）
+     - 去重键命中（同 id 出现两次应聚合一次）
+     - 游标续读（第二次 sync 只处理新增行）
+   - 以上 fixture 数字应该是**用纸笔能对账**的小数，不要依赖真实 session 大数据；否则断言会沦为 snapshot。
+   - 若 source 支持 cache_read，必须有一条"大 cache_read、小 input/output"的 fixture 确保 total 没再漏 cache（参考 `rollout-parser.test.js` 的 `Opus long-session regression` 测试）。
+
+**附加强烈建议（非强制，评审时优先鼓励）：**
+
+- Dashboard 侧 `ClientLogos.jsx` 的 `CLIENTS` 注册一条 entry，使 `source=<name>` 的数据在 UI 上可见。
+- Landing copy（`dashboard/src/content/copy.csv` 的 `landing.*` 客户端列表）一并更新。
+- CHANGELOG 条目在下一次版本 bump 时含 source 名。
+
 # 复盘协议（Retrospective Contract，CLI 无关）
 
 > 目标：让 Codex/Claude/OpenCode/Gemini 等任何 AI CLI 都走同一条复盘流程。


### PR DESCRIPTION
# What does this PR do?

- Turns the lessons from the 2026-04-24 Claude parser under-counting post-mortem into a three-point intake checklist that any future \"new AI CLI source\" PR has to satisfy. Written into AGENTS.md so Codex / Claude / OpenCode / Gemini reviewers and humans all consult the same source of truth.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- AGENTS.md gains a new section \"新 AI CLI Source 接入 Checklist（强制）\" between \"发布收尾规则\" and \"复盘协议\" with three mandatory requirements:
  1. dedupe key defined (prefer upstream message.id / request_id; cursor persists last-N ids for cross-sync duplicates)
  2. total_tokens equals the full sum of channels (specifically does not drop cache_read / cache_creation / reasoning when the source supports them)
  3. real-session fixture regression tests covering channel totals, dedupe hit, cursor resume; plus a large-cache_read case when relevant
- Adds a non-mandatory follow-up list (dashboard CLIENTS registry, landing copy, CHANGELOG) so surfaces stay aligned when a new source lands.

## Affected Modules / Contracts

- Modules touched: AGENTS.md only.
- Dependencies / contracts touched: none. Pure process documentation.
- Repo sitemap evidence: not required (single file doc edit).

## Validation

### Automated

- npm run validate:retros -> ok; retrospective index still valid.
- npm test -> 769/769 pass; docs change cannot affect runtime.

### Manual / smoke

- Spot-checked rendering of the new section in the markdown preview; links and code spans resolve.

### Uncovered scope

- Checklist currently lives only in AGENTS.md; PR template could be extended to auto-quote the three items for new-source PRs, but that's deferred.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: wording accuracy on the three mandatory items so AI and human reviewers read them consistently. Especially item 2 wording: cache_read must be included in total_tokens when upstream emits it.
- Delta since last review: n/a
- Depends on: retrospective (docs/retrospective/vibeusage/2026-04-24-claude-usage-parser-under-counting.md) already on main.
- Known gaps / follow-ups: the last open Phase item is the CI-layer token-conservation property test; once that lands the April 2026 incident has end-to-end coverage from retro → doctor → metric → checklist → property test.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mandatory AI CLI source intake checklist to AGENTS.md
> Adds a new mandatory section to [AGENTS.md](https://github.com/victorGPT/vibeusage/pull/159/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) defining requirements for integrating new AI CLI token usage sources. The checklist covers three required items: defining a deduplication key with cursor persistence, ensuring `total_tokens` includes all token channels (input, cached input, output, reasoning), and adding real-session fixture regression tests for totals, deduplication, and cursor continuation. Non-mandatory suggestions for dashboard registration, landing copy, and changelog are also included.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf5d80b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->