### PR TITLE
feat(audit): hermes + openclaw ledger strategies (Step 6, final)

### DIFF
--- a/src/lib/ops/audit-source.js
+++ b/src/lib/ops/audit-source.js
@@ -340,13 +340,19 @@ function getStrategy(id) {
     case "kimi":
       // eslint-disable-next-line global-require
       return require("./sources/kimi");
+    case "hermes":
+      // eslint-disable-next-line global-require
+      return require("./sources/hermes");
+    case "openclaw":
+      // eslint-disable-next-line global-require
+      return require("./sources/openclaw");
     default:
       return null;
   }
 }
 
 function listRegisteredSources() {
-  return ["claude", "opencode", "codex", "every-code", "gemini", "kimi"];
+  return ["claude", "opencode", "codex", "every-code", "gemini", "kimi", "hermes", "openclaw"];
 }
 
 module.exports = {

--- a/src/lib/ops/sources/hermes.js
+++ b/src/lib/ops/sources/hermes.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+/**
+ * Hermes audit strategy.
+ *
+ * Hermes does not write raw session logs; it emits one pre-aggregated event
+ * per turn into the vibeusage tracker directory:
+ *   ~/.vibeusage/tracker/hermes.usage.jsonl
+ * Each line is a `{type: "usage", emitted_at, model, input_tokens,
+ * output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+ * total_tokens}` record. src/commands/sync.js parseHermesUsageLedger already
+ * copies `total_tokens` straight into the bucket, so this audit routes the
+ * upstream total into the output channel — same pattern we use for Codex and
+ * Gemini.
+ *
+ * sessionRoot: the tracker directory (NOT `~/.hermes/...` — Hermes usage data
+ * lives under ~/.vibeusage/tracker because Hermes is a plugin that hands
+ * vibeusage ledger rows directly).
+ */
+
+module.exports = {
+  id: "hermes",
+  displayName: "Hermes Plugin",
+  sessionRoot({ home, env }) {
+    const base = (env && env.VIBEUSAGE_HOME) || path.join(home, ".vibeusage");
+    return path.join(base, "tracker");
+  },
+  walkSessions({ root }) {
+    const ledger = path.join(root, "hermes.usage.jsonl");
+    if (!fs.existsSync(ledger)) return [];
+    return [ledger];
+  },
+  extractUsage(line) {
+    if (!line) return null;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch (_err) {
+      return null;
+    }
+    if (!event || event.type !== "usage") return null;
+    const timestamp = typeof event.emitted_at === "string" ? event.emitted_at : null;
+    if (!timestamp) return null;
+    const total = nonneg(event.total_tokens);
+    if (total === 0) return null;
+    return {
+      timestamp,
+      // Hermes ledger records do not carry a stable per-event id;
+      // the ledger is append-only and duplicates are prevented at write time.
+      dedupeId: null,
+      channels: {
+        input: 0,
+        cache_creation: 0,
+        cache_read: 0,
+        output: total, // route authoritative upstream total here
+        reasoning: 0,
+      },
+    };
+  },
+};
+
+function nonneg(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}

--- a/src/lib/ops/sources/openclaw.js
+++ b/src/lib/ops/sources/openclaw.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+/**
+ * OpenClaw audit strategy.
+ *
+ * Like Hermes, OpenClaw hands vibeusage pre-aggregated ledger rows instead of
+ * raw session logs:
+ *   ~/.vibeusage/tracker/openclaw-usage-ledger.jsonl
+ * Each line is a camelCase event
+ *   { eventId, emittedAt, source, model, inputTokens, cachedInputTokens,
+ *     outputTokens, reasoningOutputTokens, totalTokens }
+ * src/commands/sync.js parseOpenclawSanitizedLedger copies `totalTokens`
+ * straight into the bucket, so this audit routes the upstream total into the
+ * output channel. Dedupe is keyed on eventId, which the ledger writer
+ * already enforces uniqueness of.
+ */
+
+module.exports = {
+  id: "openclaw",
+  displayName: "OpenClaw Plugin",
+  sessionRoot({ home, env }) {
+    const base = (env && env.VIBEUSAGE_HOME) || path.join(home, ".vibeusage");
+    return path.join(base, "tracker");
+  },
+  walkSessions({ root }) {
+    const ledger = path.join(root, "openclaw-usage-ledger.jsonl");
+    if (!fs.existsSync(ledger)) return [];
+    return [ledger];
+  },
+  extractUsage(line) {
+    if (!line) return null;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch (_err) {
+      return null;
+    }
+    if (!event || typeof event !== "object") return null;
+    const timestamp = typeof event.emittedAt === "string" ? event.emittedAt : null;
+    if (!timestamp) return null;
+    const total = nonneg(event.totalTokens);
+    if (total === 0) return null;
+    return {
+      timestamp,
+      dedupeId: typeof event.eventId === "string" && event.eventId ? event.eventId : null,
+      channels: {
+        input: 0,
+        cache_creation: 0,
+        cache_read: 0,
+        output: total,
+        reasoning: 0,
+      },
+    };
+  },
+};
+
+function nonneg(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}

--- a/test/audit-hermes-openclaw-strategy.test.js
+++ b/test/audit-hermes-openclaw-strategy.test.js
@@ -1,0 +1,179 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { runSourceAudit, getStrategy, listRegisteredSources } = require("../src/lib/ops/audit-source");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-audit-ledger-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function writeLedger(trackerDir, filename, lines) {
+  await fs.mkdir(trackerDir, { recursive: true });
+  await fs.writeFile(path.join(trackerDir, filename), `${lines.join("\n")}\n`, "utf8");
+}
+
+test("audit-source registers hermes and openclaw strategies", () => {
+  const h = getStrategy("hermes");
+  const o = getStrategy("openclaw");
+  assert.ok(h && h.id === "hermes");
+  assert.ok(o && o.id === "openclaw");
+  const ids = listRegisteredSources();
+  assert.ok(ids.includes("hermes"));
+  assert.ok(ids.includes("openclaw"));
+});
+
+test("hermes strategy sums upstream total_tokens and ignores non-usage rows", async () => {
+  await withTempDir(async (dir) => {
+    const trackerDir = path.join(dir, ".vibeusage", "tracker");
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yIso = y.toISOString().slice(0, 10);
+    const ts = (addSec) => new Date(y.getTime() + 10 * 3600 * 1000 + addSec * 1000).toISOString();
+
+    const lines = [
+      JSON.stringify({
+        type: "usage",
+        emitted_at: ts(0),
+        model: "claude-opus-4-6",
+        input_tokens: 10,
+        output_tokens: 20,
+        cache_read_tokens: 500,
+        cache_write_tokens: 30,
+        reasoning_tokens: 5,
+        total_tokens: 565,
+      }),
+      JSON.stringify({ type: "handshake", emitted_at: ts(1) }), // ignored
+      JSON.stringify({
+        type: "usage",
+        emitted_at: ts(20),
+        model: "claude-opus-4-6",
+        input_tokens: 5,
+        output_tokens: 10,
+        cache_read_tokens: 100,
+        total_tokens: 115,
+      }),
+      JSON.stringify({
+        type: "usage",
+        emitted_at: ts(30),
+        total_tokens: 0, // zero -> skipped
+      }),
+    ];
+    await writeLedger(trackerDir, "hermes.usage.jsonl", lines);
+
+    const dbJson = JSON.stringify([{ day: yIso, tokens: 565 + 115 }]);
+
+    const strategy = getStrategy("hermes");
+    const result = runSourceAudit({
+      strategy,
+      days: 3,
+      threshold: 5,
+      dbJson,
+      home: dir,
+      env: { VIBEUSAGE_HOME: path.join(dir, ".vibeusage") },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.source, "hermes");
+    const row = result.rows.find((r) => r.day === yIso);
+    assert.ok(row, "day row present");
+    assert.equal(row.truth, 680);
+    assert.equal(row.db, 680);
+    assert.equal(result.exceedsThreshold, false);
+  });
+});
+
+test("openclaw strategy sums totalTokens and dedupes by eventId", async () => {
+  await withTempDir(async (dir) => {
+    const trackerDir = path.join(dir, ".vibeusage", "tracker");
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yIso = y.toISOString().slice(0, 10);
+    const ts = (addSec) => new Date(y.getTime() + 9 * 3600 * 1000 + addSec * 1000).toISOString();
+
+    const lines = [
+      JSON.stringify({
+        eventId: "evt-1",
+        emittedAt: ts(0),
+        source: "openclaw",
+        model: "gpt-5",
+        inputTokens: 100,
+        outputTokens: 50,
+        cachedInputTokens: 0,
+        reasoningOutputTokens: 10,
+        totalTokens: 160,
+      }),
+      JSON.stringify({
+        eventId: "evt-1", // duplicate -> skipped
+        emittedAt: ts(5),
+        source: "openclaw",
+        model: "gpt-5",
+        totalTokens: 160,
+      }),
+      JSON.stringify({
+        eventId: "evt-2",
+        emittedAt: ts(20),
+        source: "openclaw",
+        model: "gpt-5",
+        totalTokens: 40,
+      }),
+    ];
+    await writeLedger(trackerDir, "openclaw-usage-ledger.jsonl", lines);
+
+    const dbJson = JSON.stringify([{ day: yIso, tokens: 200 }]);
+
+    const strategy = getStrategy("openclaw");
+    const result = runSourceAudit({
+      strategy,
+      days: 3,
+      threshold: 5,
+      dbJson,
+      home: dir,
+      env: { VIBEUSAGE_HOME: path.join(dir, ".vibeusage") },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.uniqueMessages, 2);
+    assert.equal(result.duplicatesSkipped, 1);
+    const row = result.rows.find((r) => r.day === yIso);
+    assert.ok(row);
+    assert.equal(row.truth, 200);
+  });
+});
+
+test("hermes strategy reports no-local-sessions when ledger missing", async () => {
+  await withTempDir(async (dir) => {
+    const result = runSourceAudit({
+      strategy: getStrategy("hermes"),
+      days: 3,
+      threshold: 5,
+      dbJson: "[]",
+      home: dir,
+      env: { VIBEUSAGE_HOME: path.join(dir, "no-such") },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "no-local-sessions");
+  });
+});
+
+test("openclaw strategy reports no-local-sessions when ledger missing", async () => {
+  await withTempDir(async (dir) => {
+    const result = runSourceAudit({
+      strategy: getStrategy("openclaw"),
+      days: 3,
+      threshold: 5,
+      dbJson: "[]",
+      home: dir,
+      env: { VIBEUSAGE_HOME: path.join(dir, "no-such") },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "no-local-sessions");
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Last source plug-in of the per-source audit rollout. Hermes and OpenClaw hand vibeusage pre-aggregated ledger rows under ~/.vibeusage/tracker/ instead of raw session logs, so their strategies are thin readers over the existing ledger files. Both route the upstream total_tokens straight into the output channel so the framework's sum-of-channels lands on what src/commands/sync.js already copies into vibeusage_tracker_hourly.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/ops/sources/hermes.js (new): walks <VIBEUSAGE_HOME>/tracker/hermes.usage.jsonl, filters \`type:"usage"\` records, converts emitted_at ISO strings straight through, routes total_tokens into the output channel. No per-event dedupeId because the ledger is append-only and writer-uniqueness enforced.
- src/lib/ops/sources/openclaw.js (new): walks openclaw-usage-ledger.jsonl. Routes totalTokens into output; dedupes by eventId.
- src/lib/ops/audit-source.js: registers hermes and openclaw.
- test/audit-hermes-openclaw-strategy.test.js (5 cases): registration, Hermes sum + non-usage filter + zero-total skip, OpenClaw sum + eventId dedup, no-local-sessions on each when ledger missing.

## Affected Modules / Contracts

- Modules touched: src/lib/ops/sources/hermes.js (new), src/lib/ops/sources/openclaw.js (new), src/lib/ops/audit-source.js, test/audit-hermes-openclaw-strategy.test.js (new).
- Dependencies / contracts touched: none. Purely additive plug-ins.
- Repo sitemap evidence: not required (additive strategies inside existing ops boundary).

## Validation

### Automated

- npm test -> 803/803 pass locally (798 existing + 5 new).

### Manual / smoke

- node bin/tracker.js doctor --audit-tokens --source hermes --days 180 -> no-local-sessions (Hermes plugin not active on maintainer machine, expected).
- node bin/tracker.js doctor --audit-tokens --source openclaw --days 180 -> no-local-sessions (same).
- node bin/tracker.js doctor --audit-tokens --source bogus -> exits 2 listing \"Registered: claude, opencode, codex, every-code, gemini, kimi, hermes, openclaw\" — confirms the registry now covers every source vibeusage knows about.

### Uncovered scope

- Per-channel breakdown is intentionally lost (same pattern as Codex / Gemini / Kimi) because both ledgers give us an authoritative upstream total_tokens. Callers that need per-channel Hermes / OpenClaw semantics would need a richer strategy shape.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: both strategies must stay in lock-step with src/commands/sync.js parseHermesUsageLedger / parseOpenclawSanitizedLedger. If either ledger's schema changes the strategy must follow.
- Delta since last review: n/a
- Depends on: PR #161, #162, #163, #164, #165 all merged.
- Known gaps / follow-ups: after this lands every registered vibeusage source has a doctor --audit-tokens path, closing out the per-source audit rollout.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Hermes and OpenClaw ledger audit strategies to the source registry
> - Adds [`sources/hermes.js`](https://github.com/victorGPT/vibeusage/pull/166/files#diff-85af39e7574eec0f5c3d0acfe8247b426d1fcc269664cbcfc0a8a00cb7ca0fc9) reading `~/.vibeusage/tracker/hermes.usage.jsonl`, summing `total_tokens` per `usage`-type event; rows with invalid JSON, missing timestamps, or non-positive totals are dropped; no per-event dedupe.
> - Adds [`sources/openclaw.js`](https://github.com/victorGPT/vibeusage/pull/166/files#diff-9974d3679bcc0253853b675873d2479c2ac8a645fa9c64c9bde6ec9faa25b0bc) reading `~/.vibeusage/tracker/openclaw-usage-ledger.jsonl`, summing `totalTokens` with deduplication via `eventId`; invalid/duplicate/zero-total rows are skipped.
> - Registers both strategies in [`audit-source.js`](https://github.com/victorGPT/vibeusage/pull/166/files#diff-8a0f530e1e6f691c26453dd52ddecda97cacb181c4dbc64721f5d056845fb0a7) via `getStrategy` and `listRegisteredSources`.
> - Both strategies emit a `no-local-sessions` error when their ledger file is absent.
> - Covers all behavior with a new test suite in [`audit-hermes-openclaw-strategy.test.js`](https://github.com/victorGPT/vibeusage/pull/166/files#diff-f535087f1ef46a36e11813d4c0c2e631fe753dfc4ef66f93d894048b6e6b6501).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca397bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->