### PR TITLE
feat(audit): kimi strategy (Step 5)

### DIFF
--- a/src/lib/ops/audit-source.js
+++ b/src/lib/ops/audit-source.js
@@ -337,13 +337,16 @@ function getStrategy(id) {
     case "gemini":
       // eslint-disable-next-line global-require
       return require("./sources/gemini");
+    case "kimi":
+      // eslint-disable-next-line global-require
+      return require("./sources/kimi");
     default:
       return null;
   }
 }
 
 function listRegisteredSources() {
-  return ["claude", "opencode", "codex", "every-code", "gemini"];
+  return ["claude", "opencode", "codex", "every-code", "gemini", "kimi"];
 }
 
 module.exports = {

--- a/src/lib/ops/sources/kimi.js
+++ b/src/lib/ops/sources/kimi.js
@@ -1,0 +1,105 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+/**
+ * Kimi audit strategy.
+ *
+ * Kimi CLI writes one wire log per session:
+ *   ~/.kimi/sessions/<project>/<sessionId>/wire.jsonl
+ * Each StatusUpdate line carries the delta for one Anthropic-compatible
+ * message:
+ *   { timestamp: <unix_seconds float>,
+ *     message: { type: "StatusUpdate",
+ *                payload: { message_id, token_usage: {
+ *                  input_other, input_cache_creation,
+ *                  input_cache_read, output } } } }
+ *
+ * Channel mapping lines up with src/lib/rollout.js normalizeKimiUsage so the
+ * framework's sum-of-channels row.truth equals the DB total_tokens:
+ *     input        = input_other + input_cache_creation
+ *     cache_read   = input_cache_read
+ *     output       = output
+ *     (cache_creation, reasoning) = 0  (already folded into input / n/a)
+ *     total        = input + cache_read + output
+ *
+ * Dedupe key: payload.message_id (chatcmpl-…). Kimi does not currently
+ * duplicate rows the way Claude Code does, but keying on message_id is
+ * free insurance and matches the AGENTS.md intake checklist.
+ */
+
+module.exports = {
+  id: "kimi",
+  displayName: "Kimi CLI",
+  sessionRoot({ home, env }) {
+    const base = (env && env.KIMI_HOME) || path.join(home, ".kimi");
+    return path.join(base, "sessions");
+  },
+  walkSessions({ root }) {
+    if (!fs.existsSync(root)) return [];
+    const out = [];
+    for (const proj of safeReadDirSync(root)) {
+      if (!proj.isDirectory()) continue;
+      const projDir = path.join(root, proj.name);
+      for (const session of safeReadDirSync(projDir)) {
+        if (!session.isDirectory()) continue;
+        const wire = path.join(projDir, session.name, "wire.jsonl");
+        if (!fs.existsSync(wire)) continue;
+        out.push(wire);
+      }
+    }
+    return out;
+  },
+  extractUsage(line) {
+    if (!line || !line.includes("StatusUpdate")) return null;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch (_err) {
+      return null;
+    }
+    if (obj?.message?.type !== "StatusUpdate") return null;
+    const payload = obj.message.payload;
+    const tokens = payload?.token_usage;
+    if (!tokens || typeof tokens !== "object") return null;
+    const timestamp = unixSecondsToIso(obj.timestamp);
+    if (!timestamp) return null;
+    return {
+      timestamp,
+      dedupeId: typeof payload.message_id === "string" && payload.message_id
+        ? payload.message_id
+        : null,
+      channels: {
+        input: nonneg(tokens.input_other) + nonneg(tokens.input_cache_creation),
+        cache_creation: 0, // already folded into input per normalizeKimiUsage
+        cache_read: nonneg(tokens.input_cache_read),
+        output: nonneg(tokens.output),
+        reasoning: 0,
+      },
+    };
+  },
+};
+
+function unixSecondsToIso(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const ms = n < 1e12 ? Math.floor(n * 1000) : Math.floor(n);
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+function nonneg(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+function safeReadDirSync(p) {
+  try {
+    return fs.readdirSync(p, { withFileTypes: true });
+  } catch (_err) {
+    return [];
+  }
+}

--- a/test/audit-kimi-strategy.test.js
+++ b/test/audit-kimi-strategy.test.js
@@ -1,0 +1,174 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { runSourceAudit, getStrategy } = require("../src/lib/ops/audit-source");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-audit-kimi-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function writeWire(kimiHome, proj, session, lines) {
+  const dir = path.join(kimiHome, "sessions", proj, session);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "wire.jsonl"), `${lines.join("\n")}\n`, "utf8");
+}
+
+function statusUpdate({ tsSec, messageId, inputOther = 0, cacheCreation = 0, cacheRead = 0, output = 0 }) {
+  return JSON.stringify({
+    timestamp: tsSec,
+    message: {
+      type: "StatusUpdate",
+      payload: {
+        message_id: messageId,
+        token_usage: {
+          input_other: inputOther,
+          input_cache_creation: cacheCreation,
+          input_cache_read: cacheRead,
+          output,
+        },
+      },
+    },
+  });
+}
+
+test("audit-source registers the kimi strategy", () => {
+  const s = getStrategy("kimi");
+  assert.ok(s && s.id === "kimi");
+  assert.equal(typeof s.sessionRoot, "function");
+  assert.equal(typeof s.walkSessions, "function");
+  assert.equal(typeof s.extractUsage, "function");
+});
+
+test("kimi strategy sums channels matching normalizeKimiUsage and dedupes by message_id", async () => {
+  await withTempDir(async (dir) => {
+    const kimiHome = path.join(dir, ".kimi");
+
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yIso = y.toISOString().slice(0, 10);
+    const tsBase = Math.floor((y.getTime() + 10 * 3600 * 1000) / 1000);
+
+    // msg_A: input_other 100 + cache_creation 20 + cache_read 500 + output 30 = 650
+    //   (normalizeKimiUsage: input_tokens = 100+20 = 120, cached = 500, output = 30,
+    //    total = 120 + 500 + 30 = 650)
+    //   duplicate of msg_A -> skipped
+    // msg_B: 10 + 0 + 5 + 2 = 17
+    const lines = [
+      statusUpdate({
+        tsSec: tsBase,
+        messageId: "chatcmpl-A",
+        inputOther: 100,
+        cacheCreation: 20,
+        cacheRead: 500,
+        output: 30,
+      }),
+      statusUpdate({
+        tsSec: tsBase + 2,
+        messageId: "chatcmpl-A", // dup
+        inputOther: 100,
+        cacheCreation: 20,
+        cacheRead: 500,
+        output: 30,
+      }),
+      statusUpdate({
+        tsSec: tsBase + 10,
+        messageId: "chatcmpl-B",
+        inputOther: 10,
+        cacheCreation: 0,
+        cacheRead: 5,
+        output: 2,
+      }),
+      // Non-StatusUpdate events are ignored.
+      JSON.stringify({ timestamp: tsBase + 1, message: { type: "TurnBegin", payload: {} } }),
+    ];
+
+    await writeWire(kimiHome, "proj1", "ses1", lines);
+
+    const dbJson = JSON.stringify([{ day: yIso, tokens: 650 + 17 }]);
+
+    const result = runSourceAudit({
+      strategy: getStrategy("kimi"),
+      days: 3,
+      threshold: 5,
+      dbJson,
+      home: dir,
+      env: { KIMI_HOME: kimiHome },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.source, "kimi");
+    assert.equal(result.uniqueMessages, 2);
+    assert.equal(result.duplicatesSkipped, 1);
+    const row = result.rows.find((r) => r.day === yIso);
+    assert.ok(row);
+    assert.equal(row.truth, 667);
+    assert.equal(row.db, 667);
+    assert.equal(result.exceedsThreshold, false);
+  });
+});
+
+test("kimi strategy converts unix-second timestamps to ISO", async () => {
+  await withTempDir(async (dir) => {
+    const kimiHome = path.join(dir, ".kimi");
+    // Use a fixed unix-seconds timestamp to verify conversion: 1767958695.463422 -> 2026-01-10T...
+    // (we don't care about the exact date string; we care that the line is included
+    //  when days is wide enough).
+    const tsSec = 1767958695.463422;
+    const expectedDay = new Date(tsSec * 1000).toISOString().slice(0, 10);
+    const lines = [
+      statusUpdate({
+        tsSec,
+        messageId: "m-1",
+        inputOther: 1,
+        cacheRead: 2,
+        output: 3,
+      }),
+    ];
+    await writeWire(kimiHome, "pp", "ss", lines);
+
+    const now = new Date();
+    const windowDays = Math.max(
+      1,
+      Math.ceil((now.getTime() - tsSec * 1000) / (24 * 3600 * 1000)) + 1,
+    );
+    const dbJson = JSON.stringify([{ day: expectedDay, tokens: 6 }]);
+
+    const result = runSourceAudit({
+      strategy: getStrategy("kimi"),
+      days: windowDays,
+      threshold: 5,
+      dbJson,
+      home: dir,
+      env: { KIMI_HOME: kimiHome },
+    });
+
+    assert.equal(result.ok, true);
+    const row = result.rows.find((r) => r.day === expectedDay);
+    assert.ok(row, `row for ${expectedDay} present`);
+    assert.equal(row.truth, 6);
+  });
+});
+
+test("kimi strategy reports no-local-sessions when sessions dir missing", async () => {
+  await withTempDir(async (dir) => {
+    const result = runSourceAudit({
+      strategy: getStrategy("kimi"),
+      days: 3,
+      threshold: 10,
+      dbJson: "[]",
+      home: dir,
+      env: { KIMI_HOME: path.join(dir, "no-such") },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "no-local-sessions");
+    assert.equal(result.source, "kimi");
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Step 5 of the per-source audit rollout. Adds a Kimi strategy so \`vibeusage doctor --audit-tokens --source kimi\` walks ~/.kimi/sessions/<proj>/<sess>/wire.jsonl, extracts StatusUpdate token_usage events, dedupes by message_id, and compares against vibeusage_tracker_hourly for source=kimi.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/ops/sources/kimi.js (new): strategy walks KIMI_HOME (default ~/.kimi)/sessions/<proj>/<session>/wire.jsonl. extractUsage only picks StatusUpdate events; converts unix-second timestamps (including fractional float seconds) to ISO; channel mapping matches normalizeKimiUsage: input = input_other + input_cache_creation, cache_read = input_cache_read, output = output, cache_creation + reasoning = 0. Dedupes by payload.message_id (chatcmpl-…).
- src/lib/ops/audit-source.js: registers kimi.
- test/audit-kimi-strategy.test.js (4 cases): registration, channel-sum + message_id dedupe + non-StatusUpdate filter, unix-second timestamp conversion, no-local-sessions when sessions dir missing.

## Affected Modules / Contracts

- Modules touched: src/lib/ops/sources/kimi.js (new), src/lib/ops/audit-source.js, test/audit-kimi-strategy.test.js (new).
- Dependencies / contracts touched: none. Purely additive strategy.
- Repo sitemap evidence: not required (additive strategy inside existing ops boundary).

## Validation

### Automated

- npm test -> 798/798 pass locally (794 existing + 4 new).

### Manual / smoke

- node bin/tracker.js doctor --audit-tokens --source kimi --days 180 on maintainer machine: 1 wire.jsonl scanned, 1 unique message, 0.0% drift against DB. Confirms the strategy + parser stay in lock-step.

### Uncovered scope

- Kimi is a new source with limited real-world data (1 message in DB at the time of writing). Strategy behavior at scale will be verified as real sessions accumulate; the dedup-by-message_id + four-channel sum matches the shape Moonshot documented for StatusUpdate events.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: channel mapping stays in lock-step with normalizeKimiUsage in src/lib/rollout.js. If Moonshot ever adds a new channel to StatusUpdate.payload.token_usage both must follow.
- Delta since last review: n/a
- Depends on: PR #161/#162/#163/#164 merged.
- Known gaps / follow-ups: PR-F (Hermes / OpenClaw ledger auditor) — the last source family, distinct because those two sources already hand vibeusage pre-aggregated ledger rows instead of raw session logs.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Kimi CLI audit source strategy
> - Adds a new `kimi` strategy in [`src/lib/ops/sources/kimi.js`](https://github.com/victorGPT/vibeusage/pull/165/files#diff-e0b3ce3e6ca8f0863a6a58f5a88995887974a06223224d7ef8ed1e629917fde3) that reads wire logs from `~/.kimi/sessions` (or `$KIMI_HOME`) and parses `StatusUpdate` JSONL lines to extract token usage.
> - Maps token fields to channels: `input = input_other + input_cache_creation`, `cache_read = input_cache_read`, `output = output`; sets `cache_creation` and `reasoning` to 0.
> - Registers `kimi` in [`src/lib/ops/audit-source.js`](https://github.com/victorGPT/vibeusage/pull/165/files#diff-8a0f530e1e6f691c26453dd52ddecda97cacb181c4dbc64721f5d056845fb0a7) so `getStrategy('kimi')` and `listRegisteredSources()` include it.
> - Test coverage in [`test/audit-kimi-strategy.test.js`](https://github.com/victorGPT/vibeusage/pull/165/files#diff-d7da9ecc24922f8bf89a1b4e4c862d4036a6f2d440c755bb69c3842bad73dc06) validates channel sums, deduplication via `message_id`, unix-second timestamp conversion, and no-local-sessions handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bb4f17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->