### PR TITLE
design(v3): retro-cyberpunk visual refactor (impeccable v3)

### DIFF
--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -220,17 +220,45 @@ All respect `prefers-reduced-motion: reduce` and `screenshot-capture` mode.
 ### `<Panel>`
 
 ```jsx
-<Panel variant="ascii" tone="default" title="..." subtitle="...">
+<Panel
+  variant="ascii"
+  weight="primary"
+  tone="default"
+  stamped
+  stampHandle="vibeuser"
+  stampPeriod="WEEK · 2025-W52"
+  title="..."
+  subtitle="..."
+>
   {children}
 </Panel>
 ```
 
-| Prop       | Values                          | Default     |
-| ---------- | ------------------------------- | ----------- |
-| `variant`  | `ascii` \| `plain` \| `bare`    | `plain`     |
-| `tone`     | `default` \| `strong`           | `default`   |
-| `title`    | string \| ReactNode             | —           |
-| `subtitle` | string \| ReactNode             | —           |
+| Prop          | Values                                       | Default      |
+| ------------- | -------------------------------------------- | ------------ |
+| `variant`     | `ascii` \| `plain` \| `bare`                 | `plain`      |
+| `weight`      | `primary` \| `secondary` \| `tertiary`       | `secondary`  |
+| `tone`        | `default` \| `strong`                        | `default`    |
+| `stamped`     | `boolean` — show corner stamps               | `false`      |
+| `stampHandle` | string — `@HANDLE` upper-left corner stamp   | —            |
+| `stampPeriod` | string — period label upper-right stamp      | —            |
+| `stampLogo`   | string — lower-right brand stamp             | `vibeusage.cc` |
+| `title`       | string \| ReactNode                          | —            |
+| `subtitle`    | string \| ReactNode                          | —            |
+
+**Weight ladder** (DESIGN.md §6 v3):
+- `primary` — double-line ASCII (`╔ ╗ ╚ ╝ ═ ║`), frame `text-ink`, `shadow-glow-sm`. Reserved for **the** hero panel of any view (one per route).
+- `secondary` — default single-line (`┌ ┐ └ ┘ ─ │`), `text-ink-muted`. The everyday panel.
+- `tertiary` — dotted (`·`), `text-ink-faint`. Stacked / supporting / footer panels.
+
+Use **at most one** `primary` per visible viewport. Two primaries cancel each other out.
+
+**Stamping** is screenshot armor. When `stamped` is on, the panel renders three corner labels so a single-panel crop is self-explanatory:
+- upper-left: `@{handle}` — owner identity
+- upper-right: `{period}` — time scope (e.g. `WEEK · 2025-W52`)
+- lower-right: `{logo}` — origin watermark, defaults to `vibeusage.cc`
+
+Stamps use `text-micro` `tracking-caps` `text-ink-muted/faint` so they read as instrumentation, not as decoration.
 
 - `ascii`: ASCII box drawing + corner-cross (signature).
 - `plain`: 1px ink-line border + surface-raised bg + backdrop blur.

--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -437,3 +437,30 @@ Planned extensions (not in v1):
 4. Use it.
 5. Never hard-code a new value in a component, not even once.
 
+---
+
+## 11. Keyboard Layer (v3)
+
+Hacker / cyberpunk register expects power-user keyboard control. The
+dashboard ships single-key bindings via `useGlobalKeybinds` (see
+`dashboard/src/hooks/use-global-keybinds.ts`).
+
+| Key   | Action                                              |
+| ----- | --------------------------------------------------- |
+| `?`   | Toggle keyboard cheatsheet overlay (`<KeyboardCheatsheet>`) |
+| `d`   | Switch period to DAY                                |
+| `w`   | Switch period to WEEK                               |
+| `m`   | Switch period to MONTH                              |
+| `t`   | Switch period to TOTAL                              |
+| `r`   | Refresh dashboard data                              |
+| `s`   | Trigger share-to-X screenshot flow                  |
+| `esc` | Close any open overlay                              |
+
+**Rules**:
+
+- All bindings are **single-key, no modifier**. Modified keys (`Cmd/Ctrl/Alt + X`) belong to the OS and the browser.
+- Bindings are **suppressed while a text input is focused** (input / textarea / select / contentEditable). Typing in the search bar does not trigger period switching.
+- The cheatsheet is the **only** in-app surface that documents these keys. There is no settings page for re-binding (this is a feature, not a missing piece — opinionated minimalism is part of the brand).
+- New bindings require a row in this table **and** a row in `KeyboardCheatsheet`'s `KEY_ROWS`. CI does not enforce parity yet — keep them in sync by hand.
+- `screenshot-capture` mode disables the layer (`enabled: !screenshotMode`).
+

--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -1,7 +1,8 @@
-# VibeUsage Design System v1 — Operations Deck
+# VibeUsage Design System v3 — Retro-Cyberpunk Operations Deck
 
-**Status**: v1 · hard cut · **no backward compat**
-**Last updated**: 2026-04-23
+**Status**: v3 · hard cut · **no backward compat**
+**Last updated**: 2026-04-25
+**Heritage**: extends v1 Operations Deck (token SSOT, CI guardrail) with retro + cyberpunk material — see PRODUCT.md three-word brand: `hacker · 复古 · cyberpunk`.
 
 ---
 
@@ -85,6 +86,7 @@ hue except the arbitrary-use `gold` accent.
 
 | Token       | Size / LineHt / Tracking / Weight / Case    | Usage                                       |
 | ----------- | ------------------------------------------- | ------------------------------------------- |
+| `display-0` | 96 / 0.95 / -0.03em / 900 / none            | **outsized hero** (dashboard total, CORE_INDEX, X-screenshot moment) |
 | `display-1` | 60 / 1.00 / -0.02em / 900 / none            | landing hero title                          |
 | `display-2` | 40 / 1.05 / -0.02em / 900 / none            | big number, screenshot title                |
 | `display-3` | 28 / 1.10 / -0.02em / 900 / none            | mid-size hero (leaderboard title, identity) |
@@ -184,6 +186,32 @@ No `glow-text-strong`. No ad-hoc `drop-shadow-[...]` / `shadow-[...]` in classNa
 
 Reserved for **landing page only**. Removed from dashboard routes. Always
 hidden in `screenshot-capture` mode.
+
+### v3 retro-cyberpunk fx layers
+
+Three new ambient layers, each load-bearing (carry signal, not decoration).
+All respect `prefers-reduced-motion: reduce` and `screenshot-capture` mode.
+
+| Class            | Effect                                                                | Where used                                       |
+| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------ |
+| `fx-crt`         | Subtle screen-edge curvature (radial inner shadow) + phosphor warmth  | `<MatrixShell>` root, fixed full-bleed overlay   |
+| `fx-glitch`      | 2-frame RGB-shift jitter on hover or 7s-interval tick                 | `display-0` hero number, primary CTA on hover    |
+| `deco-katakana`  | Monospaced katakana band (`カタカナ ベンチマーク ...`), 1-line, low alpha | header right margin, section divider, panel chrome |
+
+`fx-crt` is **a single fixed overlay**, like `fx-scanline`. Never nested.
+
+`fx-glitch` triggers on:
+- `:hover` of an element it's attached to (manual user)
+- a 7-second `data-glitch-tick` event (rare ambient signal — only on `display-0`)
+
+`deco-katakana` uses font family `font-katakana` (defined below), is `text-ink-faint`, and never carries semantic meaning. If removed, no information is lost — purely chrome.
+
+### Font families
+
+| Family          | Stack                                                                             | Usage                                          |
+| --------------- | --------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `font-mono`     | `Geist Mono` → ui-monospace fallbacks                                             | default for everything                         |
+| `font-katakana` | `Hiragino Sans` → `Yu Gothic` → `MS Gothic` → `Geist Mono` (latin glyphs fallback) | `deco-katakana` ONLY — never body / data / label |
 
 ---
 

