### PR TITLE
feat(audit): opencode strategy (Step 2/N)

### DIFF
--- a/src/lib/ops/audit-source.js
+++ b/src/lib/ops/audit-source.js
@@ -326,13 +326,16 @@ function getStrategy(id) {
     case "claude":
       // eslint-disable-next-line global-require
       return require("./sources/claude");
+    case "opencode":
+      // eslint-disable-next-line global-require
+      return require("./sources/opencode");
     default:
       return null;
   }
 }
 
 function listRegisteredSources() {
-  return ["claude"];
+  return ["claude", "opencode"];
 }
 
 module.exports = {

--- a/src/lib/ops/sources/opencode.js
+++ b/src/lib/ops/sources/opencode.js
@@ -1,0 +1,100 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+/**
+ * OpenCode audit strategy.
+ *
+ * OpenCode persists one JSON per assistant message under
+ *   ~/.local/share/opencode/storage/message/ses_<session>/msg_<id>.json
+ * Each file looks like:
+ *   {
+ *     role: "assistant",
+ *     id: "msg_...",
+ *     modelID: "...",
+ *     tokens: { input, output, reasoning, cache: { read, write } },
+ *     time: { created, completed }
+ *   }
+ *
+ * Channel mapping matches src/lib/rollout.js normalizeOpencodeTokens so the
+ * audit's truth sum equals what the parser emits into vibeusage_tracker_hourly
+ * (post PR #153, which added cache.read to total):
+ *     total = input + cache.write + cache.read + output + reasoning
+ *
+ * Notes:
+ *   - OPENCODE_HOME / XDG_DATA_HOME env vars override the default root (matches
+ *     the same logic used by src/commands/sync.js).
+ *   - Only assistant messages carry tokens; user messages return null from
+ *     extractUsage so the generic runner skips them.
+ *   - New OpenCode installs may persist into opencode.db (sqlite) instead of
+ *     these JSON files. The audit reports no-local-sessions in that case;
+ *     users can dump the same rows to a JSON file and feed --db-json to
+ *     compare via the backend path.
+ */
+
+module.exports = {
+  id: "opencode",
+  displayName: "OpenCode",
+  sessionRoot({ home, env }) {
+    const xdg = env.XDG_DATA_HOME || path.join(home, ".local", "share");
+    const opencodeHome = env.OPENCODE_HOME || path.join(xdg, "opencode");
+    return path.join(opencodeHome, "storage", "message");
+  },
+  walkSessions({ root }) {
+    if (!fs.existsSync(root)) return [];
+    const out = [];
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const dir = path.join(root, entry.name);
+      for (const f of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (!f.isFile()) continue;
+        if (!f.name.startsWith("msg_") || !f.name.endsWith(".json")) continue;
+        out.push(path.join(dir, f.name));
+      }
+    }
+    return out;
+  },
+  // OpenCode is one JSON per file (not JSONL). Yield the whole file body as a
+  // single "line" so extractUsage can JSON.parse it uniformly with the
+  // line-based contract.
+  *iterateRecords(filePath) {
+    let text;
+    try {
+      text = fs.readFileSync(filePath, "utf8");
+    } catch (_err) {
+      return;
+    }
+    if (!text.trim()) return;
+    yield { line: text, context: { filePath } };
+  },
+  extractUsage(line) {
+    if (!line) return null;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch (_err) {
+      return null;
+    }
+    if (obj?.role !== "assistant") return null;
+    const tokens = obj.tokens;
+    if (!tokens || typeof tokens !== "object") return null;
+    const completed = obj?.time?.completed;
+    const created = obj?.time?.created;
+    const epochMs = typeof completed === "number" ? completed : typeof created === "number" ? created : null;
+    if (!epochMs || !Number.isFinite(epochMs)) return null;
+
+    const cache = tokens.cache && typeof tokens.cache === "object" ? tokens.cache : {};
+    return {
+      timestamp: new Date(epochMs).toISOString(),
+      dedupeId: typeof obj.id === "string" && obj.id ? obj.id : null,
+      channels: {
+        input: tokens.input,
+        cache_creation: cache.write,
+        cache_read: cache.read,
+        output: tokens.output,
+        reasoning: tokens.reasoning,
+      },
+    };
+  },
+};

