### PR TITLE
feat(audit): gemini strategy (Step 4)

### DIFF
--- a/src/lib/ops/audit-source.js
+++ b/src/lib/ops/audit-source.js
@@ -334,13 +334,16 @@ function getStrategy(id) {
     case "every-code":
       // eslint-disable-next-line global-require
       return require("./sources/every-code");
+    case "gemini":
+      // eslint-disable-next-line global-require
+      return require("./sources/gemini");
     default:
       return null;
   }
 }
 
 function listRegisteredSources() {
-  return ["claude", "opencode", "codex", "every-code"];
+  return ["claude", "opencode", "codex", "every-code", "gemini"];
 }
 
 module.exports = {

--- a/src/lib/ops/sources/gemini.js
+++ b/src/lib/ops/sources/gemini.js
@@ -1,0 +1,154 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+/**
+ * Gemini audit strategy.
+ *
+ * Gemini writes one JSON per session under
+ *   ~/.gemini/tmp/<hash>/chats/session-YYYY-MM-DDTHH-MM-<id>.json
+ * The file has `{ messages: [ { role, timestamp, model, tokens } ] }` where
+ * `tokens` is the cumulative usage up to that message (not a per-turn delta).
+ *
+ * Channel semantics differ from Claude but match Codex in one important way:
+ *   input + cached + output + tool + thoughts != total
+ * because `tokens.total` is the authoritative upstream count that
+ * src/lib/rollout.js normalizeGeminiTokens passes through as-is to the DB.
+ * Naively summing the five sub-channels double-counts. As with the Codex
+ * strategy, we route `delta.total` into the output channel and zero the rest
+ * so the framework's sum-of-channels row.truth equals the DB total_tokens
+ * without exposing Gemini's internal breakdown through the generic contract.
+ *
+ * Dedupe:
+ *   - Per-file index diff mirrors parseGeminiFile's `lastTotals` state.
+ *   - When `tokens.total` drops (session reset / resume), we treat the current
+ *     cumulative as the delta just like the parser does.
+ */
+
+module.exports = {
+  id: "gemini",
+  displayName: "Gemini CLI",
+  sessionRoot({ home, env }) {
+    const base = (env && env.GEMINI_HOME) || path.join(home, ".gemini");
+    return path.join(base, "tmp");
+  },
+  walkSessions({ root }) {
+    if (!fs.existsSync(root)) return [];
+    const out = [];
+    for (const hash of safeReadDirSync(root)) {
+      if (!hash.isDirectory()) continue;
+      const chatsDir = path.join(root, hash.name, "chats");
+      for (const f of safeReadDirSync(chatsDir)) {
+        if (!f.isFile()) continue;
+        if (!f.name.startsWith("session-") || !f.name.endsWith(".json")) continue;
+        out.push(path.join(chatsDir, f.name));
+      }
+    }
+    return out;
+  },
+  *iterateRecords(filePath) {
+    let raw;
+    try {
+      raw = fs.readFileSync(filePath, "utf8");
+    } catch (_err) {
+      return;
+    }
+    if (!raw.trim()) return;
+    let session;
+    try {
+      session = JSON.parse(raw);
+    } catch (_err) {
+      return;
+    }
+    const messages = Array.isArray(session?.messages) ? session.messages : [];
+    let prevTotals = null;
+    for (const msg of messages) {
+      if (!msg || typeof msg !== "object") continue;
+      const ts = typeof msg.timestamp === "string" ? msg.timestamp : null;
+      if (!ts) continue;
+      const tokens = msg.tokens;
+      if (!tokens || typeof tokens !== "object") continue;
+
+      const curr = normalizeTokens(tokens);
+      const delta = diffTotals(curr, prevTotals);
+      prevTotals = curr;
+      if (!delta || !delta.total) continue;
+
+      yield {
+        line: JSON.stringify({ timestamp: ts, delta }),
+        context: { filePath },
+      };
+    }
+  },
+  extractUsage(line) {
+    if (!line) return null;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch (_err) {
+      return null;
+    }
+    const ts = typeof obj.timestamp === "string" ? obj.timestamp : null;
+    const d = obj.delta;
+    if (!ts || !d || !Number(d.total)) return null;
+    return {
+      timestamp: ts,
+      dedupeId: null, // per-file index diff already dedupes
+      channels: {
+        input: 0,
+        cache_creation: 0,
+        cache_read: 0,
+        // Route the authoritative upstream total into a single channel; see
+        // module docstring for why we do not split it.
+        output: Number(d.total),
+        reasoning: 0,
+      },
+    };
+  },
+};
+
+function normalizeTokens(tokens) {
+  return {
+    input: nonneg(tokens.input),
+    cached: nonneg(tokens.cached),
+    output: nonneg(tokens.output),
+    tool: nonneg(tokens.tool),
+    thoughts: nonneg(tokens.thoughts),
+    total: nonneg(tokens.total),
+  };
+}
+
+function diffTotals(curr, prev) {
+  if (!curr) return null;
+  if (!prev) {
+    // First message with tokens — the whole cumulative value is the delta.
+    return curr;
+  }
+  // Session reset: upstream total decreased (resume / new session). Trust the
+  // new value as the full delta.
+  if (curr.total < prev.total) return curr;
+  const delta = {
+    input: Math.max(0, curr.input - prev.input),
+    cached: Math.max(0, curr.cached - prev.cached),
+    output: Math.max(0, curr.output - prev.output),
+    tool: Math.max(0, curr.tool - prev.tool),
+    thoughts: Math.max(0, curr.thoughts - prev.thoughts),
+    total: Math.max(0, curr.total - prev.total),
+  };
+  return delta;
+}
+
+function nonneg(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+function safeReadDirSync(p) {
+  try {
+    return fs.readdirSync(p, { withFileTypes: true });
+  } catch (_err) {
+    return [];
+  }
+}

--- a/test/audit-gemini-strategy.test.js
+++ b/test/audit-gemini-strategy.test.js
@@ -1,0 +1,153 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { runSourceAudit, getStrategy } = require("../src/lib/ops/audit-source");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-audit-gemini-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function writeGeminiSession(geminiHome, hash, name, messages) {
+  const dir = path.join(geminiHome, "tmp", hash, "chats");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, name), JSON.stringify({ messages }), "utf8");
+}
+
+test("audit-source registers the gemini strategy", () => {
+  const s = getStrategy("gemini");
+  assert.ok(s && s.id === "gemini");
+  assert.equal(typeof s.sessionRoot, "function");
+  assert.equal(typeof s.walkSessions, "function");
+  assert.equal(typeof s.iterateRecords, "function");
+});
+
+test("gemini strategy emits per-message deltas against cumulative tokens", async () => {
+  await withTempDir(async (dir) => {
+    const geminiHome = path.join(dir, ".gemini");
+
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yIso = y.toISOString().slice(0, 10);
+    const ts = (addSec) => new Date(y.getTime() + 10 * 3600 * 1000 + addSec * 1000).toISOString();
+
+    // Cumulative tokens:
+    //   msg_0 total=100
+    //   msg_1 total=260  -> delta 160
+    //   msg_2 total=260  -> delta 0, skipped
+    //   msg_3 total=320  -> delta 60
+    // Truth = 100 + 160 + 60 = 320
+    const messages = [
+      { role: "user", timestamp: ts(0), tokens: null }, // null tokens skipped
+      {
+        role: null,
+        timestamp: ts(10),
+        model: "gemini-3-flash-preview",
+        tokens: { input: 80, output: 15, cached: 0, thoughts: 5, tool: 0, total: 100 },
+      },
+      {
+        role: null,
+        timestamp: ts(30),
+        model: "gemini-3-flash-preview",
+        tokens: { input: 210, output: 40, cached: 0, thoughts: 10, tool: 0, total: 260 },
+      },
+      {
+        role: null,
+        timestamp: ts(35),
+        model: "gemini-3-flash-preview",
+        tokens: { input: 210, output: 40, cached: 0, thoughts: 10, tool: 0, total: 260 },
+      },
+      {
+        role: null,
+        timestamp: ts(50),
+        model: "gemini-3-flash-preview",
+        tokens: { input: 260, output: 50, cached: 0, thoughts: 10, tool: 0, total: 320 },
+      },
+    ];
+
+    await writeGeminiSession(geminiHome, "abc123", "session-2026-04-23T10-00-test.json", messages);
+
+    const dbJson = JSON.stringify([{ day: yIso, tokens: 320 }]);
+
+    const strategy = getStrategy("gemini");
+    const result = runSourceAudit({
+      strategy,
+      days: 3,
+      threshold: 5,
+      dbJson,
+      home: dir,
+      env: { GEMINI_HOME: geminiHome },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.source, "gemini");
+    const row = result.rows.find((r) => r.day === yIso);
+    assert.ok(row, "day row present");
+    assert.equal(row.truth, 320, `expected 320, got ${row.truth}`);
+    assert.equal(row.db, 320);
+    assert.equal(result.exceedsThreshold, false);
+  });
+});
+
+test("gemini strategy treats a total drop as a session reset, not as negative tokens", async () => {
+  await withTempDir(async (dir) => {
+    const geminiHome = path.join(dir, ".gemini");
+
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yIso = y.toISOString().slice(0, 10);
+    const ts = (addSec) => new Date(y.getTime() + 10 * 3600 * 1000 + addSec * 1000).toISOString();
+
+    // Cumulative: 500, then drops to 200 (session resumed) -> delta = 200
+    const messages = [
+      {
+        timestamp: ts(0),
+        tokens: { input: 400, output: 90, cached: 0, thoughts: 10, tool: 0, total: 500 },
+      },
+      {
+        timestamp: ts(30),
+        tokens: { input: 150, output: 40, cached: 0, thoughts: 10, tool: 0, total: 200 },
+      },
+    ];
+    await writeGeminiSession(geminiHome, "hash2", "session-2026-04-23T11-00-reset.json", messages);
+
+    const dbJson = JSON.stringify([{ day: yIso, tokens: 500 + 200 }]);
+
+    const result = runSourceAudit({
+      strategy: getStrategy("gemini"),
+      days: 3,
+      threshold: 5,
+      dbJson,
+      home: dir,
+      env: { GEMINI_HOME: geminiHome },
+    });
+
+    assert.equal(result.ok, true);
+    const row = result.rows.find((r) => r.day === yIso);
+    assert.ok(row);
+    assert.equal(row.truth, 700);
+  });
+});
+
+test("gemini strategy reports no-local-sessions when tmp dir is missing", async () => {
+  await withTempDir(async (dir) => {
+    const result = runSourceAudit({
+      strategy: getStrategy("gemini"),
+      days: 3,
+      threshold: 10,
+      dbJson: "[]",
+      home: dir,
+      env: { GEMINI_HOME: path.join(dir, "no-such") },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "no-local-sessions");
+    assert.equal(result.source, "gemini");
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Step 4 of the per-source audit rollout. Adds a Gemini strategy so \`vibeusage doctor --audit-tokens --source gemini\` walks ~/.gemini/tmp/<hash>/chats/session-*.json, index-diffs the per-message cumulative tokens, and compares against vibeusage_tracker_hourly.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/ops/sources/gemini.js (new): strategy with stateful per-file iterateRecords that tracks prevTotals and emits delta records against each message's cumulative tokens.total (mirrors parseGeminiFile's lastTotals flow). Honors GEMINI_HOME env var. Session-reset detection (current cumulative < prev) treats the new cumulative as the full delta so we don't record negative tokens. Like Codex, delta.total is routed into the output channel because Gemini's normalizeGeminiTokens passes the authoritative upstream total straight to the DB rather than summing sub-channels.
- src/lib/ops/audit-source.js: registers gemini.
- test/audit-gemini-strategy.test.js (4 cases): registration, per-message cumulative diff + dup + zero-delta skip, session-reset semantics, no-local-sessions when tmp/ missing.

## Affected Modules / Contracts

- Modules touched: src/lib/ops/sources/gemini.js (new), src/lib/ops/audit-source.js, test/audit-gemini-strategy.test.js (new).
- Dependencies / contracts touched: none. Purely additive registration and strategy implementation.
- Repo sitemap evidence: not required (additive strategy inside existing ops boundary).

## Validation

### Automated

- npm test -> 794/794 pass locally (790 existing + 4 new).

### Manual / smoke

- node bin/tracker.js doctor --audit-tokens --source gemini --days 90 --threshold 100 on maintainer machine: scans 30 session files, surfaces 54 usage events across 2026-04-02/03 with 0.0% drift against DB. Consistent with the Gemini-never-had-cache_read-bug expectation — normalizeGeminiTokens has always trusted upstream total.

### Uncovered scope

- As with Codex, per-channel breakdown is intentionally lost (delta.total goes entirely into the output channel). Callers that need per-channel Gemini semantics must update the strategy contract.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: iterateRecords dedup/diff logic stays aligned with parseGeminiFile in src/lib/rollout.js. If parser behavior changes, this strategy must follow.
- Delta since last review: n/a
- Depends on: PR #161, #162, #163 merged.
- Known gaps / follow-ups: PR-E (Kimi), PR-F (Hermes / OpenClaw ledger auditor).

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Gemini CLI source strategy to the token audit registry
> - Adds [gemini.js](https://github.com/victorGPT/vibeusage/pull/164/files#diff-bfd603cf7f1623e983759bc8b0b67198823b2f3788fa3f5620acfe4fe4fa50ac) as a new audit source strategy that reads session JSON files from `~/.gemini/tmp` (or `$GEMINI_HOME/tmp`) and yields per-message token usage deltas.
> - Cumulative token totals are diffed across messages; a drop in the running total is treated as a session reset, using the current total as the delta.
> - `extractUsage` maps each delta's total into the `output` channel, zeroing all other channels (`input`, `cache`, `tool`, `thoughts`).
> - Registers the strategy under the id `"gemini"` in [audit-source.js](https://github.com/victorGPT/vibeusage/pull/164/files#diff-8a0f530e1e6f691c26453dd52ddecda97cacb181c4dbc64721f5d056845fb0a7) so it is discoverable via `getStrategy` and `listRegisteredSources`.
> - Behavioral Change: all token spend for Gemini sessions is attributed entirely to the output channel regardless of actual input/output breakdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff9c40c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->