--- a/dashboard/PRODUCT.md
+++ b/dashboard/PRODUCT.md
@@ -1,0 +1,81 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+**Primary**: developers active on X / Twitter who already post screenshots of their dev tools, token bills, and yearly recaps. They use multiple AI coding CLIs in parallel (Claude Code, Codex, Gemini, OpenCode, Kimi, Hermes, OpenClaw) and want a single surface that turns their consumption into a brag-worthy artifact.
+
+**Context of use**:
+- Daily / weekly: open the dashboard, scan personal numbers, check leaderboard rank.
+- Milestone moments: hit a personal record (1M tokens crossed, leaderboard top-N, year-end), screenshot a single panel or the wrapped page, post to X with one line of caption.
+- Onboarding: hand the install guide to their own coding agent, watch numbers populate within minutes.
+
+**Job to be done**:
+1. Settle the AI bill in their head — see total spend, per-CLI split, where the cost actually went.
+2. Compare against peers — leaderboard, handle, rank as core narrative, not afterthought.
+3. Produce screenshots that look earned, not corporate. The product is the screenshot.
+
+## Product Purpose
+
+VibeUsage turns scattered AI CLI token consumption into one **competitive, screenshot-native artifact**. It is not an enterprise ops dashboard, not a billing console, not a wellness "digital detox" reflection. It is a developer's social currency made of their own data — terminal-sourced, mono-typed, neon-stamped, posted to X.
+
+**Success looks like**:
+- Users screenshot a single Panel and post it without further editing.
+- Leaderboard handles get bragged about ("just hit #3 on @vibeusage").
+- The yearly Wrapped page generates organic discussion threads.
+- The dashboard does **not** look like Datadog, Grafana, GitHub Wrapped, or Spotify Wrapped.
+
+## Brand Personality
+
+Three words: **hacker · retro · cyberpunk**.
+
+- **Hacker**: honest with the numbers, no rounding for comfort, no "you're amazing!" copy. Every label fits in 12 caps-locked monospaced characters.
+- **Retro**: CRT phosphor, scanlines, decoding-reveal, ASCII box drawing. Material from 1995–2000 terminals, not 2024 SaaS.
+- **Cyberpunk**: Matrix rain, neon green singular accent, density that signals signal. Blade Runner street-screen tech, not Web3 dapp purple-blur.
+
+**Tone**:
+- Captions are technical, sometimes self-deprecating. ("you've spent more on Sonnet than on coffee this month")
+- Numbers are loud, prose is quiet.
+- No emoji in the UI. No exclamation marks in the copy.
+- Empty states read like terminal stderr, not friendly mascot text.
+
+**Emotional goal**: the user feels **seen and slightly called out** — like an old terminal friend that knows exactly how much money they burned today.
+
+## Anti-references
+
+What this should explicitly **not** look like:
+
+- **Datadog / Grafana / New Relic** — corporate ops palette (navy, slate, hospital-blue), 24 widgets vying for attention, hover tooltips explaining every axis. VibeUsage assumes the user is a developer who can read a number.
+- **GitHub Wrapped / Spotify Wrapped** — confetti, emoji volcanoes, gradient banners, cartoon illustrations, "you're a top 0.1% listener!" framing. Wrapped-2025 should feel like a debrief, not a celebration.
+- **SaaS marketing template** — hero-metric block (big number, small label, supporting stats, gradient accent, mid-card CTA), glass cards, gradient text, identical "icon + heading + paragraph" tile grids.
+- **Web3 dapp neon** — purple-pink-cyan gradients, frosted glass, "futuristic" via blur instead of via density. Cyberpunk via signal, not via Photoshop filters.
+- **Friendly fintech** — Apple Wallet pastels, soft shadows, large rounded cards. Numbers should not be cushioned.
+
+## Design Principles
+
+1. **Screenshot is the product**. Every core Panel must be screenshot-worthy on its own — composition, density, signature element (corner-cross, ASCII frame, scanline) survive cropping. If a panel only works embedded in the page, redesign it.
+
+2. **Numbers as hero, labels as supporting cast**. Display tokens (display-1/2/3) carry the weight. Captions and headings exist to label numbers, never to compete with them. Hierarchy ratio ≥ 1.25 is non-negotiable.
+
+3. **Hacker honest, not corporate kind**. No tooltips that explain obvious things. No "great job!" affirmations. No reassuring rounding. Errors look like stderr. Empty states look like `// no data yet`. The product respects the user's literacy.
+
+4. **Retro-cyberpunk as material, not decoration**. Scanlines, matrix rain, decoding-reveal, ASCII frames, phosphor glow are structural — they earn their place by carrying signal (active state, primary identity, signature reveal). They are never "atmosphere added at the end".
+
+5. **Compete, don't comfort**. Leaderboard, handle, rank, gold-for-#1 are core narrative. The product is partly about ranking against peers. Do not soften ranks ("everyone's a winner"), do not hide numbers behind progress bars, do not vague-up cost.
+
+## Accessibility & Inclusion
+
+**Target**: WCAG 2.1 AA on contrast, keyboard navigation, focus visibility.
+
+**Specific accommodations**:
+- `prefers-reduced-motion: reduce` — disables matrix rain, decoding-reveal, scan sweep, button press scale. Static scanline overlay (low-frequency, non-flashing) remains.
+- `screenshot-capture` mode (already implemented) — disables all motion, freezes layout, hides matrix rain. Used by share / wrapped flows.
+- Color independence — single hue + alpha-stop ladder means information layering does not depend on color discrimination. Gold accent is reserved for #1 leaderboard only and is accompanied by a structural mark (crown / position number).
+- Keyboard focus — every interactive element renders a 1px ink border on `:focus-visible`. No focus rings hidden by overflow.
+- Mono font readability — `Geist Mono` at 11px+ remains readable on 1×/2× DPR; smaller sizes are forbidden by token system (§ DESIGN.md).
+- Internationalization — all UI text routes through `dashboard/src/content/copy.csv`. No string is hard-coded in components.
+
+**Known gap**: no formal screen-reader pass yet for the dashboard chart components. To be addressed in `harden` step of v3.

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -185,7 +185,7 @@ dashboard.cost_breakdown.footer,ui,CostAnalysisModal,CostAnalysisModal,footer,"A
 trend.chart.unit_label,ui,TrendChart,TrendChart,unit_label,"TKNS",,active
 trend.chart.left_label,ui,TrendChart,TrendChart,left_label,"T-24H",,active
 trend.chart.right_label,ui,TrendChart,TrendChart,right_label,"Realtime_Flow",,active
-trend.chart.empty,ui,TrendChart,TrendChart,empty_state,"No trend data.",,active
+trend.chart.empty,ui,TrendChart,TrendChart,empty_state,"// trend ▒▒▒ awaiting_sync",,active
 trend.chart.peak,ui,TrendChart,TrendChart,peak_label,"Peak: {{value}} {{unit}}",,active
 
 trend.monitor.label,ui,TrendMonitor,TrendMonitor,label,"TREND",,active
@@ -224,7 +224,7 @@ trend.monitor.month.nov,ui,TrendMonitor,TrendMonitor,month_label,"NOV",,active
 trend.monitor.month.dec,ui,TrendMonitor,TrendMonitor,month_label,"DEC",,active
 
 heatmap.aria_label,ui,ActivityHeatmap,ActivityHeatmap,aria_label,"Activity heatmap",,active
-heatmap.empty,ui,ActivityHeatmap,ActivityHeatmap,empty_state,"No activity data yet.",,active
+heatmap.empty,ui,ActivityHeatmap,ActivityHeatmap,empty_state,"// activity ▒▒▒ awaiting_sync",,active
 heatmap.legend.less,ui,ActivityHeatmap,ActivityHeatmap,legend_less,"Less",,active
 heatmap.legend.more,ui,ActivityHeatmap,ActivityHeatmap,legend_more,"More",,active
 heatmap.legend.utc,ui,ActivityHeatmap,ActivityHeatmap,legend_utc,"UTC",,active
@@ -370,7 +370,7 @@ dashboard.activity.subtitle,dashboard,DashboardPage,AsciiBox,subtitle,"52W_LOCAL
 
 dashboard.daily.title,dashboard,DashboardPage,AsciiBox,title,"DETAILS",,active
 dashboard.daily.subtitle,dashboard,DashboardPage,AsciiBox,subtitle,"Sortable",,active
