### PR TITLE
release: 0.6.2 — claude audit walks <session>/subagents/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-04-25
+
+### Fixed
+
+- **Claude audit no longer under-counts subagent tokens.** `src/lib/ops/sources/claude.js#walkSessions` only walked `~/.claude/projects/<project>/*.jsonl`, missing every Task/Agent thread Claude Code writes under `<sessionId>/subagents/agent-*.jsonl`. Subagents consume real Anthropic tokens, so doctor's `truth` column under-counted by 0.5%–11% per day (worst: 19.9M tokens / day). Sync's `walkClaudeProjects` already recursed, so the DB had the right numbers — the audit was comparing an incomplete `truth` against a correct `db`, producing phantom drift signals (e.g. 22.6% on 04-16, 22.5% on 04-17).
+- After the fix, `doctor --audit-tokens --source claude` scans 844 jsonl (was 161); `truth ≈ db` on every settled day in the 14-day window (04-13/15/18/22 sit at 0.0% drift; 04-14/16/19/20/23 ≤0.4%). Remaining drift on the current/previous day is sync lag, not a calculation bug.
+- Cross-checked against Claude Code itself: SDK `usage` JSON returned by `claude -p ... --fork-session` matches the same message's `usage` field in the written jsonl byte-for-byte (input / cache_creation / cache_read / output).
+
+### Notes
+
+- No parser formula or DB schema changed. Other sources (codex, opencode, gemini, kimi, hermes, openclaw) verified via filesystem inspection to lack nested subagent dirs, so they are unaffected.
+
 ## [0.6.1] - 2026-04-25
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeusage",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Codex CLI token usage tracker (macOS-first, notify-driven).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
# What does this PR do?

Patch release bundling the post-#170 fix (#171). Without it, `vibeusage doctor --audit-tokens --source claude` under-counted the local ground truth by 0.5%–11% per day (worst 19.9M tokens / day) and produced phantom drift signals against an already-correct DB.

## Related Issue

Fixes # — bundles #171

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- `package.json`: 0.6.1 → 0.6.2
- `CHANGELOG.md`: new `[0.6.2] - 2026-04-25` entry under `Fixed` documenting the subagent walk fix, with cross-check evidence and the note that other sources are unaffected.

## Affected Modules / Contracts

- **Modules touched:** `package.json`, `CHANGELOG.md`
- **Dependencies / contracts touched:** none — version bump only; #171 already landed the code change to `src/lib/ops/sources/claude.js`.
- **Repo sitemap evidence:** not required (release bookkeeping)

## Validation

### Automated

- #171 already passed `npm test` (813/813) and CI on green.
- This release PR carries no functional code change — the test surface is identical to main as of 44a1040c.

### Manual / smoke

- Verified `node -p "require('./package.json').version"` reports `0.6.2`.
- Verified CHANGELOG entry renders under `[0.6.2]` between `[Unreleased]` and `[0.6.1]`.

### Uncovered scope

- npm publish + git tag follow the existing manual flow after merge (same as #170).

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** version bump + CHANGELOG wording. No new code.
- **Delta since last review:** first revision.
- **Known gaps / follow-ups:** post-merge tag `v0.6.2` and (if desired) npm publish, mirroring #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude audit token counting to walk `<session>/subagents/` directory
> Fixes a bug in `walkSessions` in [claude.js](https://github.com/victorGPT/vibeusage/pull/172/files#diff-916d43022d33f21926df38d6c67b73d1a2343f2b586095bf88c37318b13bd515) where subagent sessions were not being traversed during Claude audit token counting. No parser or schema changes; other sources are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28c6e86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->