### PR TITLE
refactor(ops): audit-source strategy framework (Step 1/N for per-source audits)

### DIFF
--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -9,8 +9,10 @@ const { buildDoctorReport } = require("../lib/doctor");
 const {
   DEFAULT_DAYS: AUDIT_DEFAULT_DAYS,
   DEFAULT_THRESHOLD_PCT: AUDIT_DEFAULT_THRESHOLD,
-  runAudit: runClaudeAudit,
-} = require("../lib/ops/audit-claude");
+  runSourceAudit,
+  getStrategy: getAuditStrategy,
+  listRegisteredSources,
+} = require("../lib/ops/audit-source");
 
 async function cmdDoctor(argv = []) {
   const opts = parseArgs(argv);
@@ -67,9 +69,24 @@ async function cmdDoctor(argv = []) {
 }
 
 function runAuditTokens({ opts, config }) {
+  const sourceId = opts.auditSource || "claude";
+  const strategy = getAuditStrategy(sourceId);
+  if (!strategy) {
+    const registered = listRegisteredSources().join(", ");
+    const message = `unknown --source '${sourceId}'. Registered: ${registered}.`;
+    if (opts.json) {
+      process.stdout.write(`${JSON.stringify({ ok: false, error: "unknown-source", message })}\n`);
+    } else {
+      process.stderr.write(`doctor --audit-tokens: ${message}\n`);
+    }
+    process.exitCode = 2;
+    return;
+  }
+
   let result;
   try {
-    result = runClaudeAudit({
+    result = runSourceAudit({
+      strategy,
       days: opts.auditDays,
       threshold: opts.auditThreshold,
       deviceId: config.deviceId || null,
@@ -100,7 +117,7 @@ function runAuditTokens({ opts, config }) {
   }
 
   process.stdout.write(
-    `Claude token audit (last ${result.days} days, window >= ${result.windowStartIso})\n`,
+    `${result.displayName || result.source} token audit (last ${result.days} days, window >= ${result.windowStartIso})\n`,
   );
   process.stdout.write(
     `Scanned ${result.filesScanned} .jsonl files, ${formatNumber(result.usageLines)} usage lines, ` +
@@ -142,6 +159,7 @@ function parseArgs(argv) {
     auditDays: AUDIT_DEFAULT_DAYS,
     auditThreshold: AUDIT_DEFAULT_THRESHOLD,
     auditDbJson: null,
+    auditSource: "claude",
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -158,7 +176,11 @@ function parseArgs(argv) {
       if (!Number.isFinite(n) || n < 0) throw new Error(`--threshold expects a non-negative number`);
       out.auditThreshold = n;
     } else if (arg === "--db-json") out.auditDbJson = argv[++i] || null;
-    else throw new Error(`Unknown option: ${arg}`);
+    else if (arg === "--source") {
+      const raw = argv[++i];
+      if (!raw) throw new Error(`--source expects a value`);
+      out.auditSource = String(raw).trim().toLowerCase();
+    } else throw new Error(`Unknown option: ${arg}`);
   }
   return out;
 }

--- a/src/lib/ops/audit-claude.js
+++ b/src/lib/ops/audit-claude.js
@@ -3,279 +3,29 @@
 /**
  * audit-claude.js
  *
- * Reusable core for the Claude Code ground-truth audit. Walks local
- * ~/.claude/projects/*.jsonl (dedup by message.id, sum all 4 channels) and
- * compares against vibeusage_tracker_hourly totals pulled either from a
- * caller-supplied JSON blob or via the `insforge` CLI.
- *
- * Consumers:
- *   - scripts/ops/compare-claude-ground-truth.cjs (ops CLI wrapper)
- *   - src/commands/doctor.js   (`vibeusage doctor --audit-tokens`)
+ * Thin backward-compatible shim over audit-source.js. Retained so existing
+ * consumers (`scripts/ops/compare-claude-ground-truth.cjs`, older doctor
+ * imports) keep working. New code should import audit-source directly and
+ * pass the claude strategy.
  */
 
-const fs = require("node:fs");
-const os = require("node:os");
-const path = require("node:path");
-const { spawnSync } = require("node:child_process");
+const {
+  DEFAULT_DAYS,
+  DEFAULT_THRESHOLD_PCT,
+  runSourceAudit,
+} = require("./audit-source");
+const claudeStrategy = require("./sources/claude");
 
-const DEFAULT_DAYS = 14;
-const DEFAULT_THRESHOLD_PCT = 25;
-
-function runAudit({
-  days = DEFAULT_DAYS,
-  threshold = DEFAULT_THRESHOLD_PCT,
-  userId = null,
-  deviceId = null,
-  dbJsonPath = null,
-  dbJson = null,
-  projectsDir = path.join(os.homedir(), ".claude", "projects"),
-} = {}) {
-  if (!Number.isFinite(days) || days <= 0) {
-    throw new Error(`days must be a positive number, got ${days}`);
-  }
-  if (!Number.isFinite(threshold) || threshold < 0) {
-    throw new Error(`threshold must be non-negative, got ${threshold}`);
-  }
-
-  const files = listClaudeJsonl(projectsDir);
-  if (files.length === 0) {
-    return {
-      ok: false,
-      error: "no-local-sessions",
-      message: `no Claude Code session files under ${projectsDir}`,
-      rows: [],
-      maxDriftPct: 0,
-    };
-  }
-
-  const now = new Date();
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  start.setUTCDate(start.getUTCDate() - (days - 1));
-  const windowStartIso = start.toISOString();
-
-  const local = computeLocalTotals({ files, windowStartIso });
-
-  let backend;
-  if (dbJson) {
-    backend = parseDbJson(dbJson);
-  } else if (dbJsonPath) {
-    let blob;
-    try {
-      blob = fs.readFileSync(dbJsonPath, "utf8");
-    } catch (err) {
-      return {
-        ok: false,
-        error: "db-json-read-failed",
-        message: `cannot read --db-json ${dbJsonPath}: ${err?.message || err}`,
-        rows: [],
-        maxDriftPct: 0,
-      };
-    }
-    backend = parseDbJson(blob);
-  } else {
-    const resolvedUserId = userId || resolveUserIdViaInsforge({ deviceId });
-    if (!resolvedUserId) {
-      return {
-        ok: false,
-        error: "cannot-resolve-user-id",
-        message:
-          "cannot resolve user_id; pass userId explicitly, supply dbJson, or make sure `insforge` CLI is linked to the vibeusage workspace and config.deviceId is set",
-        rows: [],
-        maxDriftPct: 0,
-      };
-    }
-    const queryRes = queryDbTotalsViaInsforge({
-      userId: resolvedUserId,
-      windowStartIso,
-    });
-    if (!queryRes.ok) {
-      return { ...queryRes, rows: [], maxDriftPct: 0 };
-    }
-    backend = queryRes.byDay;
-  }
-
-  const dayKeys = Array.from(new Set([...local.byDay.keys(), ...backend.keys()])).sort();
-  const rows = [];
-  let maxDriftPct = 0;
-  for (const day of dayKeys) {
-    const truth = (local.byDay.get(day) || { total: 0 }).total;
-    const dbTotal = backend.get(day) || 0;
-    const ratio = truth > 0 ? dbTotal / truth : null;
-    const drift = ratio == null ? null : Math.abs(ratio - 1) * 100;
-    if (drift != null && drift > maxDriftPct) maxDriftPct = drift;
-    rows.push({ day, truth, db: dbTotal, ratio, driftPct: drift });
-  }
-
-  return {
-    ok: true,
-    windowStartIso,
-    days,
-    thresholdPct: threshold,
-    filesScanned: files.length,
-    usageLines: local.scanned,
-    uniqueMessages: local.uniqueMessages,
-    duplicatesSkipped: local.skippedDup,
-    rows,
-    maxDriftPct: Number(maxDriftPct.toFixed(2)),
-    exceedsThreshold: maxDriftPct > threshold,
-  };
-}
-
-function listClaudeJsonl(projectsDir) {
-  if (!fs.existsSync(projectsDir)) return [];
-  const out = [];
-  for (const entry of fs.readdirSync(projectsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const dir = path.join(projectsDir, entry.name);
-    for (const f of fs.readdirSync(dir, { withFileTypes: true })) {
-      if (!f.isFile()) continue;
-      if (!f.name.endsWith(".jsonl")) continue;
-      out.push(path.join(dir, f.name));
-    }
-  }
-  return out;
-}
-
-function computeLocalTotals({ files, windowStartIso }) {
-  const byDay = new Map();
-  const seen = new Set();
-  let scanned = 0;
-  let skippedDup = 0;
-  for (const filePath of files) {
-    let text;
-    try {
-      text = fs.readFileSync(filePath, "utf8");
-    } catch (_err) {
-      continue;
-    }
-    for (const line of text.split("\n")) {
-      if (!line || !line.includes('"usage"')) continue;
-      let obj;
-      try {
-        obj = JSON.parse(line);
-      } catch (_err) {
-        continue;
-      }
-      const ts = typeof obj?.timestamp === "string" ? obj.timestamp : null;
-      if (!ts || ts < windowStartIso) continue;
-      const day = isoDay(ts);
-      if (!day) continue;
-      const msg = obj?.message || {};
-      const usage = msg.usage || obj.usage;
-      if (!usage || typeof usage !== "object") continue;
-      const dedupeId = msg.id || obj.requestId || null;
-      scanned += 1;
-      if (dedupeId && seen.has(dedupeId)) {
-        skippedDup += 1;
-        continue;
-      }
-      if (dedupeId) seen.add(dedupeId);
-
-      const input = nonneg(usage.input_tokens);
-      const cacheCreation = nonneg(usage.cache_creation_input_tokens);
-      const cacheRead = nonneg(usage.cache_read_input_tokens);
-      const output = nonneg(usage.output_tokens);
-      const total = input + cacheCreation + cacheRead + output;
-      if (total === 0) continue;
-
-      let row = byDay.get(day);
-      if (!row) {
-        row = { total: 0, input: 0, cache_creation: 0, cache_read: 0, output: 0, messages: 0 };
-        byDay.set(day, row);
-      }
-      row.total += total;
-      row.input += input;
-      row.cache_creation += cacheCreation;
-      row.cache_read += cacheRead;
-      row.output += output;
-      row.messages += 1;
-    }
-  }
-  return { byDay, scanned, skippedDup, uniqueMessages: seen.size };
-}
-
-function isoDay(ts) {
-  const m = ts.match(/^(\d{4}-\d{2}-\d{2})/);
-  return m ? m[1] : null;
-}
-
-function nonneg(v) {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.floor(n);
-}
-
-function resolveUserIdViaInsforge({ deviceId }) {
-  if (!deviceId) return null;
-  const r = spawnSync(
-    "insforge",
-    [
-      "db",
-      "query",
-      `SELECT user_id FROM vibeusage_tracker_devices WHERE id='${deviceId}' LIMIT 1`,
-    ],
-    { encoding: "utf8" },
-  );
-  if (r.status !== 0) return null;
-  const m = (r.stdout || "").match(
-    /\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i,
-  );
-  return m ? m[1] : null;
-}
-
-function queryDbTotalsViaInsforge({ userId, windowStartIso }) {
-  const sql =
-    `SELECT DATE(hour_start) AS day, SUM(total_tokens) AS tokens ` +
-    `FROM vibeusage_tracker_hourly ` +
-    `WHERE source='claude' AND user_id='${userId}' AND hour_start >= '${windowStartIso}' ` +
-    `GROUP BY DATE(hour_start) ORDER BY day`;
-  const r = spawnSync("insforge", ["--json", "db", "query", sql], { encoding: "utf8" });
-  if (r.status !== 0) {
-    return {
-      ok: false,
-      error: "insforge-db-query-failed",
-      message:
-        `\`insforge db query\` failed (${r.status}). Run \`insforge current\` to confirm ` +
-        `the CLI is linked to the vibeusage workspace, or pass dbJson directly.`,
-    };
-  }
-  return { ok: true, byDay: parseDbJson(r.stdout) };
-}
-
-function parseDbJson(blob) {
-  let parsed;
-  if (typeof blob === "object" && blob !== null) {
-    parsed = blob;
-  } else {
-    try {
-      parsed = JSON.parse(blob);
-    } catch (err) {
-      throw new Error(`cannot parse DB JSON: ${err?.message || err}`);
-    }
-  }
-  const rows = Array.isArray(parsed)
-    ? parsed
-    : Array.isArray(parsed?.rows)
-      ? parsed.rows
-      : Array.isArray(parsed?.data)
-        ? parsed.data
-        : null;
-  if (!rows) {
-    throw new Error(
-      `DB JSON shape unexpected (need array of {day, tokens}); got ${
-        Object.keys(parsed || {}).join(",") || "(empty)"
-      }`,
-    );
-  }
-  const byDay = new Map();
-  for (const row of rows) {
-    const rawDay = row?.day ?? row?.date ?? row?.bucket_day;
-    const day = typeof rawDay === "string" ? rawDay.slice(0, 10) : null;
-    if (!day) continue;
-    const total = nonneg(row.tokens ?? row.total_tokens ?? row.total);
-    byDay.set(day, total);
-  }
-  return byDay;
+function runAudit(opts = {}) {
+  const { projectsDir, ...rest } = opts;
+  return runSourceAudit({
+    ...rest,
+    strategy: claudeStrategy,
+    // Preserve the legacy `projectsDir` option so existing callers and tests
+    // (test/doctor-audit-tokens.test.js) keep working without knowing about
+    // the new sessionRootOverride plumbing.
+    sessionRootOverride: projectsDir || rest.sessionRootOverride || null,
+  });
 }
 
 module.exports = {

--- a/src/lib/ops/audit-source.js
+++ b/src/lib/ops/audit-source.js
@@ -1,0 +1,344 @@
+"use strict";
+
+/**
+ * audit-source.js — generic ground-truth auditor.
+ *
+ * Every AI CLI source (claude, opencode, codex, gemini, kimi, ...) carries a
+ * different session-log layout and token schema, but the audit shape is the
+ * same: walk local sessions, dedup by upstream id, sum all channels per day,
+ * then compare against DB totals.
+ *
+ * This module captures that shape. Source-specific knowledge lives in
+ * src/lib/ops/sources/<id>.js as a `strategy` object (see CONTRACT below).
+ *
+ * CONTRACT (strategy shape):
+ *   {
+ *     id: "claude" | "opencode" | ...,
+ *     displayName: "Claude Code",
+ *     sessionRoot({ home, env }) -> absolute path,
+ *     walkSessions({ root }) -> string[]  // list of files/dbs to read
+ *     extractUsage(line, context) -> null | {
+ *       timestamp: "<ISO8601>",
+ *       dedupeId: "<stable id>" | null,
+ *       channels: { input, cache_creation, cache_read, output, reasoning }
+ *     }
+ *     // optional: skip the jsonl line-by-line reader if the source uses sqlite
+ *     //            and must iterate rows differently
+ *     iterateRecords(filePath) -> iterable<{ line, context }>
+ *   }
+ *
+ * Consumers:
+ *   - doctor --audit-tokens --source <id>
+ *   - scripts/ops/compare-<source>-ground-truth.cjs  (thin CLI wrappers)
+ */
+
+const fs = require("node:fs");
+const os = require("node:os");
+const { spawnSync } = require("node:child_process");
+
+const DEFAULT_DAYS = 14;
+const DEFAULT_THRESHOLD_PCT = 25;
+
+function runSourceAudit({
+  strategy,
+  days = DEFAULT_DAYS,
+  threshold = DEFAULT_THRESHOLD_PCT,
+  userId = null,
+  deviceId = null,
+  dbJsonPath = null,
+  dbJson = null,
+  home = os.homedir(),
+  env = process.env,
+  sessionRootOverride = null,
+} = {}) {
+  if (!strategy || typeof strategy !== "object") {
+    throw new Error("runSourceAudit requires a strategy object");
+  }
+  for (const key of ["id", "sessionRoot", "walkSessions", "extractUsage"]) {
+    if (typeof strategy[key] !== "function" && typeof strategy[key] !== "string") {
+      throw new Error(`strategy.${key} is required`);
+    }
+  }
+  if (!Number.isFinite(days) || days <= 0) {
+    throw new Error(`days must be a positive number, got ${days}`);
+  }
+  if (!Number.isFinite(threshold) || threshold < 0) {
+    throw new Error(`threshold must be non-negative, got ${threshold}`);
+  }
+
+  const root = sessionRootOverride || strategy.sessionRoot({ home, env });
+  const files = strategy.walkSessions({ root });
+  if (!files || files.length === 0) {
+    return {
+      ok: false,
+      error: "no-local-sessions",
+      source: strategy.id,
+      message: `no local sessions for source=${strategy.id} under ${root}`,
+      rows: [],
+      maxDriftPct: 0,
+    };
+  }
+
+  const now = new Date();
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+  const windowStartIso = start.toISOString();
+
+  const local = computeLocalTotals({ files, windowStartIso, strategy });
+
+  let backend;
+  if (dbJson) {
+    try {
+      backend = parseDbJson(dbJson);
+    } catch (err) {
+      return { ok: false, error: "db-json-parse", source: strategy.id, message: err.message, rows: [], maxDriftPct: 0 };
+    }
+  } else if (dbJsonPath) {
+    let blob;
+    try {
+      blob = fs.readFileSync(dbJsonPath, "utf8");
+    } catch (err) {
+      return {
+        ok: false,
+        error: "db-json-read-failed",
+        source: strategy.id,
+        message: `cannot read ${dbJsonPath}: ${err?.message || err}`,
+        rows: [],
+        maxDriftPct: 0,
+      };
+    }
+    backend = parseDbJson(blob);
+  } else {
+    const resolvedUserId = userId || resolveUserIdViaInsforge({ deviceId });
+    if (!resolvedUserId) {
+      return {
+        ok: false,
+        error: "cannot-resolve-user-id",
+        source: strategy.id,
+        message:
+          "cannot resolve user_id; pass userId explicitly, supply dbJson, or make sure `insforge` CLI is linked to the vibeusage workspace and config.deviceId is set",
+        rows: [],
+        maxDriftPct: 0,
+      };
+    }
+    const queryRes = queryDbTotalsViaInsforge({
+      userId: resolvedUserId,
+      source: strategy.id,
+      windowStartIso,
+    });
+    if (!queryRes.ok) {
+      return { ...queryRes, source: strategy.id, rows: [], maxDriftPct: 0 };
+    }
+    backend = queryRes.byDay;
+  }
+
+  const dayKeys = Array.from(new Set([...local.byDay.keys(), ...backend.keys()])).sort();
+  const rows = [];
+  let maxDriftPct = 0;
+  for (const day of dayKeys) {
+    const truth = (local.byDay.get(day) || { total: 0 }).total;
+    const dbTotal = backend.get(day) || 0;
+    const ratio = truth > 0 ? dbTotal / truth : null;
+    const drift = ratio == null ? null : Math.abs(ratio - 1) * 100;
+    if (drift != null && drift > maxDriftPct) maxDriftPct = drift;
+    rows.push({ day, truth, db: dbTotal, ratio, driftPct: drift });
+  }
+
+  return {
+    ok: true,
+    source: strategy.id,
+    displayName: strategy.displayName || strategy.id,
+    windowStartIso,
+    days,
+    thresholdPct: threshold,
+    filesScanned: files.length,
+    usageLines: local.scanned,
+    uniqueMessages: local.uniqueIds,
+    duplicatesSkipped: local.skippedDup,
+    rows,
+    maxDriftPct: Number(maxDriftPct.toFixed(2)),
+    exceedsThreshold: maxDriftPct > threshold,
+  };
+}
+
+function computeLocalTotals({ files, windowStartIso, strategy }) {
+  const byDay = new Map();
+  const seen = new Set();
+  let scanned = 0;
+  let skippedDup = 0;
+
+  const records = typeof strategy.iterateRecords === "function"
+    ? strategy.iterateRecords
+    : defaultIterateRecords;
+
+  for (const filePath of files) {
+    for (const { line, context } of records(filePath)) {
+      const extracted = strategy.extractUsage(line, context);
+      if (!extracted) continue;
+      const { timestamp, dedupeId, channels } = extracted;
+      if (!timestamp || timestamp < windowStartIso) continue;
+      const day = isoDay(timestamp);
+      if (!day) continue;
+
+      scanned += 1;
+      if (dedupeId && seen.has(dedupeId)) {
+        skippedDup += 1;
+        continue;
+      }
+      if (dedupeId) seen.add(dedupeId);
+
+      const input = nonneg(channels.input);
+      const cacheCreation = nonneg(channels.cache_creation);
+      const cacheRead = nonneg(channels.cache_read);
+      const output = nonneg(channels.output);
+      const reasoning = nonneg(channels.reasoning);
+      const total = input + cacheCreation + cacheRead + output + reasoning;
+      if (total === 0) continue;
+
+      let row = byDay.get(day);
+      if (!row) {
+        row = {
+          total: 0,
+          input: 0,
+          cache_creation: 0,
+          cache_read: 0,
+          output: 0,
+          reasoning: 0,
+          messages: 0,
+        };
+        byDay.set(day, row);
+      }
+      row.total += total;
+      row.input += input;
+      row.cache_creation += cacheCreation;
+      row.cache_read += cacheRead;
+      row.output += output;
+      row.reasoning += reasoning;
+      row.messages += 1;
+    }
+  }
+
+  return { byDay, scanned, skippedDup, uniqueIds: seen.size };
+}
+
+function* defaultIterateRecords(filePath) {
+  let text;
+  try {
+    text = fs.readFileSync(filePath, "utf8");
+  } catch (_err) {
+    return;
+  }
+  for (const line of text.split("\n")) {
+    if (!line) continue;
+    yield { line, context: { filePath } };
+  }
+}
+
+function isoDay(ts) {
+  if (typeof ts !== "string") return null;
+  const m = ts.match(/^(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : null;
+}
+
+function nonneg(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+function resolveUserIdViaInsforge({ deviceId }) {
+  if (!deviceId) return null;
+  const r = spawnSync(
+    "insforge",
+    [
+      "db",
+      "query",
+      `SELECT user_id FROM vibeusage_tracker_devices WHERE id='${deviceId}' LIMIT 1`,
+    ],
+    { encoding: "utf8" },
+  );
+  if (r.status !== 0) return null;
+  const m = (r.stdout || "").match(
+    /\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i,
+  );
+  return m ? m[1] : null;
+}
+
+function queryDbTotalsViaInsforge({ userId, source, windowStartIso }) {
+  const sql =
+    `SELECT DATE(hour_start) AS day, SUM(total_tokens) AS tokens ` +
+    `FROM vibeusage_tracker_hourly ` +
+    `WHERE source='${source}' AND user_id='${userId}' AND hour_start >= '${windowStartIso}' ` +
+    `GROUP BY DATE(hour_start) ORDER BY day`;
+  const r = spawnSync("insforge", ["--json", "db", "query", sql], { encoding: "utf8" });
+  if (r.status !== 0) {
+    return {
+      ok: false,
+      error: "insforge-db-query-failed",
+      message:
+        `\`insforge db query\` failed (${r.status}). Run \`insforge current\` to confirm ` +
+        `the CLI is linked to the vibeusage workspace, or pass dbJson directly.`,
+    };
+  }
+  return { ok: true, byDay: parseDbJson(r.stdout) };
+}
+
+function parseDbJson(blob) {
+  let parsed;
+  if (typeof blob === "object" && blob !== null) {
+    parsed = blob;
+  } else {
+    try {
+      parsed = JSON.parse(blob);
+    } catch (err) {
+      throw new Error(`cannot parse DB JSON: ${err?.message || err}`);
+    }
+  }
+  const rows = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : Array.isArray(parsed?.data)
+        ? parsed.data
+        : null;
+  if (!rows) {
+    throw new Error(
+      `DB JSON shape unexpected (need array of {day, tokens}); got ${
+        Object.keys(parsed || {}).join(",") || "(empty)"
+      }`,
+    );
+  }
+  const byDay = new Map();
+  for (const row of rows) {
+    const rawDay = row?.day ?? row?.date ?? row?.bucket_day;
+    const day = typeof rawDay === "string" ? rawDay.slice(0, 10) : null;
+    if (!day) continue;
+    const total = nonneg(row.tokens ?? row.total_tokens ?? row.total);
+    byDay.set(day, total);
+  }
+  return byDay;
+}
+
+// Registry for doctor --audit-tokens --source routing.
+// Register new strategies as they land in sources/<id>.js.
+function getStrategy(id) {
+  switch (id) {
+    case "claude":
+      // eslint-disable-next-line global-require
+      return require("./sources/claude");
+    default:
+      return null;
+  }
+}
+
+function listRegisteredSources() {
+  return ["claude"];
+}
+
+module.exports = {
+  DEFAULT_DAYS,
+  DEFAULT_THRESHOLD_PCT,
+  runSourceAudit,
+  getStrategy,
+  listRegisteredSources,
+};

--- a/src/lib/ops/sources/claude.js
+++ b/src/lib/ops/sources/claude.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+module.exports = {
+  id: "claude",
+  displayName: "Claude Code",
+  sessionRoot({ home }) {
+    return path.join(home, ".claude", "projects");
+  },
+  walkSessions({ root }) {
+    if (!fs.existsSync(root)) return [];
+    const out = [];
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const dir = path.join(root, entry.name);
+      for (const f of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (!f.isFile()) continue;
+        if (!f.name.endsWith(".jsonl")) continue;
+        out.push(path.join(dir, f.name));
+      }
+    }
+    return out;
+  },
+  extractUsage(line) {
+    if (!line || !line.includes('"usage"')) return null;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch (_err) {
+      return null;
+    }
+    const msg = obj?.message || {};
+    const usage = msg.usage || obj.usage;
+    if (!usage || typeof usage !== "object") return null;
+    const timestamp = typeof obj.timestamp === "string" ? obj.timestamp : null;
+    if (!timestamp) return null;
+
+    return {
+      timestamp,
+      dedupeId: msg.id || obj.requestId || null,
+      channels: {
+        input: usage.input_tokens,
+        cache_creation: usage.cache_creation_input_tokens,
+        cache_read: usage.cache_read_input_tokens,
+        output: usage.output_tokens,
+        reasoning: 0,
+      },
+    };
+  },
+};

--- a/test/audit-source-framework.test.js
+++ b/test/audit-source-framework.test.js
@@ -1,0 +1,131 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const {
+  runSourceAudit,
+  getStrategy,
+  listRegisteredSources,
+} = require("../src/lib/ops/audit-source");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-audit-framework-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+test("getStrategy returns the claude strategy and null for unknown ids", () => {
+  const claude = getStrategy("claude");
+  assert.ok(claude && claude.id === "claude");
+  assert.equal(typeof claude.sessionRoot, "function");
+  assert.equal(typeof claude.walkSessions, "function");
+  assert.equal(typeof claude.extractUsage, "function");
+
+  assert.equal(getStrategy("does-not-exist"), null);
+});
+
+test("listRegisteredSources reports at least claude", () => {
+  const ids = listRegisteredSources();
+  assert.ok(Array.isArray(ids));
+  assert.ok(ids.includes("claude"));
+});
+
+test("runSourceAudit accepts a synthetic strategy and honors its extractUsage shape", async () => {
+  await withTempDir(async (dir) => {
+    const file = path.join(dir, "fake.log");
+    // Two unique events + 1 duplicate of the first
+    await fs.writeFile(
+      file,
+      [
+        JSON.stringify({ id: "A", ts: "2099-01-01T10:00:00Z", i: 10, cr: 90, o: 5 }),
+        JSON.stringify({ id: "A", ts: "2099-01-01T10:00:02Z", i: 10, cr: 90, o: 5 }),
+        JSON.stringify({ id: "B", ts: "2099-01-01T10:05:00Z", i: 1, cr: 2, o: 3 }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const strategy = {
+      id: "fake",
+      displayName: "Fake Source",
+      sessionRoot() {
+        return dir;
+      },
+      walkSessions({ root }) {
+        return [path.join(root, "fake.log")];
+      },
+      extractUsage(line) {
+        if (!line) return null;
+        const obj = JSON.parse(line);
+        return {
+          timestamp: obj.ts,
+          dedupeId: obj.id,
+          channels: {
+            input: obj.i,
+            cache_creation: 0,
+            cache_read: obj.cr,
+            output: obj.o,
+            reasoning: 0,
+          },
+        };
+      },
+    };
+
+    // 2099-01-01 is inside a window of 365 days -> include it. Build a DB JSON
+    // that matches the expected truth so drift is 0%.
+    // Truth: A = 10+90+5 = 105; B = 1+2+3 = 6; total = 111.
+    const dbJson = JSON.stringify([{ day: "2099-01-01", tokens: 111 }]);
+
+    const res = runSourceAudit({
+      strategy,
+      days: Math.ceil(
+        (new Date("2099-01-02") - new Date()) / (24 * 3600 * 1000),
+      ),
+      threshold: 5,
+      dbJson,
+    });
+
+    assert.equal(res.ok, true);
+    assert.equal(res.source, "fake");
+    assert.equal(res.displayName, "Fake Source");
+    assert.equal(res.uniqueMessages, 2, "dedupeId collapses to 2 unique ids");
+    assert.equal(res.duplicatesSkipped, 1);
+    const row = res.rows.find((r) => r.day === "2099-01-01");
+    assert.ok(row, "day row present");
+    assert.equal(row.truth, 111);
+    assert.equal(row.db, 111);
+    assert.equal(res.exceedsThreshold, false);
+  });
+});
+
+test("runSourceAudit rejects when strategy is missing required callables", () => {
+  assert.throws(() => runSourceAudit({}), /strategy/i);
+  assert.throws(
+    () =>
+      runSourceAudit({
+        strategy: { id: "x", sessionRoot: () => "/tmp" },
+        dbJson: "[]",
+      }),
+    /walkSessions|extractUsage/,
+  );
+});
+
+test("runSourceAudit returns no-local-sessions error when walkSessions yields nothing", async () => {
+  await withTempDir(async (dir) => {
+    const strategy = {
+      id: "empty",
+      sessionRoot: () => dir,
+      walkSessions: () => [],
+      extractUsage: () => null,
+    };
+    const res = runSourceAudit({ strategy, dbJson: "[]" });
+    assert.equal(res.ok, false);
+    assert.equal(res.error, "no-local-sessions");
+    assert.equal(res.source, "empty");
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Step 1 of the per-source ground-truth audit rollout. Splits the Claude-specific auditor into a generic runner (runSourceAudit) plus a strategy registry so each upcoming source (OpenCode, Codex, Gemini, Kimi, Every-Code, Hermes, OpenClaw) can plug in its own session walker + usage extractor without forking the 300-line audit logic.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/ops/audit-source.js (new): runSourceAudit({ strategy, days, threshold, userId, deviceId, dbJsonPath, dbJson, sessionRootOverride }). Owns dedup + day bucketing + DB comparison. Strategies implement { id, displayName, sessionRoot({home,env}), walkSessions({root}), extractUsage(line,context), [iterateRecords(filePath)] }. getStrategy / listRegisteredSources expose the routing surface.
- src/lib/ops/sources/claude.js (new): claude strategy extracted from the old audit-claude.js; walks ~/.claude/projects/*.jsonl, dedupes by message.id / requestId, returns four channels.
- src/lib/ops/audit-claude.js: thinned to a backward-compatible shim over the new framework. Preserves the legacy `projectsDir` option by translating it to sessionRootOverride so existing tests keep passing.
- src/commands/doctor.js: --audit-tokens gains --source <id>. Unknown source exits 2 with "Registered: <list>".
- test/audit-source-framework.test.js (new, 5 cases): strategy routing, synthetic strategy shape verification, missing-callables rejection, empty walkSessions path.

## Affected Modules / Contracts

- Modules touched: src/lib/ops/audit-source.js (new), src/lib/ops/sources/claude.js (new), src/lib/ops/audit-claude.js, src/commands/doctor.js, test/audit-source-framework.test.js (new).
- Dependencies / contracts touched: audit-claude.js runAudit signature preserved (options spread + projectsDir legacy passthrough). scripts/ops/compare-claude-ground-truth.cjs continues to work unchanged.
- Repo sitemap evidence: not required (internal refactor).

## Validation

### Automated

- npm test -> 783/783 pass locally, including 5 new framework cases and all prior doctor / dedup / Claude tests.
- Live smoke: node bin/tracker.js doctor --audit-tokens --source claude --days 3 reads 158 jsonl files and produces the expected table. node bin/tracker.js doctor --audit-tokens --source unknown exits 2 with "Registered: claude." confirming routing + unknown handling.

### Manual / smoke

- audit-claude.js shim still works for the legacy ops script (scripts/ops/compare-claude-ground-truth.cjs) via require semantics.

### Uncovered scope

- This PR only registers the claude strategy. Steps 2–6 land sources/{opencode,codex,gemini,kimi,every-code}.js plus matching tests as follow-up PRs.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: the strategy contract in audit-source.js top-of-file doc, since Steps 2-6 will follow it verbatim.
- Delta since last review: n/a
- Depends on: Phase A series already merged (#155 / #156 / #157 / #159 / #160).
- Known gaps / follow-ups: PR-B (OpenCode), PR-C (Codex + Every-Code), PR-D (Gemini), PR-E (Kimi), PR-F (Hermes / OpenClaw ledger auditor — separate shape).

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor token audit into a pluggable source strategy framework for `doctor --audit-tokens`
> - Introduces [audit-source.js](https://github.com/victorGPT/vibeusage/pull/161/files#diff-8a0f530e1e6f691c26453dd52ddecda97cacb181c4dbc64721f5d056845fb0a7) as a generic, source-agnostic audit runner, replacing the Claude-specific implementation in [audit-claude.js](https://github.com/victorGPT/vibeusage/pull/161/files#diff-4f39a6bb3185ca783f7f0b0229d32ee47ebfd379793744bc1c221a7e4ffe52e2) with a thin backward-compatible shim.
> - Adds a strategy registry (`getStrategy`, `listRegisteredSources`) so new token sources can be plugged in; the Claude strategy is extracted to [sources/claude.js](https://github.com/victorGPT/vibeusage/pull/161/files#diff-916d43022d33f21926df38d6c67b73d1a2343f2b586095bf88c37318b13bd515).
> - `doctor --audit-tokens` now accepts `--source <id>` (defaulting to `claude`); an unknown source exits with code 2 and prints the registered source list.
> - Report headers now reflect the selected source's `displayName` instead of the hardcoded string `'Claude'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f6518a5. 4 files reviewed, 4 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->