### PR TITLE
fix(audit): reject malformed userId/source/windowStart before SQL interpolation

### DIFF
--- a/src/lib/ops/audit-source.js
+++ b/src/lib/ops/audit-source.js
@@ -39,6 +39,16 @@ const { spawnSync } = require("node:child_process");
 const DEFAULT_DAYS = 14;
 const DEFAULT_THRESHOLD_PCT = 25;
 
+// `resolveUserIdViaInsforge` and `queryDbTotalsViaInsforge` interpolate these
+// values into a SQL string handed to `insforge db query` (argv, not shell, but
+// the argv reaches a SQL executor with service-role authority). The three
+// values are validated against strict whitelists so a malicious / typo flag
+// like --user-id "foo'; DROP TABLE users; --" cannot reach the DB.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SOURCE_ID_RE = /^[a-z][a-z0-9-]*$/;
+const ISO_TIMESTAMP_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
 function runSourceAudit({
   strategy,
   days = DEFAULT_DAYS,
@@ -246,7 +256,7 @@ function nonneg(v) {
 }
 
 function resolveUserIdViaInsforge({ deviceId }) {
-  if (!deviceId) return null;
+  if (!deviceId || !UUID_RE.test(String(deviceId))) return null;
   const r = spawnSync(
     "insforge",
     [
@@ -264,6 +274,27 @@ function resolveUserIdViaInsforge({ deviceId }) {
 }
 
 function queryDbTotalsViaInsforge({ userId, source, windowStartIso }) {
+  if (!userId || !UUID_RE.test(String(userId))) {
+    return {
+      ok: false,
+      error: "invalid-user-id",
+      message: `refusing to query DB with non-UUID user id '${String(userId).slice(0, 40)}'`,
+    };
+  }
+  if (!source || !SOURCE_ID_RE.test(String(source))) {
+    return {
+      ok: false,
+      error: "invalid-source-id",
+      message: `refusing to query DB with non-identifier source '${String(source).slice(0, 40)}'`,
+    };
+  }
+  if (!windowStartIso || !ISO_TIMESTAMP_RE.test(String(windowStartIso))) {
+    return {
+      ok: false,
+      error: "invalid-window-start",
+      message: `refusing to query DB with non-ISO windowStartIso '${String(windowStartIso).slice(0, 40)}'`,
+    };
+  }
   const sql =
     `SELECT DATE(hour_start) AS day, SUM(total_tokens) AS tokens ` +
     `FROM vibeusage_tracker_hourly ` +
@@ -361,4 +392,8 @@ module.exports = {
   runSourceAudit,
   getStrategy,
   listRegisteredSources,
+  // Exported for targeted tests that assert the SQL-interpolation inputs are
+  // validated before reaching `insforge db query`.
+  queryDbTotalsViaInsforge,
+  resolveUserIdViaInsforge,
 };

--- a/test/audit-source-sql-validation.test.js
+++ b/test/audit-source-sql-validation.test.js
@@ -1,0 +1,84 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const {
+  queryDbTotalsViaInsforge,
+  resolveUserIdViaInsforge,
+} = require("../src/lib/ops/audit-source");
+
+// These tests do NOT actually spawn `insforge`. They assert that the
+// validation layer rejects malicious or malformed inputs before we ever
+// reach the subprocess. Follow-up assertion: if someone removes the regex
+// gate one of these cases flips to an `insforge-db-query-failed` (or a
+// crash), and CI catches it.
+
+test("queryDbTotalsViaInsforge rejects non-UUID userId without invoking insforge", () => {
+  const res = queryDbTotalsViaInsforge({
+    userId: "bad'; DROP TABLE users; --",
+    source: "claude",
+    windowStartIso: "2026-04-20T00:00:00.000Z",
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.error, "invalid-user-id");
+  assert.match(res.message, /non-UUID user id/);
+});
+
+test("queryDbTotalsViaInsforge rejects empty / null userId", () => {
+  for (const v of [null, undefined, "", "   "]) {
+    const res = queryDbTotalsViaInsforge({
+      userId: v,
+      source: "claude",
+      windowStartIso: "2026-04-20T00:00:00.000Z",
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.error, "invalid-user-id", `failed for userId=${JSON.stringify(v)}`);
+  }
+});
+
+test("queryDbTotalsViaInsforge rejects non-identifier source id", () => {
+  const res = queryDbTotalsViaInsforge({
+    userId: "88377842-7d72-4e19-96f1-2c96fea8840e",
+    source: "claude'; DROP",
+    windowStartIso: "2026-04-20T00:00:00.000Z",
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.error, "invalid-source-id");
+});
+
+test("queryDbTotalsViaInsforge rejects non-ISO windowStartIso", () => {
+  const res = queryDbTotalsViaInsforge({
+    userId: "88377842-7d72-4e19-96f1-2c96fea8840e",
+    source: "claude",
+    windowStartIso: "yesterday'; DROP",
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.error, "invalid-window-start");
+});
+
+test("queryDbTotalsViaInsforge accepts well-formed inputs (falls through to insforge invocation)", () => {
+  // We cannot assert full success without a live insforge CLI, but with valid
+  // inputs the validation layer must pass control through, landing on the
+  // `insforge-db-query-failed` branch when insforge is not linked.
+  const res = queryDbTotalsViaInsforge({
+    userId: "88377842-7d72-4e19-96f1-2c96fea8840e",
+    source: "claude",
+    windowStartIso: "2026-04-20T00:00:00.000Z",
+  });
+  // Either insforge is linked (ok:true) or it is not (ok:false with
+  // insforge-db-query-failed). Validation-layer errors must not appear.
+  assert.notEqual(res.error, "invalid-user-id");
+  assert.notEqual(res.error, "invalid-source-id");
+  assert.notEqual(res.error, "invalid-window-start");
+});
+
+test("resolveUserIdViaInsforge rejects non-UUID deviceId without invoking insforge", () => {
+  // A non-UUID deviceId must short-circuit to null; crucially, it must not
+  // reach spawnSync. We cannot directly observe "did not spawn" without
+  // mocking, but we can assert the function returns null without side effects
+  // and completes synchronously.
+  assert.equal(resolveUserIdViaInsforge({ deviceId: "not-a-uuid" }), null);
+  assert.equal(resolveUserIdViaInsforge({ deviceId: "'; DROP TABLE --" }), null);
+  assert.equal(resolveUserIdViaInsforge({ deviceId: "" }), null);
+  assert.equal(resolveUserIdViaInsforge({ deviceId: null }), null);
+  assert.equal(resolveUserIdViaInsforge({}), null);
+});


### PR DESCRIPTION
# What does this PR do?

- Closes the SQL-interpolation face in \`src/lib/ops/audit-source.js\` that Codex flagged in the 2026-04-24 post-merge review. Values headed into the \`insforge db query\` argv are now validated against strict regexes up front; malformed inputs return a structured \`{ok:false, error:"invalid-*"}\` instead of reaching the SQL executor.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- src/lib/ops/audit-source.js:
  - New UUID / source-id / ISO-8601 regex constants.
  - \`queryDbTotalsViaInsforge\` gates userId / source / windowStartIso and returns \`invalid-user-id\` / \`invalid-source-id\` / \`invalid-window-start\` before any spawn call.
  - \`resolveUserIdViaInsforge\` short-circuits to null for non-UUID deviceId, so a malformed config entry cannot inject either.
  - Helpers exported so targeted tests can assert the rejection paths without touching the insforge subprocess.
- test/audit-source-sql-validation.test.js (6 cases): rejects SQL-payload userId, rejects empty/null ids, rejects injected source and non-ISO windowStart, and confirms well-formed inputs fall through past the validation layer (so the rejection gate is not silently swallowing legitimate queries).

## Affected Modules / Contracts

- Modules touched: src/lib/ops/audit-source.js, test/audit-source-sql-validation.test.js (new).
- Dependencies / contracts touched: audit-source.js gains two new named exports (\`queryDbTotalsViaInsforge\`, \`resolveUserIdViaInsforge\`). No consumer currently depends on their absence. Public runSourceAudit / getStrategy / listRegisteredSources signatures unchanged.
- Repo sitemap evidence: not required (localized fix).

## Validation

### Automated

- npm test -> 812/812 pass locally (806 existing + 6 new).

### Manual / smoke

- Rejection paths exercised by the new tests; well-formed inputs pass through and hit the normal \`insforge db query\` branch (which returns \`insforge-db-query-failed\` when the CLI is not linked — expected).

### Uncovered scope

- We do not wrap the insforge CLI authentication path itself; compromised local Insforge service-role tokens remain out of scope. Finding #1 from the same review (legacy cursor seenIds upgrade gap) was deliberately left as-is because the reproduction window is a single sync invocation after upgrade and defensive code would add complexity for negligible risk.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [x] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

- SQL strings handed to \`insforge db query\` must only contain values that match \`UUID_RE\` / \`SOURCE_ID_RE\` / \`ISO_TIMESTAMP_RE\`.
- Validation failure must never fall through to spawnSync.
- Error payloads mirror the existing \`{ok, error, message}\` shape so callers keep their current branch handling.

### Boundary Matrix (must list at least 3)

- Auditor lib -> insforge CLI: only pre-validated UUIDs, source ids, and ISO timestamps cross the boundary.
- CLI user input (flags, config.json) -> auditor: userId / deviceId / source values are rejected at the validation layer before reaching SQL construction.
- Strategy.id (hard-coded) -> auditor: already a fixed whitelist, but SOURCE_ID_RE keeps future strategies honest.

### Evidence

- test/audit-source-sql-validation.test.js asserts every rejection path.
- Codex review (2026-04-24) flagged this specific finding; this PR addresses it.

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: the three regex constants must stay strict. Loosening them (especially UUID_RE) reopens the injection face.
- Delta since last review: n/a
- Depends on: 0.6.0 already on npm / main.
- Known gaps / follow-ups: Finding #1 (legacy cursor seenIds upgrade gap) explicitly left unfixed; see PR body "Uncovered scope" above.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject malformed userId, source, and windowStart before SQL interpolation in audit source queries
> - Adds regex validation in [audit-source.js](https://github.com/victorGPT/vibeusage/pull/169/files#diff-8a0f530e1e6f691c26453dd52ddecda97cacb181c4dbc64721f5d056845fb0a7) for `userId` (UUID), `source` (lowercase alphanumeric/hyphen), and `windowStartIso` (Z-terminated ISO timestamp) before building SQL passed to `insforge db query`.
> - `queryDbTotalsViaInsforge` now returns `ok:false` with a specific error code (`invalid-user-id`, `invalid-source-id`, `invalid-window-start`) on validation failure, without invoking the subprocess.
> - `resolveUserIdViaInsforge` now short-circuits to `null` for non-UUID `deviceId` inputs instead of only checking falsiness.
> - Both functions are exported to support targeted validation tests in [audit-source-sql-validation.test.js](https://github.com/victorGPT/vibeusage/pull/169/files#diff-2a2ff8ccfb8159b45d97fd7ad9b9231f044d2554a21b168721a249d7ea317591).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf88424.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->