### PR TITLE
design(#179): tint MODEL BREAKDOWN bar track to ink-faint

### DIFF
--- a/dashboard/src/ui/matrix-a/components/NeuralAdaptiveFleet.jsx
+++ b/dashboard/src/ui/matrix-a/components/NeuralAdaptiveFleet.jsx
@@ -36,7 +36,7 @@ export const NeuralAdaptiveFleet = React.memo(function NeuralAdaptiveFleet({
         </div>
       </div>
 
-      <div className="h-1 w-full bg-surface-raised flex overflow-hidden relative">
+      <div className="h-1 w-full bg-ink-faint flex overflow-hidden relative">
         {models.map((model, index) => {
           const styleConfig = TEXTURES[index % TEXTURES.length];
           const modelKey = model?.id ? String(model.id) : `${model.name}-${index}`;


### PR DESCRIPTION
# What does this PR do?

- One-line CSS class change: `NeuralAdaptiveFleet`'s 4px MODEL BREAKDOWN bar track switches from `bg-surface-raised` (dark) to `bg-ink-faint` (8% green tint). Aligns with the kit's `.vu-mbd-bar` rule so the track reads as "phosphor under the data" instead of "black box behind the data". Last cosmetic gap to close — 4px height, uniform per-source groups, and 2-col sub-model grid were already in place.

## Related Issue

Fixes #179

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- `dashboard/src/ui/matrix-a/components/NeuralAdaptiveFleet.jsx`: bar wrapper class `bg-surface-raised` → `bg-ink-faint`

## Affected Modules / Contracts

- **Modules touched:** dashboard/src/ui/matrix-a/components/NeuralAdaptiveFleet
- **Dependencies / contracts touched:** none — visual only
- **Repo sitemap evidence:** not required

## Validation

### Automated

- `npm run build` ✓
- `npm run guardrail:design` ✓
- `npm test` ✓ 108 tests pass

### Manual / smoke

- Visual smoke pending: model breakdown bars read as phosphor-under-data; sub-model TEXTURES segments still differentiate at the same contrast (they were never reading the dark surface; it was just visual filler)

### Uncovered scope

- No automated visual diff coverage for the class swap; relied on guardrail + manual

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** trivial CSS class swap; confirm no contrast regression on TEXTURES segments
- **Depends on:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)