### PR TITLE
release: 0.6.1 — SQL-face fix in audit helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-25
+
+### Security
+
+- **Close SQL-interpolation face in audit helpers**. A post-merge Codex review (2026-04-24) flagged that `queryDbTotalsViaInsforge` and `resolveUserIdViaInsforge` in `src/lib/ops/audit-source.js` interpolated `userId`, `source`, and `windowStartIso` into a SQL string handed to `insforge db query` via argv. The subprocess reaches a SQL executor with service-role authority, so a maintainer-only typo such as `--user-id "foo'; DROP TABLE users; --"` could have run arbitrary SQL. Inputs are now gated by strict regexes (UUID for user/device ids, lowercase-kebab for source ids, ISO-8601 with Z for timestamps); malformed values short-circuit with `{ok: false, error: "invalid-*"}` and never reach `spawnSync`.
+- No change for end-users: CLI flags and config values that were already well-formed (all production callers use UUID device ids and the hardcoded source whitelist) continue to work.
+
 ## [0.6.0] - 2026-04-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeusage",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Codex CLI token usage tracker (macOS-first, notify-driven).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
# What does this PR do?

- Cuts vibeusage 0.6.1 so the Codex post-merge review finding addressed in #169 reaches every npm install. Only package.json + CHANGELOG change; no runtime code touched here (fix landed in 1c0799af).

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- package.json 0.6.0 -> 0.6.1 so the release workflow finds a new version to push via OIDC Trusted Publishing.
- CHANGELOG 0.6.1 entry documents the SQL-interpolation face fix and notes no breaking change for well-formed production callers (all existing deviceIds are UUIDs, all source values are from the 8-id hardcoded whitelist).

## Affected Modules / Contracts

- Modules touched: package.json, CHANGELOG.md.
- Dependencies / contracts touched: none. Runtime fix already merged and has 812/812 tests on main.
- Repo sitemap evidence: not required (version bump + docs).

## Validation

### Automated

- npm run ci:local -> 812/812 node tests + 6 guardrails + copy/ui-hardcode/dashboard-build all green locally.

### Manual / smoke

- Existing audit paths exercised end-to-end in 0.6.0 live smoke remain valid; the regex gates only reject ill-formed inputs which were never produced by real callers.

### Uncovered scope

- Finding #1 from the Codex review (legacy cursor seenIds upgrade gap) remains intentionally unfixed, documented in PR #169's Uncovered scope section.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence

-

## Public Exposure Addendum (required if public exposure is checked)

- Access rules:
- Exposed fields:
- Avatar / image policy:
- Regression coverage:

## Reviewer Context (optional)

- Review focus: CHANGELOG wording. Runtime fix is PR #169 which already merged and had its own review gate.
- Delta since last review: n/a
- Depends on: PR #169 merged as 1c0799af.
- Known gaps / follow-ups: none beyond Finding #1 left-unfixed note above.

## Screenshots / Logs (optional)

-

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.6.1 with SQL injection fix in audit helpers
> Bumps the version in [package.json](https://github.com/victorGPT/vibeusage/pull/170/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `0.6.0` to `0.6.1` and documents the release in [CHANGELOG.md](https://github.com/victorGPT/vibeusage/pull/170/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed). The change adds input validation to audit helpers to address a SQL injection vulnerability with no end-user facing changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e85df78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->