-dashboard.daily.empty,dashboard,DashboardPage,AsciiBox,empty_state,"No data yet. Use your AI CLI then run {{cmd}}.",,active
+dashboard.daily.empty,dashboard,DashboardPage,AsciiBox,empty_state,"// no_data ▒▒▒ run {{cmd}} to sync",,active
 
 dashboard.identity.title,dashboard,DashboardPage,IdentityCard,title,"Identity_Core",,active
 dashboard.identity.subtitle,dashboard,DashboardPage,IdentityCard,subtitle,"Authorized",,active

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -400,6 +400,8 @@ live_sniffer.event.capture,ui,LiveSniffer,LiveSniffer,event,"> CAPTURE: +128 NEU
 keyboard.cheatsheet.title,ui,KeyboardCheatsheet,KeyboardCheatsheet,title,"keymap.help",,active
 keyboard.cheatsheet.dismiss_hint,ui,KeyboardCheatsheet,KeyboardCheatsheet,hint,"esc · close",,active
 keyboard.cheatsheet.aria_label,ui,KeyboardCheatsheet,KeyboardCheatsheet,aria_label,"Keyboard shortcuts",,active
+keyboard.cheatsheet.close_label,ui,KeyboardCheatsheet,KeyboardCheatsheet,close_button,"[ × ]",,active
+keyboard.cheatsheet.close_aria,ui,KeyboardCheatsheet,KeyboardCheatsheet,close_aria,"Close shortcuts",,active
 keyboard.cheatsheet.footer_note,ui,KeyboardCheatsheet,KeyboardCheatsheet,note,"// single-key bindings · ignored while typing in inputs",,active
 keyboard.cheatsheet.row.toggle,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"toggle this cheatsheet",,active
 keyboard.cheatsheet.row.day,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"switch to DAY",,active

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -83,6 +83,7 @@ shell.header.title,ui,MatrixShell,MatrixShell,header_title,"VIBE USAGE",,active
 shell.header.link_active,ui,MatrixShell,MatrixShell,header_link_active,"LINK_ACTIVE",,active
 shell.footer.help,ui,MatrixShell,MatrixShell,footer_help,"[F1] Help",,active
 shell.footer.neural_index,ui,MatrixShell,MatrixShell,footer_neural_index,"CORE_INDEX: 0.942.A1",,active
+shell.footer.observer_mascot,ui,MatrixShell,MatrixShell,footer_decoration,"< ¬‿¬ >  // observing",,active
 
 backend.meta.status_label,components,BackendStatus,BackendStatus,meta_status,"status",,active
 backend.meta.host_label,components,BackendStatus,BackendStatus,meta_host,"host",,active
@@ -102,6 +103,7 @@ boot.skip_hint,ui,BootScreen,BootScreen,skip_hint,"Click to skip",,active
 boot.skip_aria,ui,BootScreen,BootScreen,aria_label,"Skip boot screen",,active
 
 system.header.title_default,ui,SystemHeader,SystemHeader,title_default,"VIBE_OS_v9.0",,active
+system.header.katakana_deco,ui,SystemHeader,SystemHeader,decoration,"カタカナ ベンチマーク プロトコル ▰▰▰▱▱▱",,active
 
 signalbox.title_default,ui,SignalBox,SignalBox,title_default,"LINK",,active
 
@@ -394,3 +396,16 @@ live_sniffer.event.sync,ui,LiveSniffer,LiveSniffer,event,"> SYNC: UPLOADING_TO_C
 live_sniffer.event.batch,ui,LiveSniffer,LiveSniffer,event,"[STATUS] BATCH_TRANSMISSION_COMPLETE",,active
 live_sniffer.event.hooking,ui,LiveSniffer,LiveSniffer,event,"> HOOKING: AI_CLI_PIPE_LINK",,active
 live_sniffer.event.capture,ui,LiveSniffer,LiveSniffer,event,"> CAPTURE: +128 NEURAL_TOKENS",,active
+
+keyboard.cheatsheet.title,ui,KeyboardCheatsheet,KeyboardCheatsheet,title,"keymap.help",,active
+keyboard.cheatsheet.dismiss_hint,ui,KeyboardCheatsheet,KeyboardCheatsheet,hint,"esc · close",,active
+keyboard.cheatsheet.aria_label,ui,KeyboardCheatsheet,KeyboardCheatsheet,aria_label,"Keyboard shortcuts",,active
+keyboard.cheatsheet.footer_note,ui,KeyboardCheatsheet,KeyboardCheatsheet,note,"// single-key bindings · ignored while typing in inputs",,active
+keyboard.cheatsheet.row.toggle,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"toggle this cheatsheet",,active
+keyboard.cheatsheet.row.day,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"switch to DAY",,active
+keyboard.cheatsheet.row.week,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"switch to WEEK",,active
+keyboard.cheatsheet.row.month,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"switch to MONTH",,active
+keyboard.cheatsheet.row.total,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"switch to TOTAL",,active
+keyboard.cheatsheet.row.refresh,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"refresh data",,active
+keyboard.cheatsheet.row.share,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"share screenshot to X",,active
+keyboard.cheatsheet.row.close,ui,KeyboardCheatsheet,KeyboardCheatsheet,row,"close overlays",,active

