### PR TITLE
release: 0.6.0 — per-source audit framework + defensive ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-24
+
+### Added
+
+- **Per-source token audit** across every CLI vibeusage knows about. `vibeusage doctor --audit-tokens --source <id>` walks local sessions (or ledgers), dedupes by upstream id where available, sums channels to a day total, and compares against `vibeusage_tracker_hourly`. Exit 0 within threshold, 1 over threshold, 2 on hard errors.
+  - Supported ids: `claude`, `opencode`, `codex`, `every-code`, `gemini`, `kimi`, `hermes`, `openclaw`.
+  - `--source all` runs every strategy and prints one status row per source so you can eyeball drift without memorising names.
+  - `--days N --threshold PCT --db-json PATH --json` flags behave the same as in 0.5.0; `--db-json` stays a single-source concept.
+- **Strategy framework** in `src/lib/ops/audit-source.js` + `src/lib/ops/sources/<id>.js`. New sources plug in by filling a small strategy object (`sessionRoot`, `walkSessions`, `extractUsage`, optional `iterateRecords`). The backwards-compatible `audit-claude.js` shim stays for any downstream import.
+- **Token-conservation property test** (`test/parser-total-conservation.test.js`) fuzzes every `normalize*Usage` with ~200 deterministic LCG inputs and asserts `total_tokens === input + cached + output + reasoning` on compose-based normalizers (Claude / Kimi / OpenCode). The April 2026 Claude under-count would have failed this on the first fuzz input.
+- **`AGENTS.md` "新 AI CLI Source 接入 Checklist" (强制)**: documents the three invariants every new source PR must satisfy (dedupe key, total_tokens covers all channels, fixture-backed regression tests).
+- **Defensive ops**:
+  - `scripts/ops/compare-claude-ground-truth.cjs` CLI wrapper for maintainers who want a standalone script instead of `doctor`.
+  - Claude parser now returns a `dedupSkipped` metric; `sync` writes a `claude_dedup_spike` line to `notify.debug.jsonl` when the skip ratio goes above 50% — early-warning signal if Claude Code ever changes its session-log write pattern again.
+
+### Changed
+
+- CI workflows bumped from Node 18 to Node 20 (`deploy-preflight.yml`, `guardrails.yml`, `release.yml preflight`). `npm-publish` stays on Node 22 because Trusted Publishing requires npm ≥ 11.5.1.
+- Landing copy and dashboard `CLIENTS` registry updated to include Kimi and Hermes alongside Codex / Claude Code / Gemini / OpenCode / OpenClaw.
+- Integration labels brought in line with official brand names: "Claude" → "Claude Code", "Opencode Plugin" → "OpenCode Plugin".
+
+### Notes
+
+- No parser formula changed in this release — the 0.5.0 cache_read + dedupe fixes remain authoritative. 0.6.0 is the "observability + framework" cut: the thing that stops a similar bug from lasting months next time.
+- Retrospective at `docs/retrospective/vibeusage/2026-04-24-claude-usage-parser-under-counting.md` remains the reference post-mortem for the April incident.
+
 ## [0.5.0] - 2026-04-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeusage",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Codex CLI token usage tracker (macOS-first, notify-driven).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
# What does this PR do?

- Cuts vibeusage 0.6.0 so every install pulls in the per-source audit framework + Phase A defensive layer shipped through PRs #152-#167. No parser semantics change (0.5.0 cache_read + dedupe fixes remain authoritative); 0.6.0 is the observability + framework cut so a similar under-count can never last months again.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- package.json 0.5.0 -> 0.6.0 so the release workflow finds a new version to push via OIDC Trusted Publishing.
- CHANGELOG 0.6.0 entry enumerates the audit framework (audit-source.js strategy contract, 8 registered sources, --source all, token-conservation property test, AGENTS.md new-source checklist), node-20 CI bump, branding fixes, Kimi + Hermes landing copy.

## Affected Modules / Contracts

- Modules touched: package.json, CHANGELOG.md.
- Dependencies / contracts touched: none. Runtime code for the audit strategies already landed in prior PRs.
- Repo sitemap evidence: not required (version bump + docs).

## Validation

### Automated

- npm run ci:local -> 806/806 node tests + 6 guardrails + copy/ui-hardcode/dashboard-build all green locally.

### Manual / smoke

- node bin/tracker.js doctor --audit-tokens --source all --days 7 --threshold 100 on maintainer box renders the expected 8-row table (claude/opencode/codex with data, gemini/kimi informational, every-code/hermes/openclaw no-local-sessions). Confirms the audit pipeline end-to-end ships in this release.
- node bin/tracker.js doctor --audit-tokens --source unknown exits 2 with "Registered: all, claude, opencode, codex, every-code, gemini, kimi, hermes, openclaw" — the full surface is discoverable.

### Uncovered scope

- Historical bucket backfill for non-Claude sources remains per-device. Users that want to rewrite OpenCode (or other) historical numbers can follow the same cursor scrub + `sync --drain` recipe documented in 0.5.0's CHANGELOG.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: CHANGELOG wording around the 0.5.0 vs 0.6.0 distinction — 0.5.0 fixed the bug; 0.6.0 ships the prevention mechanism.
- Delta since last review: n/a
- Depends on: PR #152, #153, #154, #155, #156, #157, #159, #160, #161, #162, #163, #164, #165, #166, #167 all merged to main.
- Known gaps / follow-ups: after this lands on npm (OIDC Trusted Publishing), the legacy NPM_TOKEN secret can stay removed — 0.4.0's token-less release path proved out in 0.5.0 and holds here.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.6.0 with per-source token audit framework and defensive ops
> - Adds `vibeusage doctor --audit-tokens --source <id>` command backed by a pluggable strategy framework in [audit-source.js](https://github.com/victorGPT/vibeusage/pull/168/files#diff-8a0f530e1e6f691c26453dd52ddecda97cacb181c4dbc64721f5d056845fb0a7) and per-source modules under `src/lib/ops/sources/`
> - Adds a `dedupSkipped` metric with spike logging and a compare-claude ground-truth script as defensive ops tooling
> - Adds a mandatory AGENTS.md checklist for contributors adding new sources, and a token-conservation property test
> - Bumps CI workflows to Node 20 and adds Kimi/Hermes to the landing copy and dashboard registry
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e40ed91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->