--- a/test/audit-opencode-strategy.test.js
+++ b/test/audit-opencode-strategy.test.js
@@ -1,0 +1,116 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const {
+  runSourceAudit,
+  getStrategy,
+} = require("../src/lib/ops/audit-source");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-audit-opencode-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function writeMsg(storageRoot, sessionId, msgId, body) {
+  const dir = path.join(storageRoot, "message", sessionId);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${msgId}.json`), JSON.stringify(body), "utf8");
+}
+
+function assistantMsg({ id, ts, input = 0, output = 0, reasoning = 0, cacheRead = 0, cacheWrite = 0 }) {
+  return {
+    role: "assistant",
+    id,
+    modelID: "gpt-5",
+    tokens: {
+      input,
+      output,
+      reasoning,
+      cache: { read: cacheRead, write: cacheWrite },
+    },
+    time: { created: ts - 1000, completed: ts },
+  };
+}
+
+test("audit-source registers the opencode strategy", () => {
+  const s = getStrategy("opencode");
+  assert.ok(s && s.id === "opencode");
+  assert.equal(typeof s.sessionRoot, "function");
+  assert.equal(typeof s.walkSessions, "function");
+  assert.equal(typeof s.extractUsage, "function");
+  assert.equal(typeof s.iterateRecords, "function");
+});
+
+test("opencode strategy sums all channels (input + cache.write + cache.read + output + reasoning)", async () => {
+  await withTempDir(async (dir) => {
+    // OpenCode layout: <dir>/opencode/storage/message/ses_X/msg_*.json
+    const opencodeHome = path.join(dir, "opencode");
+    const storageRoot = path.join(opencodeHome, "storage");
+
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yIso = y.toISOString().slice(0, 10);
+    const ts = y.getTime() + 10 * 3600 * 1000; // 10:00 UTC yesterday
+
+    // msg_A: input=100, cache.write=50, cache.read=1000, output=10, reasoning=5 -> total 1165
+    await writeMsg(storageRoot, "ses_A", "msg_aaa", assistantMsg({
+      id: "msg_aaa", ts, input: 100, output: 10, reasoning: 5, cacheRead: 1000, cacheWrite: 50,
+    }));
+    // duplicate of msg_A (same id, different file) -> skipped
+    await writeMsg(storageRoot, "ses_A", "msg_aaa2", assistantMsg({
+      id: "msg_aaa", ts: ts + 1000, input: 100, output: 10, reasoning: 5, cacheRead: 1000, cacheWrite: 50,
+    }));
+    // msg_B: another real message -> counted
+    await writeMsg(storageRoot, "ses_A", "msg_bbb", assistantMsg({
+      id: "msg_bbb", ts: ts + 5000, input: 1, output: 2, reasoning: 3, cacheRead: 4, cacheWrite: 5,
+    }));
+    // user message -> skipped by role filter
+    await writeMsg(storageRoot, "ses_A", "msg_user", { role: "user", id: "msg_user", time: { completed: ts } });
+
+    const dbJson = JSON.stringify([{ day: yIso, tokens: 1165 + (1 + 2 + 3 + 4 + 5) }]);
+
+    const strategy = getStrategy("opencode");
+    const result = runSourceAudit({
+      strategy,
+      days: 3,
+      threshold: 5,
+      dbJson,
+      // force the strategy to look inside our temp dir
+      home: dir,
+      env: { OPENCODE_HOME: opencodeHome },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.source, "opencode");
+    assert.equal(result.uniqueMessages, 2, "two unique ids (msg_aaa + msg_bbb)");
+    assert.equal(result.duplicatesSkipped, 1);
+    const row = result.rows.find((r) => r.day === yIso);
+    assert.ok(row, "day row present");
+    assert.equal(row.truth, 1165 + 15);
+    assert.equal(row.db, 1165 + 15);
+    assert.equal(result.exceedsThreshold, false);
+  });
+});
+
+test("opencode strategy reports no-local-sessions when storage dir is empty", async () => {
+  await withTempDir(async (dir) => {
+    const result = runSourceAudit({
+      strategy: getStrategy("opencode"),
+      days: 3,
+      threshold: 10,
+      dbJson: "[]",
+      home: dir,
+      env: { OPENCODE_HOME: path.join(dir, "nothing-here") },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "no-local-sessions");
+    assert.equal(result.source, "opencode");
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Step 2 of the per-source ground-truth audit rollout. Adds an OpenCode strategy on top of the Step 1 framework so \`vibeusage doctor --audit-tokens --source opencode\` walks the local storage/message/ses_*/msg_*.json files, dedupes by message id, and compares channel sums against vibeusage_tracker_hourly for source=opencode. OpenCode shares the same cache_read bug class that hit Claude in April 2026, so this lets users / maintainers check their OpenCode numbers the same way.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/ops/sources/opencode.js (new): strategy with a custom iterateRecords so the framework can handle OpenCode's one-JSON-per-file layout, plus an assistant-role filter. Honors OPENCODE_HOME / XDG_DATA_HOME env vars the same way src/commands/sync.js does. Channel mapping matches normalizeOpencodeTokens: total = input + cache.write + cache.read + output + reasoning.
- src/lib/ops/audit-source.js: register opencode in getStrategy and listRegisteredSources.
- test/audit-opencode-strategy.test.js (3 cases): strategy registration, channel-sum correctness with a synthetic ses_A dir (dup id + user-role filter verified), no-local-sessions when storage dir is missing.

## Affected Modules / Contracts

- Modules touched: src/lib/ops/sources/opencode.js (new), src/lib/ops/audit-source.js, test/audit-opencode-strategy.test.js (new).
- Dependencies / contracts touched: none. New strategy is additive to the registry; existing --source claude behavior unchanged.
- Repo sitemap evidence: not required (additive strategy inside existing ops boundary).

## Validation

### Automated

- npm test -> 786/786 pass locally (783 existing + 3 new).

### Manual / smoke

- node bin/tracker.js doctor --audit-tokens --source opencode --days 365 --threshold 1000 on the maintainer machine: 687 message files scanned, several days with 20-87% drift visible in the window 2026-01 (same cache_read-era under-count we already saw on Claude). Confirms the strategy reads real data and the generic runner routes correctly.
- node bin/tracker.js doctor --audit-tokens --source unknown still exits 2 with \"Registered: claude, opencode\", confirming the registry list is up to date.

### Uncovered scope

- OpenCode installs that store messages only in opencode.db (sqlite) will see no-local-sessions. Those users can dump rows to JSON and feed --db-json the same way maintainers do for the maintainer CLI path; a future PR could add a sqlite-reading iterateRecords.
- Historical OpenCode buckets per device still reflect the pre-0.5.0 under-count. Same backfill recipe as Claude applies: scrub cursor for .jsonl + bucket + opencode sqlite state, then \`vibeusage sync --drain\`.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: confirm the channel mapping stays in lock-step with src/lib/rollout.js normalizeOpencodeTokens. If either side changes, the audit lies.
- Delta since last review: n/a
- Depends on: PR #161 already merged.
- Known gaps / follow-ups: PR-C (Codex + Every-Code), PR-D (Gemini), PR-E (Kimi), PR-F (Hermes / OpenClaw ledger auditor).

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenCode audit strategy to discover and parse local session message files
> - Adds a new `opencode` audit strategy in [sources/opencode.js](https://github.com/victorGPT/vibeusage/pull/162/files#diff-630fead9846bd7e77ed88eeb221a4a7646885512dd5e1c86142d98a101f74e60) that locates per-message JSON files under `OPENCODE_HOME` (or `XDG_DATA_HOME` fallback), walks session directories for `msg_*.json` files, and extracts token usage from assistant-role messages.
> - Maps token channels to `input`, `cache.write`, `cache.read`, `output`, and `reasoning`; dedupes by message `id`; converts epoch-ms timestamps to ISO strings.
> - Registers `"opencode"` in `listRegisteredSources()` and adds a `getStrategy("opencode")` route in [audit-source.js](https://github.com/victorGPT/vibeusage/pull/162/files#diff-8a0f530e1e6f691c26453dd52ddecda97cacb181c4dbc64721f5d056845fb0a7).
> - Tests in [audit-opencode-strategy.test.js](https://github.com/victorGPT/vibeusage/pull/162/files#diff-b2d1d5efad671a0080bc3bc997f31c9adb691b44e8fe2bca60722de8b619fefc) cover channel summation, dedupe, user-role skipping, and the `no-local-sessions` error path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efdd693.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->