### PR TITLE
design(#178): document heading/body/data as canonical text scale

### DIFF
--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -82,7 +82,26 @@ hue except the arbitrary-use `gold` accent.
 
 ## 3. Typography Tokens
 
-`Geist Mono` is the only font-family. 7 size stops. No `text-[Npx]`.
+`Geist Mono` is the only font-family. No `text-[Npx]`.
+
+### 3.1 Canonical text scale (use these by default)
+
+Per kit chat2 ("Type / Text + data scale: 会不会太多样式了"), there are
+exactly **3** canonical non-display text styles. Reach for one of these
+first; only fall back to the auxiliary stops in §3.2 when a layout truly
+needs a finer granularity.
+
+| Token     | Size / LineHt / Tracking / Weight / Case | Usage                       |
+| --------- | ---------------------------------------- | --------------------------- |
+| `heading` | 14 / 1.25 / 0.12em / 700 / UPPERCASE     | label, panel title, nav     |
+| `body`    | 13 / 1.50 / 0     / 500 / none           | prose                       |
+| `data`    | 12 / 1.40 / 0     / 500 tabular-nums     | numbers, table cells        |
+
+### 3.2 Display + auxiliary stops
+
+Display tokens are unchanged. `caption` / `micro` are kept as tactical
+aliases (existing call sites and dense status pills); avoid them in new
+code unless `heading` / `data` genuinely won't fit.
 
 | Token       | Size / LineHt / Tracking / Weight / Case    | Usage                                       |
 | ----------- | ------------------------------------------- | ------------------------------------------- |
@@ -90,11 +109,8 @@ hue except the arbitrary-use `gold` accent.
 | `display-1` | 60 / 1.00 / -0.02em / 900 / none            | landing hero title                          |
 | `display-2` | 40 / 1.05 / -0.02em / 900 / none            | big number, screenshot title                |
 | `display-3` | 28 / 1.10 / -0.02em / 900 / none            | mid-size hero (leaderboard title, identity) |
-| `heading`   | 14 / 1.25 /  0.12em / 700 / UPPERCASE       | panel title, nav primary                    |
-| `body`      | 13 / 1.50 /  0     / 500 / none             | body paragraph                              |
-| `data`      | 12 / 1.40 /  0     / 500 tabular-nums       | numbers, table cells                        |
-| `caption`   | 11 / 1.30 /  0.12em / 600 / UPPERCASE       | label, sub-title                            |
-| `micro`     | 10 / 1.20 /  0.22em / 700 / UPPERCASE       | tag, status, pagination                     |
+| `caption`   | 11 / 1.30 /  0.12em / 600 / UPPERCASE       | _legacy_ — prefer `heading`                 |
+| `micro`     | 10 / 1.20 /  0.22em / 700 / UPPERCASE       | _legacy_ — prefer `heading` (or `data`)     |
 
 ### Letter-spacing (4 canonical values only)
 


### PR DESCRIPTION
# What does this PR do?

- Doc-only update to `dashboard/DESIGN.md §3` (Typography Tokens). Per kit chat2 ("Type / Text + data scale: 会不会太多样式了"), the design system kit collapsed the 5-style text scale (heading/body/data/caption/micro) to **3 canonical** (heading/body/data) on the design-system preview card. This PR mirrors that intent in DESIGN.md by splitting §3 into:
  - **§3.1 Canonical text scale** — heading / body / data are the 3 to reach for first
  - **§3.2 Display + auxiliary stops** — display-0..3 unchanged; caption / micro retained as tactical aliases marked _legacy_
- `tailwind.config.cjs` token definitions are **unchanged on purpose** — see Risk Addendum.

## Related Issue

Refs #178 (kept open as tracking ticket for the per-component caption/micro migration)

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- `dashboard/DESIGN.md`: §3 Type rewritten — split into §3.1 canonical (heading/body/data) and §3.2 display + auxiliary; caption/micro marked _legacy_ with note to prefer heading/data

## Affected Modules / Contracts

- **Modules touched:** dashboard/DESIGN.md (SSOT doc)
- **Dependencies / contracts touched:** zero code change — `tailwind.config.cjs` tokens preserved
- **Repo sitemap evidence:** not required (doc-only)

## Validation

### Automated

- `npm run build` ✓ (no code change, but verified clean build)
- `npm run guardrail:design` ✓
- `npm test` ✓ 108 tests pass

### Manual / smoke

- N/A — doc change

### Uncovered scope

- ~135 existing `text-caption` / `text-micro` call sites are NOT migrated in this PR. A blanket replace would cause visible density shifts (caption 11/600 vs heading 14/700 — real font-size + weight delta). Per-component visual review should drive that migration in follow-up PRs (issue #178 stays open).

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** is the §3.1/§3.2 split clear about which tokens are canonical for new code vs which are tactical aliases for existing call sites?
- **Known gaps / follow-ups:** issue #178 tracks the call-site migration; this PR does not implement it

🤖 Generated with [Claude Code](https://claude.com/claude-code)