### PR TITLE
feat(doctor): --audit-tokens --source all (one-stop overview)

### DIFF
--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -70,9 +70,12 @@ async function cmdDoctor(argv = []) {
 
 function runAuditTokens({ opts, config }) {
   const sourceId = opts.auditSource || "claude";
+  if (sourceId === "all") {
+    return runAuditTokensAll({ opts, config });
+  }
   const strategy = getAuditStrategy(sourceId);
   if (!strategy) {
-    const registered = listRegisteredSources().join(", ");
+    const registered = ["all", ...listRegisteredSources()].join(", ");
     const message = `unknown --source '${sourceId}'. Registered: ${registered}.`;
     if (opts.json) {
       process.stdout.write(`${JSON.stringify({ ok: false, error: "unknown-source", message })}\n`);
@@ -148,6 +151,76 @@ function runAuditTokens({ opts, config }) {
     );
     process.exitCode = 1;
   }
+}
+
+function runAuditTokensAll({ opts, config }) {
+  const ids = listRegisteredSources();
+  const perSource = [];
+  let anyExceeds = false;
+  let anyHardError = false;
+
+  for (const id of ids) {
+    const strategy = getAuditStrategy(id);
+    let result;
+    try {
+      result = runSourceAudit({
+        strategy,
+        days: opts.auditDays,
+        threshold: opts.auditThreshold,
+        deviceId: config.deviceId || null,
+        // --db-json is source-specific so we skip it under --source=all; the
+        // only sane paths are insforge auto-mode or no-local-sessions.
+      });
+    } catch (err) {
+      result = { ok: false, source: id, error: "audit-error", message: err?.message || String(err) };
+      anyHardError = true;
+    }
+    if (result.ok && result.exceedsThreshold) anyExceeds = true;
+    // no-local-sessions is informational, not a hard error; other non-ok states
+    // (cannot-resolve-user-id, insforge-db-query-failed, etc.) count as errors.
+    if (!result.ok && result.error !== "no-local-sessions") anyHardError = true;
+    perSource.push(result);
+  }
+
+  if (opts.json) {
+    process.stdout.write(
+      `${JSON.stringify({ ok: !anyHardError, thresholdPct: opts.auditThreshold, days: opts.auditDays, sources: perSource }, null, 2)}\n`,
+    );
+  } else {
+    process.stdout.write(
+      `Token audit across all registered sources (last ${opts.auditDays} days)\n\n`,
+    );
+    process.stdout.write(
+      `${"source".padEnd(12)}  ${"status".padEnd(22)}  ${"max drift".padStart(10)}  ${"files".padStart(6)}  ${"events".padStart(6)}\n`,
+    );
+    process.stdout.write(`${"-".repeat(70)}\n`);
+    for (const r of perSource) {
+      if (r.ok) {
+        const statusText = r.exceedsThreshold
+          ? `FAIL > ${opts.auditThreshold}%`
+          : `ok`;
+        const drift = `${r.maxDriftPct.toFixed(1)}%`;
+        process.stdout.write(
+          `${r.source.padEnd(12)}  ${statusText.padEnd(22)}  ${drift.padStart(10)}  ${String(r.filesScanned).padStart(6)}  ${String(r.usageLines).padStart(6)}\n`,
+        );
+      } else {
+        const statusText =
+          r.error === "no-local-sessions" ? "no local sessions" : `ERR ${r.error}`;
+        process.stdout.write(
+          `${r.source.padEnd(12)}  ${statusText.padEnd(22)}  ${"—".padStart(10)}  ${"—".padStart(6)}  ${"—".padStart(6)}\n`,
+        );
+      }
+    }
+    process.stdout.write(
+      `\nThreshold ${opts.auditThreshold}%. ` +
+        (anyExceeds
+          ? `At least one source exceeds threshold — rerun \`vibeusage doctor --audit-tokens --source <id>\` for details.\n`
+          : `All sources within threshold.\n`),
+    );
+  }
+
+  if (anyHardError) process.exitCode = 2;
+  else if (anyExceeds) process.exitCode = 1;
 }
 
 function parseArgs(argv) {

--- a/test/doctor-audit-all.test.js
+++ b/test/doctor-audit-all.test.js
@@ -1,0 +1,96 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { spawnSync } = require("node:child_process");
+const { test } = require("node:test");
+
+async function withTempDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-audit-all-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function runCli({ args, env }) {
+  const bin = path.join(__dirname, "..", "bin", "tracker.js");
+  return spawnSync(process.execPath, [bin, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+test("doctor --audit-tokens --source all --json lists every registered source", async () => {
+  await withTempDir(async (dir) => {
+    // Empty HOME so every source returns no-local-sessions. That is an
+    // acceptable state (informational, not hard error), and exercises the
+    // all-sources iteration deterministically.
+    const res = runCli({
+      args: ["doctor", "--audit-tokens", "--source", "all", "--json"],
+      env: {
+        HOME: dir,
+        XDG_DATA_HOME: path.join(dir, "xdg"),
+        VIBEUSAGE_HOME: path.join(dir, "vibe-home"),
+        CODEX_HOME: path.join(dir, "codex-home"),
+        CODE_HOME: path.join(dir, "code-home"),
+        GEMINI_HOME: path.join(dir, "gemini-home"),
+        KIMI_HOME: path.join(dir, "kimi-home"),
+        OPENCODE_HOME: path.join(dir, "opencode-home"),
+      },
+    });
+
+    assert.equal(res.status, 0, `expected exit 0, got ${res.status}. stderr=${res.stderr}`);
+    const payload = JSON.parse(res.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.sources.length, 8);
+    const ids = payload.sources.map((s) => s.source).sort();
+    assert.deepEqual(
+      ids,
+      ["claude", "codex", "every-code", "gemini", "hermes", "kimi", "openclaw", "opencode"],
+    );
+    for (const entry of payload.sources) {
+      assert.equal(entry.ok, false);
+      assert.equal(entry.error, "no-local-sessions");
+    }
+  });
+});
+
+test("doctor --audit-tokens --source all human output renders a table with status column", async () => {
+  await withTempDir(async (dir) => {
+    const res = runCli({
+      args: ["doctor", "--audit-tokens", "--source", "all"],
+      env: {
+        HOME: dir,
+        XDG_DATA_HOME: path.join(dir, "xdg"),
+        VIBEUSAGE_HOME: path.join(dir, "vibe-home"),
+        CODEX_HOME: path.join(dir, "codex-home"),
+        CODE_HOME: path.join(dir, "code-home"),
+        GEMINI_HOME: path.join(dir, "gemini-home"),
+        KIMI_HOME: path.join(dir, "kimi-home"),
+        OPENCODE_HOME: path.join(dir, "opencode-home"),
+      },
+    });
+
+    assert.equal(res.status, 0);
+    const stdout = res.stdout;
+    assert.match(stdout, /Token audit across all registered sources/);
+    assert.match(stdout, /no local sessions/);
+    for (const id of ["claude", "opencode", "codex", "every-code", "gemini", "kimi", "hermes", "openclaw"]) {
+      assert.ok(stdout.includes(id), `expected stdout to mention source "${id}"`);
+    }
+    assert.match(stdout, /All sources within threshold/);
+  });
+});
+
+test("--source all includes 'all' in the registered list shown on unknown source", async () => {
+  await withTempDir(async (dir) => {
+    const res = runCli({
+      args: ["doctor", "--audit-tokens", "--source", "bogus"],
+      env: { HOME: dir },
+    });
+    assert.equal(res.status, 2);
+    assert.match(res.stderr, /Registered: all, claude/);
+  });
+});


### PR DESCRIPTION
# What does this PR do?

- Adds a one-stop \`--source all\` mode to \`vibeusage doctor --audit-tokens\` so users do not have to remember the eight registered source names. Runs every audit strategy in sequence and renders a compact status / max-drift / file-count table (or a machine-readable \`{ok, sources: [...]}\` JSON when --json is set).

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/commands/doctor.js: runAuditTokens short-circuits into a new runAuditTokensAll when --source all is passed. Iterates getAuditStrategy over listRegisteredSources and aggregates results. Exit code is 0 when every source is within threshold (no-local-sessions rows count as informational), 1 when any source exceeds threshold, 2 when any source hits a hard error like cannot-resolve-user-id or insforge-db-query-failed. Unknown-source error message now lists \`all\` in the registered list for discoverability.
- test/doctor-audit-all.test.js (3 cases): JSON shape covers all 8 ids, human table rendering includes "no local sessions" status + every source id + "All sources within threshold" summary, unknown-source hint includes \`all\`.

## Affected Modules / Contracts

- Modules touched: src/commands/doctor.js, test/doctor-audit-all.test.js (new).
- Dependencies / contracts touched: --source all is additive to the existing per-source CLI. --source=<id>, --db-json, --days, --threshold, --json all keep their prior behavior.
- Repo sitemap evidence: not required (CLI-only addition).

## Validation

### Automated

- npm test -> 806/806 pass locally (803 existing + 3 new).

### Manual / smoke

- \`node bin/tracker.js doctor --audit-tokens --source all --days 7 --threshold 100\` on maintainer box produces a table for all 8 sources (3 with real data, 3 with no-local-sessions, plus every-code and hermes informational).
- \`--source bogus\` now surfaces \"Registered: all, claude, opencode, ...\" as the hint.

### Uncovered scope

- --source all intentionally skips --db-json (the flag is a single-source concept). Users that want a BYO DB comparison across every source should iterate per-source manually.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: exit code semantics on --source all. Current mapping: 0 green, 1 any exceeds threshold, 2 any hard error. no-local-sessions is never a hard error because plugins that are not active on the box should not block the overview.
- Delta since last review: n/a
- Depends on: PR #166 merged (completes the 8-source registry).
- Known gaps / follow-ups: 0.6.0 release to ship the Phase A + Ralph-loop audit suite to existing npm users.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--source all` support to `doctor --audit-tokens` for a multi-source overview
> - Adds a new `runAuditTokensAll` function in [doctor.js](https://github.com/victorGPT/vibeusage/pull/167/files#diff-6c8875e6b05bb0a5d137333b4dbc8ceada96428ca327b553823f4cd2ee5ea072) that iterates all registered sources, runs per-source audits, and aggregates results.
> - Human output renders a summary table with columns for source, status, max drift, files, and events; JSON output includes an `ok` flag and per-source results.
> - Exit code is set to 2 on hard errors, 1 if any source exceeds the threshold, and 0 otherwise.
> - The unknown-source error message now includes `all` in the list of valid identifiers.
> - Tests in [doctor-audit-all.test.js](https://github.com/victorGPT/vibeusage/pull/167/files#diff-90b053e14b13c5be837d2c255e29c967f7766688d97c6c33e158be22ba60ff37) cover JSON output, human-readable table output, and the updated error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eef4a67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->