### PR TITLE
fix(audit): claude walkSessions recurses into <session>/subagents/

### DIFF
--- a/src/lib/ops/sources/claude.js
+++ b/src/lib/ops/sources/claude.js
@@ -11,14 +11,25 @@ module.exports = {
   },
   walkSessions({ root }) {
     if (!fs.existsSync(root)) return [];
+    // Recurse: Claude Code writes the main thread under
+    // `projects/<project>/<session>.jsonl` AND subagent threads under
+    // `projects/<project>/<sessionId>/subagents/agent-*.jsonl`. Subagents
+    // burn real Anthropic tokens, so the audit must include them. Sync's
+    // walkClaudeProjects (rollout.js) already recurses; this mirrors it.
     const out = [];
-    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
-      const dir = path.join(root, entry.name);
-      for (const f of fs.readdirSync(dir, { withFileTypes: true })) {
-        if (!f.isFile()) continue;
-        if (!f.name.endsWith(".jsonl")) continue;
-        out.push(path.join(dir, f.name));
+    const stack = [root];
+    while (stack.length) {
+      const dir = stack.pop();
+      let entries;
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch (_err) {
+        continue;
+      }
+      for (const entry of entries) {
+        const p = path.join(dir, entry.name);
+        if (entry.isDirectory()) stack.push(p);
+        else if (entry.isFile() && entry.name.endsWith(".jsonl")) out.push(p);
       }
     }
     return out;

--- a/test/doctor-audit-tokens.test.js
+++ b/test/doctor-audit-tokens.test.js
@@ -110,6 +110,41 @@ test("runAudit flags drift when DB totals disagree with local ground truth", asy
   });
 });
 
+test("runAudit includes subagent jsonl files nested under <session>/subagents/", async () => {
+  await withTempDir(async (dir) => {
+    const projects = path.join(dir, "projects");
+    const sessionDir = path.join(projects, "proj", "sess-1", "subagents");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const mainJsonl = path.join(projects, "proj", "session.jsonl");
+    const subJsonl = path.join(sessionDir, "agent-abc.jsonl");
+
+    const now = new Date();
+    const y = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yIso = `${y.toISOString().slice(0, 10)}T10:00:00.000Z`;
+    const day = yIso.slice(0, 10);
+
+    await fs.writeFile(
+      mainJsonl,
+      `${assistantLine({ ts: yIso, messageId: "main_1", input: 1, cr: 9, output: 0 })}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      subJsonl,
+      `${assistantLine({ ts: yIso, messageId: "sub_1", input: 100, cr: 900, output: 0 })}\n`,
+      "utf8",
+    );
+
+    const dbJson = JSON.stringify([{ day, tokens: 1010 }]);
+    const res = runAudit({ days: 3, threshold: 5, dbJson, projectsDir: projects });
+
+    assert.equal(res.ok, true);
+    assert.equal(res.uniqueMessages, 2, "main + subagent both counted");
+    const row = res.rows.find((r) => r.day === day);
+    assert.equal(row.truth, 1010, "subagent token included in truth");
+    assert.equal(res.exceedsThreshold, false);
+  });
+});
+
 test("runAudit returns an error shape when no sessions are available", async () => {
   await withTempDir(async (dir) => {
     const res = runAudit({


### PR DESCRIPTION
# What does this PR do?

Fix the doctor `--audit-tokens --source claude` ground-truth scanner so it counts subagent token usage. The strategy at `src/lib/ops/sources/claude.js` only walked `projects/<project>/*.jsonl`, missing every Task/Agent thread Claude Code writes under `projects/<project>/<sessionId>/subagents/agent-*.jsonl`. Sync's `walkClaudeProjects` already recurses, so the DB had the right numbers — the audit was comparing an incomplete `truth` against a correct `db`, producing phantom drift signals.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- `src/lib/ops/sources/claude.js`: replace two-level loop with iterative full recursion, mirroring `rollout.js#walkClaudeProjects`. Comment cites the subagent path explicitly.
- `test/doctor-audit-tokens.test.js`: new case writes a main jsonl + a nested `subagents/agent-*.jsonl`, asserts both land in `truth` and `uniqueMessages == 2`.

## Affected Modules / Contracts

- **Modules touched:** `src/lib/ops/sources/claude.js`, `test/doctor-audit-tokens.test.js`
- **Dependencies / contracts touched:** none — strategy contract (`walkSessions(root) -> string[]`) unchanged; only the implementation expands the file set. Audit DB schema and sync path untouched.
- **Repo sitemap evidence:** not required (internal change to one source strategy file)

## Validation

### Automated

- `node --test test/doctor-audit-tokens.test.js` → 4/4 pass (incl. new subagent case)
- `npm test` → 813/813 pass, no regressions

### Manual / smoke

- `node bin/tracker.js doctor --audit-tokens --source claude` before fix: 161 files, max drift 99.5%, 04-13/14/16/17/18/21/22/23 all showed phantom drift 0.3%–22.6%.
- After fix: 844 files, 12,102 unique messages, 04-13/15/18/22 sit at 0.0% drift; 04-14/16/19/20/23 ≤0.4%; remaining drift is sync lag (today/yesterday) + one historic outlier (04-17, +15%), unrelated to this change.
- Cross-checked the calculation rule against Claude Code itself: replayed a turn via `claude -p ... --fork-session`, the SDK `usage` JSON output (input=6, cache_creation=99,866, cache_read=0, output=6) matches the same message's `usage` field in the written jsonl byte-for-byte.

### Uncovered scope

- The historic 04-17 drift (~15%) remains and is not investigated here — likely an early sync dedupe artefact. Filed separately if it persists past the next `sync --drain`.
- Other sources (codex, opencode, gemini, kimi, hermes, openclaw) verified via filesystem inspection to lack nested subagent dirs, but not exhaustively re-tested in CI.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** confirm the recursion is bounded by the existing strategy contract (no I/O outside `~/.claude/projects`) and that the dedupe set in `audit-source.js` still wins over duplicate `message.id`s introduced by subagent files.
- **Delta since last review:** first revision.
- **Known gaps / follow-ups:** see "Uncovered scope" above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)