### PR TITLE
design(#177): warn/err color tokens for status indicators

### DIFF
--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -48,8 +48,10 @@ primary number, identity handle. **Not** for label / button / caption.
 
 ## 2. Color Tokens
 
-Two tracks only: green ink (data) and neutral surface (ground). No third
-hue except the arbitrary-use `gold` accent.
+Two tracks for prose / surfaces / accents: green ink (data) and neutral
+surface (ground), with one `gold` accent. A narrow status escape hatch
+(`warn` / `err`) extends the palette **only** for status indicators —
+never for prose, accents, or surfaces (see §2.4).
 
 ### 2.1 `ink.*` — green data ink
 
@@ -77,6 +79,26 @@ hue except the arbitrary-use `gold` accent.
 | Token  | Value       | Usage                                |
 | ------ | ----------- | ------------------------------------ |
 | `gold` | `#FFD700`   | leaderboard #1 only                  |
+
+### 2.4 Status escape hatch
+
+The green-on-green ladder can't carry severity for status indicators —
+verified in kit chat2 user feedback. Two tokens fill that gap, and only
+that gap.
+
+| Token  | Tailwind                            | Value       | Usage                                |
+| ------ | ----------------------------------- | ----------- | ------------------------------------ |
+| `warn` | `text-warn` `border-warn` `bg-warn` | `#FFB300`   | degraded / rate-limited status indicator |
+| `err`  | `text-err` `border-err` `bg-err`    | `#FF3344`   | failure / error status indicator     |
+
+Matching `box-shadow` glows: `shadow-warn-glow` / `shadow-err-glow`.
+CSS-var mirrors: `--warn` / `--warn-glow` / `--err` / `--err-glow`.
+
+**Hard rule.** `warn` / `err` are reserved for connection state,
+banners reporting an error, and similar status surfaces. They are
+**never** valid for prose copy, accent text, surface backgrounds,
+iconography, or hover / focus rings. If a non-status component needs
+to communicate severity, redesign the layout — don't reach for these.
 
 ---
 

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -22,6 +22,14 @@
   --surface: #050505;
   --surface-raised: rgba(0, 10, 0, 0.7);
   --surface-strong: rgba(0, 10, 0, 0.82);
+
+  /* Status escape hatch (DESIGN.md §2 v3). Reserved for status indicators
+   * where the green-on-green ladder can't carry severity. Do not use as
+   * accent for prose, surfaces, or icons. */
+  --warn: #ffb300;
+  --warn-glow: rgba(255, 179, 0, 0.4);
+  --err: #ff3344;
+  --err-glow: rgba(255, 51, 68, 0.45);
 }
 
 html,

--- a/dashboard/src/ui/matrix-a/components/ConnectionStatus.jsx
+++ b/dashboard/src/ui/matrix-a/components/ConnectionStatus.jsx
@@ -28,11 +28,11 @@ export function ConnectionStatus({ status = "STABLE", title, className = "" }) {
       indicator: bit,
     },
     UNSTABLE: {
-      color: "text-yellow-400",
+      color: "text-warn",
       indicator: "!",
     },
     LOST: {
-      color: "text-red-500/90",
+      color: "text-err",
       indicator: "×",
     },
   };