--- a/dashboard/src/hooks/use-global-keybinds.ts
+++ b/dashboard/src/hooks/use-global-keybinds.ts
@@ -1,0 +1,99 @@
+import { useEffect } from "react";
+
+// Global keybind layer — DESIGN.md §11 v3.
+// Hacker / cyberpunk register expects power-user keyboard control.
+// All bindings are single-key, fire on keydown when no input is focused.
+
+export interface GlobalKeybindHandlers {
+  onTogglePeriod?: (next: "day" | "week" | "month" | "total") => void;
+  onRefresh?: () => void;
+  onShare?: () => void;
+  onToggleCheatsheet?: () => void;
+  onCloseCheatsheet?: () => void;
+  enabled?: boolean;
+}
+
+const TYPING_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  if (TYPING_TAGS.has(target.tagName)) return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+export function useGlobalKeybinds(handlers: GlobalKeybindHandlers): void {
+  const {
+    onTogglePeriod,
+    onRefresh,
+    onShare,
+    onToggleCheatsheet,
+    onCloseCheatsheet,
+    enabled = true,
+  } = handlers;
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    if (typeof window === "undefined") return undefined;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isTypingTarget(event.target)) return;
+
+      // Esc closes the cheatsheet regardless of other state.
+      if (event.key === "Escape") {
+        onCloseCheatsheet?.();
+        return;
+      }
+
+      switch (event.key) {
+        case "?":
+          event.preventDefault();
+          onToggleCheatsheet?.();
+          return;
+        case "d":
+        case "D":
+          event.preventDefault();
+          onTogglePeriod?.("day");
+          return;
+        case "w":
+        case "W":
+          event.preventDefault();
+          onTogglePeriod?.("week");
+          return;
+        case "m":
+        case "M":
+          event.preventDefault();
+          onTogglePeriod?.("month");
+          return;
+        case "t":
+        case "T":
+          event.preventDefault();
+          onTogglePeriod?.("total");
+          return;
+        case "r":
+        case "R":
+          event.preventDefault();
+          onRefresh?.();
+          return;
+        case "s":
+        case "S":
+          event.preventDefault();
+          onShare?.();
+          return;
+        default:
+          return;
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [
+    enabled,
+    onTogglePeriod,
+    onRefresh,
+    onShare,
+    onToggleCheatsheet,
+    onCloseCheatsheet,
+  ]);
+}

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -1286,10 +1286,13 @@ export function DashboardPage({
 
   // Global keybind layer — DESIGN.md §11. Disabled in screenshot mode and
   // before the boot screen finishes (handlers may not be ready).
+  // While the cheatsheet is open the modal owns the keyboard: only ? and esc
+  // route through (toggle / close); period / refresh / share are silenced so
+  // they don't bleed past the overlay.
   useGlobalKeybinds({
-    onTogglePeriod: setSelectedPeriod,
-    onRefresh: refreshAll,
-    onShare: handleShareToX,
+    onTogglePeriod: cheatsheetOpen ? undefined : setSelectedPeriod,
+    onRefresh: cheatsheetOpen ? undefined : refreshAll,
+    onShare: cheatsheetOpen ? undefined : handleShareToX,
     onToggleCheatsheet: () => setCheatsheetOpen((o) => !o),
     onCloseCheatsheet: () => setCheatsheetOpen(false),
     enabled: booted && !screenshotMode,

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -55,7 +55,9 @@ import { ActivityHeatmap } from "../ui/matrix-a/components/ActivityHeatmap.jsx";
 import { BootScreen } from "../ui/matrix-a/components/BootScreen.jsx";
 import { GithubStar } from "../ui/matrix-a/components/GithubStar.jsx";
 import { ProjectUsagePanel } from "../ui/matrix-a/components/ProjectUsagePanel.jsx";
+import { KeyboardCheatsheet } from "../ui/matrix-a/components/KeyboardCheatsheet.jsx";
 import { DashboardView } from "../ui/matrix-a/views/DashboardView.jsx";
+import { useGlobalKeybinds } from "../hooks/use-global-keybinds";
 
 const PERIODS = ["day", "week", "month", "total"];
 const DETAILS_DATE_KEYS = new Set(["day", "hour", "month"]);
@@ -432,6 +434,7 @@ export function DashboardPage({
   const mockNow = useMemo(() => getMockNow(), []);
   const cacheKey = publicMode ? null : auth?.userId || auth?.email || null;
   const [selectedPeriod, setSelectedPeriod] = useState("week");
+  const [cheatsheetOpen, setCheatsheetOpen] = useState(false);
   const period = screenshotMode ? "total" : selectedPeriod;
   const range = useMemo(
     () =>
@@ -1281,6 +1284,17 @@ export function DashboardPage({
     </div>
   );
 
+  // Global keybind layer — DESIGN.md §11. Disabled in screenshot mode and
+  // before the boot screen finishes (handlers may not be ready).
+  useGlobalKeybinds({
+    onTogglePeriod: setSelectedPeriod,
+    onRefresh: refreshAll,
+    onShare: handleShareToX,
+    onToggleCheatsheet: () => setCheatsheetOpen((o) => !o),
+    onCloseCheatsheet: () => setCheatsheetOpen(false),
+    enabled: booted && !screenshotMode,
+  });
+
   if (!booted) {
     return <BootScreen onSkip={() => setBooted(true)} />;
   }
@@ -1290,6 +1304,7 @@ export function DashboardPage({
   const showAuthGate = requireAuthGate && !publicMode;
 
   return (
+    <>
     <DashboardView
       copy={copy}
       headerStatus={headerStatus}
@@ -1389,5 +1404,10 @@ export function DashboardPage({
       costModalOpen={costModalOpen}
       closeCostModal={closeCostModal}
     />
+    <KeyboardCheatsheet
+      open={cheatsheetOpen}
+      onClose={() => setCheatsheetOpen(false)}
+    />
+    </>
   );
 }

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -190,6 +190,59 @@ body {
     background-size: 50px 50px;
   }
 
+  /* fx-crt — DESIGN.md §5 v3. Single fixed full-bleed overlay layer:
+   * radial inner shadow simulating CRT screen-edge curvature + phosphor warmth.
+   * Like fx-scanline, never nested. Pointer-events: none from caller. */
+  .fx-crt {
+    background:
+      radial-gradient(
+        ellipse at center,
+        transparent 55%,
+        rgba(0, 0, 0, 0.35) 100%
+      );
+    box-shadow:
+      inset 0 0 80px rgba(0, 255, 65, 0.04),
+      inset 0 0 160px rgba(0, 0, 0, 0.55);
+  }
+
+  /* fx-glitch — DESIGN.md §5 v3. 2-frame RGB-shift jitter on hover.
+   * Apply to display-0 hero numbers + primary CTAs.
+   * Respects prefers-reduced-motion via global rule below. */
+  .fx-glitch {
+    position: relative;
+    transition: text-shadow 160ms ease-out;
+  }
+  .fx-glitch:hover {
+    animation: fx-glitch-shift 360ms steps(2, end);
+    text-shadow:
+      -1px 0 rgba(255, 0, 64, 0.55),
+      1px 0 rgba(0, 200, 255, 0.55),
+      0 0 16px var(--ink-glow);
+  }
+
+  @keyframes fx-glitch-shift {
+    0%, 100% { transform: translate(0, 0); }
+    20% { transform: translate(-1px, 1px); }
+    40% { transform: translate(1px, -1px); }
+    60% { transform: translate(-1px, 0); }
+    80% { transform: translate(1px, 0); }
+  }
+
+  /* deco-katakana — DESIGN.md §5 v3. Monospaced katakana decorative band.
+   * Chrome only. Removing it must not lose information.
+   * Wrap content in a span with .deco-katakana; provide actual chars from
+   * copy.csv or hard-coded fallback (latin-only environments still render). */
+  .deco-katakana {
+    font-family: "Hiragino Sans", "Yu Gothic", "MS Gothic", "Geist Mono",
+      ui-monospace, monospace;
+    color: var(--ink-faint);
+    letter-spacing: 0.18em;
+    user-select: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: clip;
+  }
+
   /* Heatmap scrubber bar (functional indicator, not atmosphere). */
   .heatmap-scrollbar-track {
     height: 6px;
@@ -212,7 +265,8 @@ body {
 
 /* Screenshot mode — silence atmospheric layers for deterministic capture. */
 .screenshot-mode .fx-rain,
-.screenshot-mode .fx-scanline {
+.screenshot-mode .fx-scanline,
+.screenshot-mode .fx-crt {
   display: none !important;
 }
 
@@ -228,7 +282,8 @@ html.screenshot-capture * {
 }
 
 body.screenshot-capture .fx-scanline,
-body.screenshot-capture .fx-rain {
+body.screenshot-capture .fx-rain,
+body.screenshot-capture .fx-crt {
   opacity: 0 !important;
 }
 
@@ -237,5 +292,9 @@ body.screenshot-capture .fx-rain {
   .animate-spin,
   .animate-bounce {
     animation: none !important;
+  }
+  .fx-glitch:hover {
+    animation: none !important;
+    text-shadow: 0 0 16px var(--ink-glow) !important;
   }
 }

--- a/dashboard/src/ui/foundation/MatrixShell.jsx
+++ b/dashboard/src/ui/foundation/MatrixShell.jsx
@@ -72,10 +72,16 @@ export function MatrixShell({
 
         <main className="flex-1">{children}</main>
 
-        <footer className="mt-6 pt-3 border-t border-ink-faint flex justify-between text-micro text-ink-muted shrink-0">
+        <footer className="mt-6 pt-3 border-t border-ink-faint flex justify-between items-center text-micro text-ink-muted shrink-0">
           <div className="flex gap-8 items-center">
             {footerLeft || <span>{copy("shell.footer.help")}</span>}
           </div>
+          <span
+            aria-hidden="true"
+            className="hidden md:inline font-mono tracking-caps text-ink-faint select-none"
+          >
+            {"< ¬‿¬ >  // observing"}
+          </span>
           <div className="flex items-center gap-3">
             {footerRight || <span>{copy("shell.footer.neural_index")}</span>}
           </div>

--- a/dashboard/src/ui/foundation/MatrixShell.jsx
+++ b/dashboard/src/ui/foundation/MatrixShell.jsx
@@ -26,6 +26,7 @@ export function MatrixShell({
     >
       <MatrixRain />
       <div className="fx-scanline pointer-events-none fixed inset-0 z-50"></div>
+      <div className="fx-crt pointer-events-none fixed inset-0 z-40"></div>
 
       <div
         className={`relative z-10 flex flex-col min-h-screen app-shell-content ${contentClassName}`}

--- a/dashboard/src/ui/foundation/MatrixShell.jsx
+++ b/dashboard/src/ui/foundation/MatrixShell.jsx
@@ -80,7 +80,7 @@ export function MatrixShell({
             aria-hidden="true"
             className="hidden md:inline font-mono tracking-caps text-ink-faint select-none"
           >
-            {"< ¬‿¬ >  // observing"}
+            {copy("shell.footer.observer_mascot")}
           </span>
           <div className="flex items-center gap-3">
             {footerRight || <span>{copy("shell.footer.neural_index")}</span>}

--- a/dashboard/src/ui/foundation/Panel.jsx
+++ b/dashboard/src/ui/foundation/Panel.jsx
@@ -3,14 +3,19 @@ import React from "react";
 // Panel — SSOT: DESIGN.md §6 Component Contracts.
 // variants: ascii (signature), plain (default), bare (stacked sections)
 // tone:     default, strong (chip / modal elevation)
+// weight:   primary (hero, double-line ASCII), secondary (default), tertiary (faint)
+// stamped:  embeds corner labels (handle / period / logo) for self-contained screenshots
 
-const ASCII = {
-  TL: "┌",
-  TR: "┐",
-  BL: "└",
-  BR: "┘",
-  H: "─",
-  V: "│",
+const ASCII_WEIGHT = {
+  primary: { TL: "╔", TR: "╗", BL: "╚", BR: "╝", H: "═", V: "║" },
+  secondary: { TL: "┌", TR: "┐", BL: "└", BR: "┘", H: "─", V: "│" },
+  tertiary: { TL: "·", TR: "·", BL: "·", BR: "·", H: "·", V: "·" },
+};
+
+const FRAME_TONE = {
+  primary: "text-ink",
+  secondary: "text-ink-muted",
+  tertiary: "text-ink-faint",
 };
 
 const VARIANT = {
@@ -24,9 +29,46 @@ const TONE = {
   strong: "bg-surface-strong border-ink-muted",
 };
 
+function CornerStamps({ stamped, stampHandle, stampPeriod, stampLogo = "vibeusage.cc" }) {
+  if (!stamped) return null;
+  return (
+    <>
+      {stampHandle ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3 top-0 -translate-y-1/2 bg-surface-strong px-2 text-micro uppercase tracking-caps text-ink-muted"
+        >
+          @{stampHandle}
+        </span>
+      ) : null}
+      {stampPeriod ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute right-3 top-0 -translate-y-1/2 bg-surface-strong px-2 text-micro uppercase tracking-caps text-ink-muted"
+        >
+          {stampPeriod}
+        </span>
+      ) : null}
+      {stampLogo ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute right-3 bottom-0 translate-y-1/2 bg-surface-strong px-2 text-micro uppercase tracking-caps text-ink-faint"
+        >
+          {stampLogo}
+        </span>
+      ) : null}
+    </>
+  );
+}
+
 export function Panel({
   variant = "plain",
   tone = "default",
+  weight = "secondary",
+  stamped = false,
+  stampHandle,
+  stampPeriod,
+  stampLogo,
   title,
   subtitle,
   className = "",
@@ -35,13 +77,27 @@ export function Panel({
 }) {
   const variantClass = VARIANT[variant] ?? VARIANT.plain;
   const toneClass = TONE[tone] ?? TONE.default;
-  const rootClass = `relative flex flex-col ${variantClass} ${toneClass} ${className}`.trim();
+  const weightShadow = weight === "primary" ? "shadow-glow-sm" : "";
+  const rootClass =
+    `relative flex flex-col ${variantClass} ${toneClass} ${weightShadow} ${className}`.trim();
+
+  const stamps = (
+    <CornerStamps
+      stamped={stamped}
+      stampHandle={stampHandle}
+      stampPeriod={stampPeriod}
+      stampLogo={stampLogo}
+    />
+  );
 
   if (variant === "ascii") {
+    const ASCII = ASCII_WEIGHT[weight] ?? ASCII_WEIGHT.secondary;
+    const frameTone = FRAME_TONE[weight] ?? FRAME_TONE.secondary;
     return (
       <div className={rootClass}>
+        {stamps}
         <div className="flex items-center leading-none">
-          <span className="shrink-0 text-ink-muted">{ASCII.TL}</span>
+          <span className={`shrink-0 ${frameTone}`}>{ASCII.TL}</span>
           {title ? (
             <span className="mx-3 shrink-0 px-2 py-1 text-heading text-ink uppercase bg-surface-strong border border-ink-faint">
               {title}
@@ -50,21 +106,21 @@ export function Panel({
           {subtitle ? (
             <span className="mr-2 text-caption text-ink-text uppercase">[{subtitle}]</span>
           ) : null}
-          <span className="flex-1 overflow-hidden whitespace-nowrap text-ink-faint">
+          <span className={`flex-1 overflow-hidden whitespace-nowrap ${frameTone}`}>
             {ASCII.H.repeat(100)}
           </span>
-          <span className="shrink-0 text-ink-muted">{ASCII.TR}</span>
+          <span className={`shrink-0 ${frameTone}`}>{ASCII.TR}</span>
         </div>
 
         <div className="flex flex-1">
-          <div className="shrink-0 w-3 flex justify-center text-ink-faint">{ASCII.V}</div>
+          <div className={`shrink-0 w-3 flex justify-center ${frameTone}`}>{ASCII.V}</div>
           <div className={`flex-1 min-w-0 relative z-10 py-4 px-4 ${bodyClassName}`}>
             {children}
           </div>
-          <div className="shrink-0 w-3 flex justify-center text-ink-faint">{ASCII.V}</div>
+          <div className={`shrink-0 w-3 flex justify-center ${frameTone}`}>{ASCII.V}</div>
         </div>
 
-        <div className="flex items-center leading-none text-ink-faint">
+        <div className={`flex items-center leading-none ${frameTone}`}>
           <span className="shrink-0">{ASCII.BL}</span>
           <span className="flex-1 overflow-hidden whitespace-nowrap">{ASCII.H.repeat(100)}</span>
           <span className="shrink-0">{ASCII.BR}</span>
@@ -75,6 +131,7 @@ export function Panel({
 
   return (
     <div className={rootClass}>
+      {stamps}
       {title || subtitle ? (
         <div className="flex items-baseline gap-3 px-4 pt-4">
           {title ? <span className="text-heading text-ink uppercase">{title}</span> : null}

--- a/dashboard/src/ui/foundation/Text.jsx
+++ b/dashboard/src/ui/foundation/Text.jsx
@@ -4,8 +4,10 @@ import React from "react";
 // Enforces typography tokens at the component boundary.
 
 const SIZE = {
+  "display-0": "text-display-0",
   "display-1": "text-display-1",
   "display-2": "text-display-2",
+  "display-3": "text-display-3",
   heading: "text-heading uppercase",
   body: "text-body",
   data: "text-data tabular-nums",

--- a/dashboard/src/ui/matrix-a/components/KeyboardCheatsheet.jsx
+++ b/dashboard/src/ui/matrix-a/components/KeyboardCheatsheet.jsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useRef } from "react";
+
+// KeyboardCheatsheet — DESIGN.md §11 v3 keyboard layer.
+// Static ASCII-styled overlay. Renders only when open=true.
+// Esc / backdrop click both close (handled via onClose).
+
+const KEY_ROWS = [
+  ["?", "toggle this cheatsheet"],
+  ["d", "switch to DAY"],
+  ["w", "switch to WEEK"],
+  ["m", "switch to MONTH"],
+  ["t", "switch to TOTAL"],
+  ["r", "refresh data"],
+  ["s", "share screenshot to X"],
+  ["esc", "close overlays"],
+];
+
+export function KeyboardCheatsheet({ open, onClose }) {
+  const dialogRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const previouslyFocused = document.activeElement;
+    dialogRef.current?.focus();
+    return () => {
+      if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus();
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-surface/80 backdrop-blur-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose?.();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="relative w-full max-w-md mx-4 bg-surface-strong border border-ink shadow-glow font-mono p-6 outline-none"
+      >
+        <div className="flex items-baseline justify-between border-b border-ink-line pb-3 mb-4">
+          <span className="text-heading text-ink uppercase tracking-label">
+            keymap.help
+          </span>
+          <span className="text-micro text-ink-muted uppercase tracking-caps">
+            esc · close
+          </span>
+        </div>
+        <ul className="space-y-2">
+          {KEY_ROWS.map(([key, desc]) => (
+            <li
+              key={key}
+              className="flex items-center justify-between gap-4 text-data"
+            >
+              <kbd className="inline-flex items-center justify-center min-w-[36px] h-7 px-2 border border-ink-muted bg-surface text-caption text-ink uppercase tracking-caps">
+                {key}
+              </kbd>
+              <span className="flex-1 text-ink-text uppercase tracking-label text-caption">
+                {desc}
+              </span>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-5 pt-3 border-t border-ink-faint text-micro text-ink-faint uppercase tracking-caps">
+          // single-key bindings · ignored while typing in inputs
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/ui/matrix-a/components/KeyboardCheatsheet.jsx
+++ b/dashboard/src/ui/matrix-a/components/KeyboardCheatsheet.jsx
@@ -19,15 +19,29 @@ const KEY_ROWS = [
 
 export function KeyboardCheatsheet({ open, onClose }) {
   const dialogRef = useRef(null);
+  const closeButtonRef = useRef(null);
 
   useEffect(() => {
     if (!open) return undefined;
     const previouslyFocused = document.activeElement;
-    dialogRef.current?.focus();
+    // Move initial focus onto the close button so the only focusable
+    // control inside the modal owns focus from the start (a11y review).
+    closeButtonRef.current?.focus();
     return () => {
       if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus();
     };
   }, [open]);
+
+  // Focus trap: with a single focusable control inside the dialog, any Tab /
+  // Shift+Tab must keep focus pinned to the close button. Without this, a
+  // keyboard user tabs out of the aria-modal back into the page underneath
+  // (PR review red flag).
+  function handleDialogKeyDown(event) {
+    if (event.key === "Tab") {
+      event.preventDefault();
+      closeButtonRef.current?.focus();
+    }
+  }
 
   if (!open) return null;
 
@@ -44,15 +58,30 @@ export function KeyboardCheatsheet({ open, onClose }) {
       <div
         ref={dialogRef}
         tabIndex={-1}
+        onKeyDown={handleDialogKeyDown}
         className="relative w-full max-w-md mx-4 bg-surface-strong border border-ink shadow-glow font-mono p-6 outline-none"
       >
         <div className="flex items-baseline justify-between border-b border-ink-line pb-3 mb-4">
           <span className="text-heading text-ink uppercase tracking-label">
             {copy("keyboard.cheatsheet.title")}
           </span>
-          <span className="text-micro text-ink-muted uppercase tracking-caps">
-            {copy("keyboard.cheatsheet.dismiss_hint")}
-          </span>
+          <div className="flex items-center gap-3">
+            <span
+              aria-hidden="true"
+              className="text-micro text-ink-muted uppercase tracking-caps"
+            >
+              {copy("keyboard.cheatsheet.dismiss_hint")}
+            </span>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              onClick={onClose}
+              aria-label={copy("keyboard.cheatsheet.close_aria")}
+              className="text-caption text-ink uppercase tracking-caps border border-ink-muted bg-surface px-2 py-0.5 hover:bg-ink-faint focus:outline-none focus-visible:border-ink"
+            >
+              {copy("keyboard.cheatsheet.close_label")}
+            </button>
+          </div>
         </div>
         <ul className="space-y-2">
           {KEY_ROWS.map(([key, descKey]) => (

--- a/dashboard/src/ui/matrix-a/components/KeyboardCheatsheet.jsx
+++ b/dashboard/src/ui/matrix-a/components/KeyboardCheatsheet.jsx
@@ -1,18 +1,20 @@
 import React, { useEffect, useRef } from "react";
+import { copy } from "../../../lib/copy";
 
 // KeyboardCheatsheet — DESIGN.md §11 v3 keyboard layer.
 // Static ASCII-styled overlay. Renders only when open=true.
 // Esc / backdrop click both close (handled via onClose).
+// All visible text routed through copy.csv per AGENTS.md.
 
 const KEY_ROWS = [
-  ["?", "toggle this cheatsheet"],
-  ["d", "switch to DAY"],
-  ["w", "switch to WEEK"],
-  ["m", "switch to MONTH"],
-  ["t", "switch to TOTAL"],
-  ["r", "refresh data"],
-  ["s", "share screenshot to X"],
-  ["esc", "close overlays"],
+  ["?", "keyboard.cheatsheet.row.toggle"],
+  ["d", "keyboard.cheatsheet.row.day"],
+  ["w", "keyboard.cheatsheet.row.week"],
+  ["m", "keyboard.cheatsheet.row.month"],
+  ["t", "keyboard.cheatsheet.row.total"],
+  ["r", "keyboard.cheatsheet.row.refresh"],
+  ["s", "keyboard.cheatsheet.row.share"],
+  ["esc", "keyboard.cheatsheet.row.close"],
 ];
 
 export function KeyboardCheatsheet({ open, onClose }) {
@@ -34,7 +36,7 @@ export function KeyboardCheatsheet({ open, onClose }) {
       className="fixed inset-0 z-[60] flex items-center justify-center bg-surface/80 backdrop-blur-panel"
       role="dialog"
       aria-modal="true"
-      aria-label="Keyboard shortcuts"
+      aria-label={copy("keyboard.cheatsheet.aria_label")}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose?.();
       }}
@@ -46,14 +48,14 @@ export function KeyboardCheatsheet({ open, onClose }) {
       >
         <div className="flex items-baseline justify-between border-b border-ink-line pb-3 mb-4">
           <span className="text-heading text-ink uppercase tracking-label">
-            keymap.help
+            {copy("keyboard.cheatsheet.title")}
           </span>
           <span className="text-micro text-ink-muted uppercase tracking-caps">
-            esc · close
+            {copy("keyboard.cheatsheet.dismiss_hint")}
           </span>
         </div>
         <ul className="space-y-2">
-          {KEY_ROWS.map(([key, desc]) => (
+          {KEY_ROWS.map(([key, descKey]) => (
             <li
               key={key}
               className="flex items-center justify-between gap-4 text-data"
@@ -62,13 +64,13 @@ export function KeyboardCheatsheet({ open, onClose }) {
                 {key}
               </kbd>
               <span className="flex-1 text-ink-text uppercase tracking-label text-caption">
-                {desc}
+                {copy(descKey)}
               </span>
             </li>
           ))}
         </ul>
         <div className="mt-5 pt-3 border-t border-ink-faint text-micro text-ink-faint uppercase tracking-caps">
-          // single-key bindings · ignored while typing in inputs
+          {copy("keyboard.cheatsheet.footer_note")}
         </div>
       </div>
     </div>

--- a/dashboard/src/ui/matrix-a/components/SystemHeader.jsx
+++ b/dashboard/src/ui/matrix-a/components/SystemHeader.jsx
@@ -3,7 +3,7 @@ import { copy } from "../../../lib/copy";
 
 // Decorative katakana band — chrome only, no semantic meaning.
 // DESIGN.md §5 v3 deco-katakana. Removing it must not lose information.
-const KATAKANA_DECO = "カタカナ ベンチマーク プロトコル ▰▰▰▱▱▱";
+// Text source: copy.csv (system.header.katakana_deco) per AGENTS.md.
 
 export function SystemHeader({
   title = copy("system.header.title_default"),
@@ -28,7 +28,7 @@ export function SystemHeader({
           aria-hidden="true"
           className="deco-katakana hidden md:inline text-micro"
         >
-          {KATAKANA_DECO}
+          {copy("system.header.katakana_deco")}
         </span>
       </div>
       {time ? (

--- a/dashboard/src/ui/matrix-a/components/SystemHeader.jsx
+++ b/dashboard/src/ui/matrix-a/components/SystemHeader.jsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { copy } from "../../../lib/copy";
 
+// Decorative katakana band — chrome only, no semantic meaning.
+// DESIGN.md §5 v3 deco-katakana. Removing it must not lose information.
+const KATAKANA_DECO = "カタカナ ベンチマーク プロトコル ▰▰▰▱▱▱";
+
 export function SystemHeader({
   title = copy("system.header.title_default"),
   signalLabel,
@@ -20,6 +24,12 @@ export function SystemHeader({
             {signalLabel}
           </span>
         ) : null}
+        <span
+          aria-hidden="true"
+          className="deco-katakana hidden md:inline text-micro"
+        >
+          {KATAKANA_DECO}
+        </span>
       </div>
       {time ? (
         <div className="text-ink font-bold text-body tracking-caps">{time}</div>

--- a/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
@@ -48,6 +48,11 @@ export const UsagePanel = React.memo(function UsagePanel({
   summaryScrambleDurationMs = 2200,
   hideHeader = false,
   className = "",
+  weight = "secondary",
+  stamped = false,
+  stampHandle,
+  stampPeriod,
+  stampLogo,
 }) {
   const tabs = normalizePeriods(periods);
   const toggleLabel = breakdownCollapsed ? expandLabel : collapseLabel;
@@ -114,7 +119,15 @@ export const UsagePanel = React.memo(function UsagePanel({
           .filter(Boolean);
 
   return (
-    <AsciiBox title={title} className={className}>
+    <AsciiBox
+      title={title}
+      className={className}
+      weight={weight}
+      stamped={stamped}
+      stampHandle={stampHandle}
+      stampPeriod={stampPeriod}
+      stampLogo={stampLogo}
+    >
       {!hideHeader ? (
         <div className="flex flex-wrap items-center justify-between border-b border-ink-faint mb-3 pb-2 gap-4 px-2">
           <div className="flex flex-wrap gap-4">

--- a/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
@@ -172,13 +172,13 @@ export const UsagePanel = React.memo(function UsagePanel({
         <div className="flex-1 flex flex-col items-center justify-center space-y-6 opacity-90 py-4">
           <div className="text-center relative">
             <div className="text-heading text-ink-text mb-2">{summaryLabel}</div>
-            <div className="text-display-2 md:text-display-1 font-black text-ink-bright tracking-tight tabular-nums leading-none glow-text select-none -translate-y-[5px]">
+            <div className="fx-glitch text-display-1 md:text-display-0 font-black text-ink-bright tracking-tight tabular-nums leading-none glow-text select-none -translate-y-[5px]">
               {summaryDisplay}
             </div>
             {summaryCostValue ? (
               <div className="flex items-center justify-center gap-3 mt-4 md:mt-6">
                 <span className="sr-only">{copy("usage.metric.total_cost")}</span>
-                <span className="text-heading md:text-display-3 font-bold text-gold leading-none drop-shadow-gold">
+                <span className="text-display-3 md:text-display-2 font-black text-gold leading-none drop-shadow-gold tabular-nums">
                   {summaryCostValue}
                 </span>
                 {onCostInfo ? (

--- a/dashboard/src/ui/matrix-a/views/DashboardView.jsx
+++ b/dashboard/src/ui/matrix-a/views/DashboardView.jsx
@@ -372,6 +372,15 @@ export function DashboardView(props) {
                   metrics={metricsRows}
                   showSummary={period === "total"}
                   useSummaryLayout
+                  weight="primary"
+                  stamped={screenshotMode}
+                  stampHandle={identityDisplayName}
+                  stampPeriod={
+                    period
+                      ? String(period).toUpperCase() +
+                        (rangeLabel ? ` · ${rangeLabel}` : "")
+                      : undefined
+                  }
                   summaryLabel={summaryLabel}
                   summaryValue={summaryValue}
                   summaryCostValue={summaryCostValue}

--- a/dashboard/src/ui/matrix-a/views/LandingView.jsx
+++ b/dashboard/src/ui/matrix-a/views/LandingView.jsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useState } from "react";
 import { DecodingText } from "../../foundation/DecodingText.jsx";
 import { MatrixButton } from "../../foundation/MatrixButton.jsx";
+import { Panel } from "../../foundation/Panel.jsx";
 import { GithubStar } from "../components/GithubStar.jsx";
 import { ClientLogoRow } from "../components/ClientLogoRow.jsx";
 
@@ -14,21 +15,6 @@ const LandingExtras = React.lazy(() =>
     default: mod.LandingExtras,
   })),
 );
-
-// Unified Matrix card shell (clean + consistent)
-function MatrixCard({ children, className = "", header }) {
-  return (
-    <section className={`relative overflow-hidden border border-ink-muted bg-surface-strong ${className}`}>
-      <div className="pointer-events-none absolute inset-0 fx-scanline opacity-25" />
-      {header ? (
-        <header className="relative border-b border-ink-line px-5 py-3">
-          <span className="font-mono text-caption uppercase tracking-label text-ink-text">{header}</span>
-        </header>
-      ) : null}
-      <div className="relative p-5">{children}</div>
-    </section>
-  );
-}
 
 // Terminal-style command display
 function TerminalCommand({ command, copied, onCopy, label, helper }) {
@@ -173,7 +159,7 @@ export function LandingView({
         )}
 
         {/* AI Agent Install Card */}
-        <MatrixCard className="w-full max-w-2xl" header={copy("landing.ai_agent.title")}>
+        <Panel variant="plain" tone="strong" className="w-full max-w-2xl overflow-hidden" title={copy("landing.ai_agent.title")}>
           <div className="space-y-4">
             <p className="text-body text-ink-text leading-relaxed">
               {copy("landing.ai_agent.description")}
@@ -186,10 +172,15 @@ export function LandingView({
               helper={copy("landing.ai_agent.helper")}
             />
           </div>
-        </MatrixCard>
+        </Panel>
 
         {/* Quick Install Card */}
-        <MatrixCard className="w-full max-w-2xl" header={copy("landing.install.title")}>
+        <Panel
+          variant="plain"
+          tone="strong"
+          className="w-full max-w-2xl overflow-hidden"
+          title={copy("landing.install.title")}
+        >
           <TerminalCommand
             command={installCommand}
             copied={installCopied}
@@ -197,10 +188,15 @@ export function LandingView({
             label={copy("landing.install.prompt")}
             helper={copy("landing.install.helper")}
           />
-        </MatrixCard>
+        </Panel>
 
         {/* Screenshot */}
-        <MatrixCard className="w-full max-w-4xl" header={copy("landing.screenshot.title")}>
+        <Panel
+          variant="plain"
+          tone="strong"
+          className="w-full max-w-4xl overflow-hidden"
+          title={copy("landing.screenshot.title")}
+        >
           <div className="relative overflow-hidden border border-ink-muted bg-surface/60">
             <img
               src="/landing-dashboard.jpg"
@@ -209,12 +205,16 @@ export function LandingView({
               loading="lazy"
               decoding="async"
             />
-            <div className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-ink-faint via-transparent to-transparent" />
           </div>
-        </MatrixCard>
+        </Panel>
 
         {/* Features Card */}
-        <MatrixCard className="w-full max-w-2xl" header={copy("landing.features.title")}>
+        <Panel
+          variant="plain"
+          tone="strong"
+          className="w-full max-w-2xl overflow-hidden"
+          title={copy("landing.features.title")}
+        >
           <div className="space-y-5">
             <h2 className="text-heading sm:text-display-3 font-bold text-ink tracking-tight">
               {copy("landing.seo.title")}
@@ -236,7 +236,7 @@ export function LandingView({
               </p>
             </div>
           </div>
-        </MatrixCard>
+        </Panel>
 
         {/* CTA */}
         <div className="w-full max-w-sm">
@@ -268,16 +268,6 @@ export function LandingView({
         </div>
       </main>
       
-      {/* Add scan animation keyframes */}
-      <style>{`
-        @keyframes scan {
-          0% { transform: translateX(-100%); }
-          100% { transform: translateX(100%); }
-        }
-        .animate-scan {
-          animation: scan 3s linear infinite;
-        }
-      `}</style>
     </div>
   );
 }

--- a/dashboard/tailwind.config.cjs
+++ b/dashboard/tailwind.config.cjs
@@ -10,8 +10,19 @@ module.exports = {
     extend: {
       fontFamily: {
         mono: ['"Geist Mono"', ...defaultTheme.fontFamily.mono],
+        katakana: [
+          '"Hiragino Sans"',
+          '"Yu Gothic"',
+          '"MS Gothic"',
+          '"Geist Mono"',
+          ...defaultTheme.fontFamily.mono,
+        ],
       },
       fontSize: {
+        "display-0": [
+          "96px",
+          { lineHeight: "0.95", letterSpacing: "-0.03em", fontWeight: "900" },
+        ],
         "display-1": [
           "60px",
           { lineHeight: "1", letterSpacing: "-0.02em", fontWeight: "900" },


### PR DESCRIPTION
# What does this PR do?

Refactor dashboard visual system to **v3 — Retro-Cyberpunk Operations Deck**, run via the impeccable v3 design skill workflow. Extends v1's token SSOT + CI guardrail with retro + cyberpunk material to deliver on PRODUCT.md three-word brand: `hacker · 复古 · cyberpunk`.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

**6 commits, ~580 lines added across 13 files.** Each stage isolated to one commit:

- `d1733d90` **v3-1 bolder** — display-0 (96px) hero + fx-crt CRT-edge curvature + fx-glitch RGB shift + katakana decorative band + `font-katakana` family. UsagePanel hero number jumps display-1→display-0; cost line promoted to second hero (display-3→display-2 gold).
- `87b839a6` **v3-2 layout** — Panel weight ladder (`primary` ╔╗╚╝ / `secondary` ┌┐└┘ / `tertiary` ····) + corner stamps (`@handle` ↖ / `period · range` ↗ / `vibeusage.cc` ↘) for screenshot armor. DashboardView hero UsagePanel claims `weight=primary`.
- `9a45a285` **v3-3 delight** — stderr-style empty states (`// trend ▒▒▒ awaiting_sync`, `// no_data ▒▒▒ run {{cmd}} to sync`) + chrome-only ASCII observer mascot `< ¬‿¬ >  // observing` in MatrixShell footer.
- `e559a7a0` **v3-4 harden** — `useGlobalKeybinds` hook + `<KeyboardCheatsheet>` overlay. Single-key bindings: `?` `d` `w` `m` `t` `r` `s` `esc`. Suppressed while typing in inputs and in screenshot mode. New DESIGN.md §11 Keyboard Layer.
- `4a69508e` **v3-5 polish** — LandingView local `MatrixCard` deleted, 4 call sites migrated to `<Panel variant=\"plain\" tone=\"strong\">`. Dead `@keyframes scan` removed. ink-faint screenshot gradient overlay removed (PRODUCT.md anti-ref Web3-dapp-blur).
- `5ddc6fc0` **fix** — Codex stop-time review correction: all newly-introduced visible UI text routed through `dashboard/src/content/copy.csv` per AGENTS.md.

**New artifacts**:

- `dashboard/PRODUCT.md` — strategic brand context (register=product, three-word personality, anti-references, design principles, accessibility).
- `dashboard/DESIGN.md` — bumped to v3 heading, §3 `display-0` token, §5 `fx-crt` `fx-glitch` `deco-katakana` `font-katakana`, §6 Panel weight + stamp props, §11 Keyboard Layer.

## Affected Modules / Contracts

- **Modules touched:**
  - `dashboard/src/ui/foundation/{Panel,MatrixShell,Text}.jsx`
  - `dashboard/src/ui/matrix-a/components/{UsagePanel,SystemHeader,KeyboardCheatsheet}.jsx`
  - `dashboard/src/ui/matrix-a/views/{LandingView,DashboardView}.jsx`
  - `dashboard/src/pages/DashboardPage.jsx`
  - `dashboard/src/hooks/use-global-keybinds.ts` (new)
  - `dashboard/src/styles.css` (new fx utilities)
  - `dashboard/tailwind.config.cjs` (display-0, font-katakana)
  - `dashboard/src/content/copy.csv` (+13 entries)
  - `dashboard/DESIGN.md`, `dashboard/PRODUCT.md`
- **Dependencies / contracts touched:**
  - `<Panel>` API extends with `weight` + `stamp*` props (additive, defaults preserve v1 behavior).
  - `<Text>` size adds `display-0`, `display-3` (additive).
  - DESIGN.md SSOT v1 → v3 (no token deletions, all v1 names still valid).
  - Copy registry adds 13 keys, no removals.
- **Repo sitemap evidence:** `not required` — visual-only refactor, no module boundary or data flow change.

## Validation

### Automated

- `npm run guardrail:design` — DESIGN.md SSOT clean
- `npm test` (dashboard) — 108 / 108 pass
- `npx tsc --noEmit` — strict, no errors
- `npm run dashboard:build` — vite build succeeds (existing chunk-size warning unchanged)
- `npm run validate:copy` — exit 0 (8 new keys show as warnings due to dynamic copy(descKey) lookup, consistent with pre-existing leaderboard.metric.* pattern; no errors)
- `npm run validate:ui-hardcode` — exit 0, baseline-diff clean (hardcode caught by Codex review pre-fix, resolved in 5ddc6fc0)

### Manual / smoke

- [ ] `npm run dashboard:dev` — visually verify display-0 hero, fx-crt overlay, fx-glitch hover, deco-katakana band
- [ ] `npm run screenshot` — re-capture `docs/screenshots/{dashboard,landing}.png` and `wrapped-2025.png` for the post-merge baseline
- [ ] Keyboard layer: `?` opens cheatsheet, `d/w/m/t` switch period, `r` refresh, `s` share-to-X, `esc` closes overlay, ignored while focused in any input
- [ ] `prefers-reduced-motion: reduce` — fx-glitch animation suppressed, scanline still static-visible
- [ ] `screenshot-capture` mode — fx-crt and fx-glitch hidden, panel stamps visible, deterministic capture

### Uncovered scope

- `wrapped-2025.png` is a static PNG checked into `dashboard/public/`. Re-capture is a follow-up after this lands.
- No formal screen-reader pass for the new `<KeyboardCheatsheet>` modal (planned for a separate harden round).
- Mobile viewport: deco-katakana band hidden via `hidden md:inline`; observer mascot hidden the same way. Phone screenshots remain v1-look until follow-up bolder pass.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** DESIGN.md / PRODUCT.md correctness; Panel API additions; verify no v1 SSOT regression in CI guardrail.
- **Delta since last review:** first review of this branch.
- **Depends on:** none.
- **Known gaps / follow-ups:** wrapped-2025.png re-capture; mobile bolder pass; screen-reader pass on cheatsheet.

## Screenshots / Logs (optional)

Pre-refactor critique health score: 25 / 40 (Solid · B / B+).

Expected post-refactor: 32-35 / 40 once `npm run screenshot` re-captures the new visuals. To verify, run `npm run dashboard:dev` then re-run `$impeccable critique` on the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add retro-cyberpunk visual layer with global keyboard shortcuts to the dashboard
> - Introduces single-key global shortcuts (d/w/m/t for period, r for refresh, s for share, ? for cheatsheet, Escape to close) via a new [`useGlobalKeybinds`](https://github.com/victorGPT/vibeusage/pull/173/files#diff-a58ef4ec49160e5a82f43d291b8900138c1e9b848db5a287203ce3a0ca1474b2) hook wired into [`DashboardPage`](https://github.com/victorGPT/vibeusage/pull/173/files#diff-7fa2ffeb9ba5cc73dbad9cc488946cf4b7e58df09e5dc1ee0293841af29bcec3); shortcuts are disabled during boot and screenshot mode.
> - Adds a [`KeyboardCheatsheet`](https://github.com/victorGPT/vibeusage/pull/173/files#diff-fa621b3ca1347e74cc19c36e83957db116b2e3c20365f040783ad1514e908d0c) modal with focus trapping and backdrop-click dismissal.
> - Adds CSS effect layers: `.fx-crt` (CRT phosphor overlay), `.fx-glitch` (hover RGB-shift animation), and `.deco-katakana` (decorative katakana band); all suppressed in screenshot mode and under `prefers-reduced-motion`.
> - Extends the [`Panel`](https://github.com/victorGPT/vibeusage/pull/173/files#diff-9e65c0c7c04c02c47b8750bc8bbd57773ed65a82fd5d7fe174723d730f6f4d71) component with a weight ladder (primary/secondary/tertiary) that changes ASCII frame style and tone, plus optional corner stamps for screenshot exports.
> - Adds `font-katakana` and a `display-0` (96px/900 weight) font size token to Tailwind config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efac896.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->