### PR TITLE
design(#175): replace katakana decoration band with ASCII

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -103,7 +103,7 @@ boot.skip_hint,ui,BootScreen,BootScreen,skip_hint,"Click to skip",,active
 boot.skip_aria,ui,BootScreen,BootScreen,aria_label,"Skip boot screen",,active
 
 system.header.title_default,ui,SystemHeader,SystemHeader,title_default,"VIBE_OS_v9.0",,active
-system.header.katakana_deco,ui,SystemHeader,SystemHeader,decoration,"カタカナ ベンチマーク プロトコル ▰▰▰▱▱▱",,active
+system.header.katakana_deco,ui,SystemHeader,SystemHeader,decoration,"BENCHMARK · OPERATIONS · PROTOCOL ▰▰▰▱▱▱",,active
 
 signalbox.title_default,ui,SignalBox,SignalBox,title_default,"LINK",,active
 

--- a/dashboard/src/ui/foundation/MatrixShell.jsx
+++ b/dashboard/src/ui/foundation/MatrixShell.jsx
@@ -61,7 +61,7 @@ export function MatrixShell({
                 </div>
                 <span
                   aria-hidden="true"
-                  className="deco-katakana hidden md:inline text-micro"
+                  className="hidden md:inline text-micro tracking-caps text-ink-faint whitespace-nowrap select-none"
                 >
                   {copy("system.header.katakana_deco")}
                 </span>

--- a/dashboard/src/ui/matrix-a/components/SystemHeader.jsx
+++ b/dashboard/src/ui/matrix-a/components/SystemHeader.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { copy } from "../../../lib/copy";
 
-// Decorative katakana band — chrome only, no semantic meaning.
-// DESIGN.md §5 v3 deco-katakana. Removing it must not lose information.
-// Text source: copy.csv (system.header.katakana_deco) per AGENTS.md.
+// Decorative band — chrome only, no semantic meaning.
+// Uses ASCII text from copy.csv (system.header.katakana_deco) so the band stays
+// legible on systems without CJK fonts installed (no tofu boxes).
 
 export function SystemHeader({
   title = copy("system.header.title_default"),
@@ -26,7 +26,7 @@ export function SystemHeader({
         ) : null}
         <span
           aria-hidden="true"
-          className="deco-katakana hidden md:inline text-micro"
+          className="hidden md:inline text-micro tracking-caps text-ink-faint whitespace-nowrap select-none"
         >
           {copy("system.header.katakana_deco")}
         </span>


### PR DESCRIPTION
# What does this PR do?

- Replaces the decorative katakana band in the system header (`カタカナ ベンチマーク プロトコル ▰▰▰▱▱▱`) with ASCII text (`BENCHMARK · OPERATIONS · PROTOCOL ▰▰▰▱▱▱`). Per kit chat reproduction, the band rendered as □□□ tofu boxes on systems without Hiragino Sans / Yu Gothic / MS Gothic CJK fonts (Linux containers, some Windows installs).

## Related Issue

Fixes #175

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- `dashboard/src/content/copy.csv`: `system.header.katakana_deco` text changed from katakana to ASCII equivalent
- `dashboard/src/ui/foundation/MatrixShell.jsx`: drop `deco-katakana` class, use `text-micro tracking-caps text-ink-faint whitespace-nowrap select-none` directly
- `dashboard/src/ui/matrix-a/components/SystemHeader.jsx`: same class swap; comment updated to explain the ASCII choice
- `.deco-katakana` CSS class kept in `dashboard/src/styles.css` for downstream prototypes that want a CJK band

## Affected Modules / Contracts

- **Modules touched:** dashboard/src/ui/foundation/MatrixShell, dashboard/src/ui/matrix-a/components/SystemHeader, dashboard/src/content/copy
- **Dependencies / contracts touched:** none — purely visual chrome
- **Repo sitemap evidence:** not required (visual chrome only)

## Validation

### Automated

- `npm run build` ✓
- `npm test` ✓ 108 tests pass
- `npm run guardrail:design` ✓

### Manual / smoke

- Visual smoke: header band reads "BENCHMARK · OPERATIONS · PROTOCOL ▰▰▰▱▱▱" in green-faint micro
- Pending: verify on Linux container without CJK fonts (was the original tofu repro environment)

### Uncovered scope

- No automated test for "tofu box count == 0"; relied on visual confirmation

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** the kit chat history is the design SSOT — see `design-system/chats/chat2.md` for the original "乱码了" report and decision
- **Depends on:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)