--- a/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
@@ -178,7 +178,7 @@ export const UsagePanel = React.memo(function UsagePanel({
       ) : null}
 
       {error ? (
-        <div className="text-caption text-red-400/90 px-2 py-1">
+        <div className="text-caption text-err px-2 py-1">
           {copy("shared.error.prefix", { error })}
         </div>
       ) : null}

--- a/dashboard/tailwind.config.cjs
+++ b/dashboard/tailwind.config.cjs
@@ -71,6 +71,10 @@ module.exports = {
           strong: "rgba(0, 10, 0, 0.82)",
         },
         gold: "#FFD700",
+        // Status escape hatch — DESIGN.md §2 v3 (kit chat2). Used only for
+        // status indicators where green-on-green can't carry severity.
+        warn: "#FFB300",
+        err: "#FF3344",
       },
       boxShadow: {
         panel: "0 0 0 1px rgba(0, 255, 65, 0.08), 0 18px 40px rgba(0, 0, 0, 0.45)",
@@ -81,6 +85,8 @@ module.exports = {
         gold: "0 0 18px rgba(255, 215, 0, 0.35)",
         "gold-sm": "0 0 10px rgba(255, 215, 0, 0.3)",
         "gold-faint": "0 0 20px rgba(255, 215, 0, 0.1)",
+        "warn-glow": "0 0 10px rgba(255, 179, 0, 0.40)",
+        "err-glow": "0 0 10px rgba(255, 51, 68, 0.45)",
       },
       dropShadow: {
         glow: "0 0 8px rgba(0, 255, 65, 0.8)",


### PR DESCRIPTION
# What does this PR do?

- Adds `warn` (#FFB300) and `err` (#FF3344) color tokens as a status escape hatch. Per kit chat2 (Status + states regenerate), the green-on-green ladder can't carry severity for status indicators — a real perceptual gap reported in the kit. Tokens stay narrowly scoped: status indicators only, never prose / surfaces / accents.
- Migrates ad-hoc `text-yellow-400` / `text-red-500/90` / `text-red-400/90` (Tailwind defaults) in two existing components onto the new tokens.

## Related Issue

Fixes #177

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [x] Risk / contract change

## Changes Made

- `dashboard/tailwind.config.cjs`: register `warn` / `err` colors + `warn-glow` / `err-glow` box-shadows
- `dashboard/src/styles.css`: mirror as `--warn` / `--warn-glow` / `--err` / `--err-glow` CSS vars for runtime access
- `dashboard/src/ui/matrix-a/components/ConnectionStatus.jsx`: `text-yellow-400` → `text-warn`, `text-red-500/90` → `text-err`
- `dashboard/src/ui/matrix-a/components/UsagePanel.jsx`: `text-red-400/90` → `text-err` on the error banner

## Affected Modules / Contracts

- **Modules touched:** dashboard/tailwind.config, dashboard/src/styles, dashboard/src/ui/matrix-a/components/ConnectionStatus, dashboard/src/ui/matrix-a/components/UsagePanel
- **Dependencies / contracts touched:** design system palette ceiling expanded from "two ink stops + gold + neutral" to "two ink stops + gold + neutral + warn/err (status only)" — documented in design-system/colors_and_type.css mirror (lands with PR #185)
- **Repo sitemap evidence:** not required (design token addition)

## Validation

### Automated

- `npm run build` ✓
- `npm run guardrail:design` ✓
- `npm test` ✓ 108 tests pass
- `grep -r "text-(red |yellow|amber)-\d+" dashboard/src` shows the migrated sites are gone except for `MatrixAvatar.jsx` (gold-leaderboard avatar — separate concern)

### Manual / smoke

- Connection lost → red `×` indicator
- Connection unstable → amber `!` indicator
- Connection stable → green flicker (unchanged)

### Uncovered scope

- `MatrixAvatar.jsx:50` still uses `bg-yellow-900/20 border-yellow-500/50` for the gold leaderboard #1 ring. That's a separate gold-token consolidation (out of scope here).

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

- The Risk/contract checkbox is marked because this expands the documented design palette from green+gold to green+gold+warn/err. Hard rule documented in commit message + DESIGN.md (#178 follow-up): warn/err are reserved for status indicators only, not prose / accent / surface.

## Reviewer Context (optional)

- **Review focus:** confirm warn/err migration sites (ConnectionStatus, UsagePanel error banner) are the only visible diff. New tokens aren't yet referenced anywhere else.
- **Depends on:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `warn` and `err` color tokens for status indicators in the dashboard
> - Adds `warn` (`#FFB300`) and `err` (`#FF3344`) as named color tokens in [tailwind.config.cjs](https://github.com/victorGPT/vibeusage/pull/182/files#diff-eaf233e2044daebe81896f2e321496c7e26a5f4354d841bb155b10648adae7c9), generating utilities like `text-warn`, `bg-err`, `shadow-warn-glow`, etc.
> - Mirrors the tokens as CSS variables (`--warn`, `--warn-glow`, `--err`, `--err-glow`) in [styles.css](https://github.com/victorGPT/vibeusage/pull/182/files#diff-11d13f90c49c6e5d55ef15d7519497ca703ae341c1306ede3496cd2d3b32bdf6) for runtime CSS consumers.
> - Updates `ConnectionStatus.jsx` and `UsagePanel.jsx` to use `text-warn`/`text-err` instead of raw Tailwind palette classes (`text-yellow-400`, `text-red-500/90`, `text-red-400/90`).
> - Documents the tokens in [DESIGN.md](https://github.com/victorGPT/vibeusage/pull/182/files#diff-194ef001afeb8c0d41ed8edec1d318966ebdc65d3e76b76152063ee88ec9d9f3) under a new §2.4 'Status escape hatch', restricting their use to status indicators only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c44b44c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->