### PR TITLE
feat(audit): codex + every-code strategies (Step 3)

### DIFF
--- a/src/lib/ops/audit-source.js
+++ b/src/lib/ops/audit-source.js
@@ -67,7 +67,11 @@ function runSourceAudit({
   }
 
   const root = sessionRootOverride || strategy.sessionRoot({ home, env });
-  const files = strategy.walkSessions({ root });
+  const now = new Date();
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+  const windowStartIso = start.toISOString();
+  const files = strategy.walkSessions({ root, windowStartIso });
   if (!files || files.length === 0) {
     return {
       ok: false,
@@ -78,11 +82,6 @@ function runSourceAudit({
       maxDriftPct: 0,
     };
   }
-
-  const now = new Date();
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  start.setUTCDate(start.getUTCDate() - (days - 1));
-  const windowStartIso = start.toISOString();
 
   const local = computeLocalTotals({ files, windowStartIso, strategy });
 
@@ -329,13 +328,19 @@ function getStrategy(id) {
     case "opencode":
       // eslint-disable-next-line global-require
       return require("./sources/opencode");
+    case "codex":
+      // eslint-disable-next-line global-require
+      return require("./sources/codex");
+    case "every-code":
+      // eslint-disable-next-line global-require
+      return require("./sources/every-code");
     default:
       return null;
   }
 }
 
 function listRegisteredSources() {
-  return ["claude", "opencode"];
+  return ["claude", "opencode", "codex", "every-code"];
 }
 
 module.exports = {

--- a/src/lib/ops/sources/_rollout-base.js
+++ b/src/lib/ops/sources/_rollout-base.js
@@ -1,0 +1,203 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+/**
+ * Shared strategy factory for Codex-family rollout audits.
+ *
+ * Codex and Every-Code write identical rollout .jsonl streams into
+ * <home>/<subdir>/sessions/<YYYY>/<MM>/<DD>/rollout-*.jsonl. The directory
+ * layout is the only difference (CODEX_HOME / CODE_HOME). Token accounting
+ * semantics differ from Claude's in two important ways:
+ *
+ *   1. Token events are `payload.type === "token_count"` rows that carry
+ *      `info.total_token_usage` (cumulative) and `info.last_token_usage`
+ *      (delta for the latest API call). Events with `info: null` are
+ *      rate-limit-only pings and must be ignored.
+ *
+ *   2. `input_tokens` already includes cached input, and `output_tokens`
+ *      already includes `reasoning_output_tokens`. Naively summing all five
+ *      channels double-counts. The authoritative per-turn total is simply
+ *      `total_tokens` on the upstream payload, which is what normalizeUsage
+ *      passes through to the DB unchanged.
+ *
+ * Approach:
+ *   - walkSessions prunes by YYYY/MM/DD directories before hitting the jsonl
+ *     files so the auditor does not scan all ~240K Codex rollouts just to
+ *     look at the last 14 days.
+ *   - iterateRecords is stateful per file: it tracks the last seen
+ *     total_token_usage and yields a synthetic delta object whenever the
+ *     total changes (uses last_token_usage when available, otherwise the
+ *     total_prev diff). Duplicate token_count rows with identical totals are
+ *     skipped; that mirrors parseRolloutFile's pickDelta logic.
+ *   - extractUsage routes the authoritative `total_tokens` number into the
+ *     `output` channel and zeroes the rest. The framework sums the five
+ *     channels to compute row.truth, so putting the whole total into one
+ *     channel is a deliberate trick that keeps day totals correct without
+ *     exposing Codex's overlapping channel semantics through the generic
+ *     contract.
+ */
+
+function makeRolloutStrategy({ id, displayName, envKey, defaultSubdir }) {
+  return {
+    id,
+    displayName,
+    sessionRoot({ home, env }) {
+      const base = (env && env[envKey]) || path.join(home, defaultSubdir);
+      return path.join(base, "sessions");
+    },
+    walkSessions({ root, windowStartIso }) {
+      if (!fs.existsSync(root)) return [];
+      // Rollout events written on day N can carry timestamps from day N-1
+      // (sessions straddle midnight). Keep directories starting one day
+      // before the window so we do not drop boundary events.
+      const bufferDay = shiftIsoDay(windowStartIso, -1);
+      const out = [];
+      for (const year of safeReadDirSync(root)) {
+        if (!year.isDirectory() || !/^\d{4}$/.test(year.name)) continue;
+        const yearDir = path.join(root, year.name);
+        for (const month of safeReadDirSync(yearDir)) {
+          if (!month.isDirectory() || !/^\d{2}$/.test(month.name)) continue;
+          const monthDir = path.join(yearDir, month.name);
+          for (const day of safeReadDirSync(monthDir)) {
+            if (!day.isDirectory() || !/^\d{2}$/.test(day.name)) continue;
+            if (bufferDay) {
+              const dayIso = `${year.name}-${month.name}-${day.name}`;
+              if (dayIso < bufferDay) continue;
+            }
+            const dayDir = path.join(monthDir, day.name);
+            for (const f of safeReadDirSync(dayDir)) {
+              if (!f.isFile()) continue;
+              if (!f.name.startsWith("rollout-") || !f.name.endsWith(".jsonl")) continue;
+              out.push(path.join(dayDir, f.name));
+            }
+          }
+        }
+      }
+      return out;
+    },
+    *iterateRecords(filePath) {
+      let text;
+      try {
+        text = fs.readFileSync(filePath, "utf8");
+      } catch (_err) {
+        return;
+      }
+      if (!text) return;
+      let prevTotal = null;
+      for (const line of text.split("\n")) {
+        if (!line || !line.includes("token_count")) continue;
+        let obj;
+        try {
+          obj = JSON.parse(line);
+        } catch (_err) {
+          continue;
+        }
+        const payload = obj?.payload;
+        if (!payload || payload.type !== "token_count") continue;
+        const info = payload.info;
+        if (!info) continue;
+        const total = info.total_token_usage || null;
+        const last = info.last_token_usage || null;
+        if (!total && !last) continue;
+        // Duplicate token_count: same totals, skip.
+        if (prevTotal && total && sameUsage(prevTotal, total)) continue;
+        let delta;
+        if (last && Number(last.total_tokens) > 0) {
+          delta = last;
+        } else if (prevTotal && total) {
+          delta = diffUsage(total, prevTotal);
+        } else if (total) {
+          delta = total;
+        } else {
+          delta = null;
+        }
+        if (total) prevTotal = total;
+        if (!delta || !Number(delta.total_tokens)) continue;
+        yield {
+          line: JSON.stringify({ timestamp: obj.timestamp, delta }),
+          context: { filePath },
+        };
+      }
+    },
+    extractUsage(line) {
+      if (!line) return null;
+      let obj;
+      try {
+        obj = JSON.parse(line);
+      } catch (_err) {
+        return null;
+      }
+      const ts = typeof obj.timestamp === "string" ? obj.timestamp : null;
+      const d = obj.delta;
+      if (!ts || !d) return null;
+      const totalTokens = Number(d.total_tokens);
+      if (!Number.isFinite(totalTokens) || totalTokens <= 0) return null;
+      return {
+        timestamp: ts,
+        dedupeId: null, // per-file dedup already done in iterateRecords
+        channels: {
+          input: 0,
+          cache_creation: 0,
+          cache_read: 0,
+          // Route the authoritative Codex upstream total into a single
+          // channel so the framework's sum-of-channels lands on it. See
+          // module docstring for why we do not split the channels.
+          output: totalTokens,
+          reasoning: 0,
+        },
+      };
+    },
+  };
+}
+
+function safeReadDirSync(p) {
+  try {
+    return fs.readdirSync(p, { withFileTypes: true });
+  } catch (_err) {
+    return [];
+  }
+}
+
+function sameUsage(a, b) {
+  if (!a || !b) return false;
+  for (const k of [
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+  ]) {
+    if (Number(a[k] || 0) !== Number(b[k] || 0)) return false;
+  }
+  return true;
+}
+
+function diffUsage(curr, prev) {
+  if (!curr || !prev) return curr || null;
+  const currTotal = Number(curr.total_tokens || 0);
+  const prevTotal = Number(prev.total_tokens || 0);
+  if (currTotal < prevTotal) return curr; // session reset
+  const out = {};
+  for (const k of [
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+  ]) {
+    out[k] = Math.max(0, Number(curr[k] || 0) - Number(prev[k] || 0));
+  }
+  return out;
+}
+
+function shiftIsoDay(iso, deltaDays) {
+  if (typeof iso !== "string" || !iso) return null;
+  const base = new Date(`${iso.slice(0, 10)}T00:00:00Z`);
+  if (Number.isNaN(base.getTime())) return null;
+  base.setUTCDate(base.getUTCDate() + deltaDays);
+  return base.toISOString().slice(0, 10);
+}
+
+module.exports = { makeRolloutStrategy };

--- a/src/lib/ops/sources/codex.js
+++ b/src/lib/ops/sources/codex.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const { makeRolloutStrategy } = require("./_rollout-base");
+
+module.exports = makeRolloutStrategy({
+  id: "codex",
+  displayName: "Codex CLI",
+  envKey: "CODEX_HOME",
+  defaultSubdir: ".codex",
+});

--- a/src/lib/ops/sources/every-code.js
+++ b/src/lib/ops/sources/every-code.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const { makeRolloutStrategy } = require("./_rollout-base");
+
+module.exports = makeRolloutStrategy({
+  id: "every-code",
+  displayName: "Every Code",
+  envKey: "CODE_HOME",
+  defaultSubdir: ".code",
+});

--- a/test/audit-codex-strategy.test.js
+++ b/test/audit-codex-strategy.test.js
@@ -1,0 +1,190 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { runSourceAudit, getStrategy } = require("../src/lib/ops/audit-source");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-audit-codex-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function tokenCountEvent({ ts, last, total }) {
+  return JSON.stringify({
+    timestamp: ts,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: { last_token_usage: last, total_token_usage: total },
+    },
+  });
+}
+
+function usage({ input = 0, cached = 0, output = 0, reasoning = 0, total }) {
+  const tot = total != null ? total : input + output;
+  return {
+    input_tokens: input,
+    cached_input_tokens: cached,
+    output_tokens: output,
+    reasoning_output_tokens: reasoning,
+    total_tokens: tot,
+  };
+}
+
+async function writeRollout(sessionsDir, dateParts, filename, lines) {
+  const [y, m, d] = dateParts;
+  const dir = path.join(sessionsDir, y, m, d);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, filename), `${lines.join("\n")}\n`, "utf8");
+}
+
+test("audit-source registers codex and every-code strategies", () => {
+  const c = getStrategy("codex");
+  const e = getStrategy("every-code");
+  assert.ok(c && c.id === "codex");
+  assert.ok(e && e.id === "every-code");
+  assert.equal(typeof c.walkSessions, "function");
+  assert.equal(typeof c.iterateRecords, "function");
+  assert.equal(typeof e.walkSessions, "function");
+});
+
+test("codex strategy sums upstream total_tokens and dedupes identical token_count pings", async () => {
+  await withTempDir(async (dir) => {
+    const codexHome = path.join(dir, ".codex");
+    const sessionsDir = path.join(codexHome, "sessions");
+
+    // Window-relevant day: yesterday UTC.
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const dayIso = y.toISOString().slice(0, 10);
+    const [yy, mm, dd] = dayIso.split("-");
+    const baseTs = `${dayIso}T10:00:00.000Z`;
+    const mkTs = (addSec) => new Date(y.getTime() + 10 * 3600 * 1000 + addSec * 1000).toISOString();
+
+    // 1st event: first API call. total=100
+    // 2nd event: dup (same total) — skipped.
+    // 3rd event: second API call. total=120, last=20. Delta contributes 20.
+    // 4th event: info:null (rate-limit ping) — skipped.
+    const lines = [
+      tokenCountEvent({
+        ts: baseTs,
+        last: usage({ input: 90, output: 10, total: 100 }),
+        total: usage({ input: 90, output: 10, total: 100 }),
+      }),
+      tokenCountEvent({
+        ts: mkTs(5),
+        last: usage({ input: 90, output: 10, total: 100 }),
+        total: usage({ input: 90, output: 10, total: 100 }),
+      }),
+      tokenCountEvent({
+        ts: mkTs(60),
+        last: usage({ input: 15, output: 5, total: 20 }),
+        total: usage({ input: 105, output: 15, total: 120 }),
+      }),
+      JSON.stringify({
+        timestamp: mkTs(90),
+        type: "event_msg",
+        payload: { type: "token_count", info: null },
+      }),
+    ];
+
+    await writeRollout(sessionsDir, [yy, mm, dd], "rollout-test.jsonl", lines);
+
+    // Truth = 100 (first call) + 20 (second call) = 120
+    const dbJson = JSON.stringify([{ day: dayIso, tokens: 120 }]);
+
+    const result = runSourceAudit({
+      strategy: getStrategy("codex"),
+      days: 3,
+      threshold: 5,
+      dbJson,
+      home: dir,
+      env: {},
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.source, "codex");
+    const row = result.rows.find((r) => r.day === dayIso);
+    assert.ok(row, "day row present");
+    assert.equal(row.truth, 120);
+    assert.equal(row.db, 120);
+    assert.equal(result.exceedsThreshold, false);
+  });
+});
+
+test("every-code strategy reads ~/.code/sessions instead of ~/.codex/sessions", async () => {
+  await withTempDir(async (dir) => {
+    const sessionsDir = path.join(dir, ".code", "sessions");
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const dayIso = y.toISOString().slice(0, 10);
+    const [yy, mm, dd] = dayIso.split("-");
+    const baseTs = `${dayIso}T08:00:00.000Z`;
+
+    const lines = [
+      tokenCountEvent({
+        ts: baseTs,
+        last: usage({ input: 50, output: 7, total: 57 }),
+        total: usage({ input: 50, output: 7, total: 57 }),
+      }),
+    ];
+    await writeRollout(sessionsDir, [yy, mm, dd], "rollout-ec.jsonl", lines);
+
+    const dbJson = JSON.stringify([{ day: dayIso, tokens: 57 }]);
+    const result = runSourceAudit({
+      strategy: getStrategy("every-code"),
+      days: 3,
+      threshold: 5,
+      dbJson,
+      home: dir,
+      env: {},
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.source, "every-code");
+    const row = result.rows.find((r) => r.day === dayIso);
+    assert.ok(row);
+    assert.equal(row.truth, 57);
+    assert.equal(row.db, 57);
+  });
+});
+
+test("codex strategy prunes YYYY/MM/DD directories older than the window", async () => {
+  await withTempDir(async (dir) => {
+    const sessionsDir = path.join(dir, ".codex", "sessions");
+    // Stale day far outside the window (always > 14 days ago)
+    await writeRollout(
+      sessionsDir,
+      ["2020", "01", "01"],
+      "rollout-stale.jsonl",
+      [
+        tokenCountEvent({
+          ts: "2020-01-01T00:00:00.000Z",
+          last: usage({ input: 1, output: 1, total: 2 }),
+          total: usage({ input: 1, output: 1, total: 2 }),
+        }),
+      ],
+    );
+    // Empty but eligible day (no rollout file)
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const dayIso = y.toISOString().slice(0, 10);
+    const [yy, mm, dd] = dayIso.split("-");
+    const recentDir = path.join(sessionsDir, yy, mm, dd);
+    await fs.mkdir(recentDir, { recursive: true });
+
+    const strategy = getStrategy("codex");
+    const root = strategy.sessionRoot({ home: dir, env: {} });
+    const windowStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 13));
+    const files = strategy.walkSessions({ root, windowStartIso: windowStart.toISOString() });
+
+    // Stale 2020 directory must not appear in the file list.
+    assert.equal(files.length, 0, `expected 0 files, got ${JSON.stringify(files)}`);
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Step 3 of the per-source audit rollout. Adds Codex and Every-Code as a shared pair — they share the rollout .jsonl format, so their audit strategies live as thin leaves over a new sources/_rollout-base.js factory. Also extends the framework so strategies receive windowStartIso in walkSessions, which lets the Codex strategy prune ~239K YYYY/MM/DD directories down to the ~65 files actually inside the audit window (measured 2.6s end-to-end on the maintainer machine).

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/ops/sources/_rollout-base.js (new): makeRolloutStrategy({ id, displayName, envKey, defaultSubdir }) factory. walkSessions prunes directories by YYYY-MM-DD with a 1-day buffer so rollout events that straddle midnight still get counted. iterateRecords is stateful per file: it watches total_token_usage, skips identical pings, and emits synthetic delta records derived from last_token_usage (preferred) or total-diff fallback. extractUsage routes the authoritative upstream total_tokens into the `output` channel so the framework's sum-of-channels equals total_tokens directly — Codex's channel breakdown overlaps (input includes cached; output includes reasoning) which rules out naive channel summation.
- src/lib/ops/sources/codex.js + src/lib/ops/sources/every-code.js: two-line leaves over the factory.
- src/lib/ops/audit-source.js: framework threads windowStartIso into strategy.walkSessions; registry gains codex / every-code.
- test/audit-codex-strategy.test.js (4 cases): registry + channel sum with duplicate ping skip + Every-Code reading ~/.code/sessions + YYYY/MM/DD prune dropping stale 2020 directories.

## Affected Modules / Contracts

- Modules touched: src/lib/ops/audit-source.js, src/lib/ops/sources/_rollout-base.js (new), src/lib/ops/sources/codex.js (new), src/lib/ops/sources/every-code.js (new), test/audit-codex-strategy.test.js (new).
- Dependencies / contracts touched: audit-source now passes windowStartIso into walkSessions — additive arg, existing Claude + OpenCode strategies ignore it (backward compatible). No runtime code changes.
- Repo sitemap evidence: not required (additive strategy inside existing ops boundary).

## Validation

### Automated

- npm test -> 790/790 pass locally (786 existing + 4 new).

### Manual / smoke

- node bin/tracker.js doctor --audit-tokens --source codex --days 7 --threshold 100 on maintainer box: 239K rollout files pruned to 65; table shows drift 0.0-1.0% on most days, ~62% outlier on 2026-04-21 caused by cross-device aggregation. Total runtime ~2.6 seconds.
- node bin/tracker.js doctor --audit-tokens --source every-code --days 7 routes correctly (confirms every-code registry entry and ~/.code/sessions resolution).

### Uncovered scope

- Per-channel breakdown is intentionally lost for Codex sources (the whole total is pinned to the output channel). The audit contract only exposes row-level totals so no caller is affected, but future consumers that want per-channel Codex semantics will need a richer strategy shape.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: the stateful iterateRecords in _rollout-base.js mirrors parseRolloutFile's pickDelta logic but lives independently. If the parser's dedup policy ever changes, this strategy must follow.
- Delta since last review: n/a
- Depends on: PR #161 and PR #162 already merged.
- Known gaps / follow-ups: PR-D (Gemini), PR-E (Kimi), PR-F (Hermes / OpenClaw ledger auditor).

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `codex` and `every-code` audit strategies with delta token tracking
> - Adds a shared `makeRolloutStrategy` factory in [_rollout-base.js](https://github.com/victorGPT/vibeusage/pull/163/files#diff-18f707f4f983a2222118bd03881a5ace6981d8bf788ea2b363d6da7e8e406f45) that walks `rollout-*.jsonl` files under date-structured session directories, deduplicates token events, and computes per-call token deltas.
> - Registers `codex` (Codex CLI, `~/.codex`) and `every-code` (Every Code, `~/.code`) as new audit sources in [audit-source.js](https://github.com/victorGPT/vibeusage/pull/163/files#diff-8a0f530e1e6f691c26453dd52ddecda97cacb181c4dbc64721f5d056845fb0a7).
> - Passes `windowStartIso` into `strategy.walkSessions` so strategies can prune stale session directories, reducing scanned files to the relevant time window.
> - Maps upstream `total_tokens` into the `output` channel only, zeroing other channels.
> - Behavioral Change: `listRegisteredSources` now returns `['claude','opencode','codex','every-code']`; `walkSessions` receives `windowStartIso` for all strategies, which may reduce `filesScanned` and row counts for strategies that use it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf4fd33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->