### PR TITLE
fix(sync): proper-lockfile + --rebuild=<source> for cursor-correct re-aggregation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "vibeusage",
-  "version": "0.3.5",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibeusage",
-      "version": "0.3.5",
+      "version": "0.6.2",
       "bundleDependencies": [
         "@insforge/sdk"
       ],
       "license": "MIT",
       "dependencies": {
-        "@insforge/sdk": "1.2.2"
+        "@insforge/sdk": "1.2.2",
+        "proper-lockfile": "^4.1.2"
       },
       "bin": {
         "tracker": "bin/tracker.js",
@@ -641,6 +642,12 @@
       "dev": true,
       "license": "(BSD-3-Clause AND Apache-2.0)"
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -657,6 +664,32 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/socket.io-client": {
       "version": "4.8.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "validate:ui-hardcode": "node scripts/ops/validate-ui-hardcode.cjs"
   },
   "dependencies": {
-    "@insforge/sdk": "1.2.2"
+    "@insforge/sdk": "1.2.2",
+    "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
     "@sourcegraph/scip-typescript": "^0.3.6",
@@ -60,5 +61,8 @@
   ],
   "engines": {
     "node": "20.x"
-  }
+  },
+  "bundleDependencies": [
+    "@insforge/sdk"
+  ]
 }

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -146,8 +146,11 @@ function runAuditTokens({ opts, config }) {
   if (result.exceedsThreshold) {
     process.stderr.write(
       `\nFAIL drift ${result.maxDriftPct.toFixed(2)}% exceeds threshold ${result.thresholdPct}%.\n` +
-        `If vibeusage >= 0.5.0, scrub the Claude/OpenCode cursor block in\n` +
-        `~/.vibeusage/tracker/cursors.json and rerun \`vibeusage sync --drain\`.\n`,
+        `Rebuild this source from its local session files: ` +
+        `\`vibeusage sync --rebuild ${result.source}\`\n` +
+        `(That clears the source's file/bucket/group cursors atomically and ` +
+        `re-parses every session — fixing drift caused by interrupted uploads ` +
+        `or partial cursor edits.)\n`,
     );
     process.exitCode = 1;
   }

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -501,6 +501,13 @@ function parseArgs(argv) {
     // A rebuild always wants a full upload pass, otherwise the freshly-rebuilt
     // buckets would sit in queue.jsonl behind the default 10-batch cap.
     out.drain = true;
+    // OpenClaw is the only source whose ledger parsing is gated behind an
+    // explicit flag (see sync flow's `opts.fromOpenclaw ? parseOpenclaw... : noop`).
+    // A `--rebuild=openclaw` that doesn't also turn that flag on would scrub
+    // the OpenClaw cursors and persist the cleared state without ever re-
+    // aggregating from the ledger — leaving totals stale until a later
+    // plugin-triggered sync. Force the flag so rebuild actually rebuilds.
+    if (out.rebuild === "openclaw") out.fromOpenclaw = true;
   }
   return out;
 }

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -4,6 +4,7 @@ const fs = require("node:fs/promises");
 const cp = require("node:child_process");
 
 const { ensureDir, readJson, writeJson, openLock } = require("../lib/fs");
+const { scrubSourceCursors, listSupportedSources } = require("../lib/cursor-scrub");
 const {
   listRolloutFiles,
   listClaudeProjectFiles,
@@ -65,6 +66,30 @@ async function cmdSync(argv) {
 
     const config = await readJson(configPath);
     const cursors = (await readJson(cursorsPath)) || { version: 1, files: {}, updatedAt: null };
+
+    if (opts.rebuild) {
+      const scrub = scrubSourceCursors({
+        cursors,
+        sourceId: opts.rebuild,
+        home,
+        env: process.env,
+      });
+      // Persist the cleared cursors before parsing begins. If we crash mid-
+      // rebuild, the next sync resumes from a clean state for this source
+      // rather than re-accumulating onto cached totals (the original bug).
+      await writeJson(cursorsPath, cursors);
+      process.stdout.write(
+        `Rebuilding source=${scrub.sourceId}: cleared ${scrub.filesRemoved} file ` +
+          `cursors, ${scrub.bucketsRemoved} hourly buckets, ` +
+          `${scrub.projectBucketsRemoved} project buckets, ` +
+          `${scrub.groupsRemoved} groupQueued entries` +
+          (scrub.extraCursorsCleared.length
+            ? `, ${scrub.extraCursorsCleared.join("+")}`
+            : "") +
+          `.\n`,
+      );
+    }
+
     const uploadThrottle = normalizeUploadState(await readJson(uploadThrottlePath));
     let uploadThrottleState = uploadThrottle;
 
@@ -445,6 +470,7 @@ function parseArgs(argv) {
     fromRetry: false,
     fromOpenclaw: false,
     drain: false,
+    rebuild: null,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -453,7 +479,28 @@ function parseArgs(argv) {
     else if (a === "--from-retry") out.fromRetry = true;
     else if (a === "--from-openclaw") out.fromOpenclaw = true;
     else if (a === "--drain") out.drain = true;
-    else throw new Error(`Unknown option: ${a}`);
+    else if (a === "--rebuild") {
+      const v = argv[++i];
+      if (!v || v.startsWith("--")) {
+        throw new Error("--rebuild requires a source id (e.g. --rebuild claude)");
+      }
+      out.rebuild = v;
+    } else if (a.startsWith("--rebuild=")) {
+      const v = a.slice("--rebuild=".length);
+      if (!v) throw new Error("--rebuild= requires a source id");
+      out.rebuild = v;
+    } else throw new Error(`Unknown option: ${a}`);
+  }
+  if (out.rebuild) {
+    const supported = listSupportedSources();
+    if (!supported.includes(out.rebuild)) {
+      throw new Error(
+        `--rebuild: unknown source '${out.rebuild}'. Supported: ${supported.join(", ")}`,
+      );
+    }
+    // A rebuild always wants a full upload pass, otherwise the freshly-rebuilt
+    // buckets would sit in queue.jsonl behind the default 10-batch cap.
+    out.drain = true;
   }
   return out;
 }

--- a/src/lib/cursor-scrub.js
+++ b/src/lib/cursor-scrub.js
@@ -1,0 +1,164 @@
+"use strict";
+
+const path = require("node:path");
+
+// scrubSourceCursors clears every cursor field that, if left in place, would
+// cause a re-parse of a source's session files to *accumulate* into
+// previously-uploaded buckets instead of *rebuilding* them from scratch.
+//
+// This is the helper that fixes the bug behind the recent "DB tokens doubled"
+// incident: clearing only `cursors.files` causes the parser to re-read the
+// jsonl files and add their token totals on top of whatever was still cached
+// in `cursors.hourly.buckets`. The result is buckets at roughly 2x the
+// ground truth.
+//
+// Four cursor surfaces must be cleared in lockstep for a source rebuild to
+// be correct:
+//   1. cursors.files entries whose path lives under that source's session
+//      root (so the parser re-reads each file from offset 0).
+//   2. cursors.hourly.buckets keyed `<source>|<model>|<hour>` (so per-bucket
+//      totals restart at zero before re-aggregation).
+//   3. cursors.hourly.groupQueued keys for that source (so the next sync
+//      re-enqueues each touched bucket to queue.jsonl for upload).
+//   4. cursors.projectHourly.buckets keyed `<project>|<source>|<hour>`
+//      (project-scoped totals are aggregated independently from the global
+//      hourly state and would otherwise stay doubled in the dashboard's
+//      per-project views).
+//
+// `cursors.projectHourly.projects` holds project metadata (git remotes,
+// display names) and is intentionally preserved — it carries no token
+// totals, just identity.
+//
+// Sources that don't use `cursors.files` (sqlite-backed opencode, ledger-
+// backed hermes/openclaw) carry their progress in dedicated cursor fields;
+// those are reset directly.
+
+const SOURCES = {
+  claude: {
+    sessionRoot: ({ home }) => path.join(home, ".claude", "projects"),
+  },
+  codex: {
+    sessionRoot: ({ home, env }) =>
+      path.join(env.CODEX_HOME || path.join(home, ".codex"), "sessions"),
+  },
+  "every-code": {
+    sessionRoot: ({ home, env }) =>
+      path.join(env.CODE_HOME || path.join(home, ".code"), "sessions"),
+  },
+  gemini: {
+    sessionRoot: ({ home, env }) =>
+      path.join(env.GEMINI_HOME || path.join(home, ".gemini"), "tmp"),
+  },
+  kimi: {
+    sessionRoot: ({ home, env }) =>
+      path.join(env.KIMI_HOME || path.join(home, ".kimi"), "sessions"),
+  },
+  opencode: {
+    extraCursorKeys: ["opencode", "opencodeSqlite"],
+  },
+  hermes: {
+    extraCursorKeys: ["hermesLedger"],
+  },
+  openclaw: {
+    extraCursorKeys: ["openclawLedger"],
+  },
+};
+
+function listSupportedSources() {
+  return Object.keys(SOURCES);
+}
+
+function scrubSourceCursors({ cursors, sourceId, home, env = process.env }) {
+  if (!cursors || typeof cursors !== "object") {
+    throw new Error("scrubSourceCursors: cursors must be an object");
+  }
+  const config = SOURCES[sourceId];
+  if (!config) {
+    throw new Error(
+      `scrubSourceCursors: unknown sourceId '${sourceId}'. Supported: ${listSupportedSources().join(", ")}`,
+    );
+  }
+
+  const result = {
+    sourceId,
+    filesRemoved: 0,
+    bucketsRemoved: 0,
+    groupsRemoved: 0,
+    projectBucketsRemoved: 0,
+    extraCursorsCleared: [],
+  };
+
+  // 1) cursors.files — strip every entry whose path lives under this source's
+  // session root, so the parser re-reads them from byte 0.
+  if (config.sessionRoot && cursors.files && typeof cursors.files === "object") {
+    const prefix = config.sessionRoot({ home, env });
+    for (const key of Object.keys(cursors.files)) {
+      if (typeof key !== "string") continue;
+      if (key.startsWith(prefix)) {
+        delete cursors.files[key];
+        result.filesRemoved += 1;
+      }
+    }
+  }
+
+  // 2) cursors.hourly.buckets — strip every bucket keyed for this source so
+  // its totals restart at zero before re-aggregation.
+  if (cursors.hourly && typeof cursors.hourly === "object") {
+    const bucketPrefix = `${sourceId}|`;
+    if (cursors.hourly.buckets && typeof cursors.hourly.buckets === "object") {
+      for (const key of Object.keys(cursors.hourly.buckets)) {
+        if (typeof key === "string" && key.startsWith(bucketPrefix)) {
+          delete cursors.hourly.buckets[key];
+          result.bucketsRemoved += 1;
+        }
+      }
+    }
+    // 3) cursors.hourly.groupQueued — strip per-source enqueue records so
+    // the next sync re-enqueues each touched bucket for upload.
+    if (cursors.hourly.groupQueued && typeof cursors.hourly.groupQueued === "object") {
+      for (const key of Object.keys(cursors.hourly.groupQueued)) {
+        if (typeof key === "string" && key.startsWith(bucketPrefix)) {
+          delete cursors.hourly.groupQueued[key];
+          result.groupsRemoved += 1;
+        }
+      }
+    }
+  }
+
+  // 4) cursors.projectHourly.buckets — keyed `<project_key>|<source>|<hour>`.
+  // Strip the buckets where the middle segment matches this source, leaving
+  // every other source's project-scoped totals (and the projects metadata
+  // map) untouched.
+  if (
+    cursors.projectHourly &&
+    typeof cursors.projectHourly === "object" &&
+    cursors.projectHourly.buckets &&
+    typeof cursors.projectHourly.buckets === "object"
+  ) {
+    for (const key of Object.keys(cursors.projectHourly.buckets)) {
+      if (typeof key !== "string") continue;
+      const parts = key.split("|");
+      if (parts.length >= 2 && parts[1] === sourceId) {
+        delete cursors.projectHourly.buckets[key];
+        result.projectBucketsRemoved += 1;
+      }
+    }
+  }
+
+  // 5) Source-specific top-level cursor fields (opencode sqlite progress,
+  // hermes/openclaw ledger offsets). Resetting these is what makes a
+  // rebuild work for non-file sources.
+  for (const key of config.extraCursorKeys || []) {
+    if (key in cursors) {
+      delete cursors[key];
+      result.extraCursorsCleared.push(key);
+    }
+  }
+
+  return result;
+}
+
+module.exports = {
+  scrubSourceCursors,
+  listSupportedSources,
+};

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -1,5 +1,6 @@
 const fs = require("node:fs/promises");
 const path = require("node:path");
+const lockfile = require("proper-lockfile");
 
 async function ensureDir(p) {
   await fs.mkdir(p, { recursive: true });
@@ -47,22 +48,128 @@ async function chmod600IfPossible(filePath) {
   } catch (_e) {}
 }
 
-async function openLock(lockPath, { quietIfLocked }) {
+// proper-lockfile gives us atomic mkdir-based mutual exclusion plus a heart-
+// beat mechanism that auto-recovers from orphan locks without TOCTOU races:
+//
+//   - The holder process refreshes the lock-directory's mtime every `update`
+//     ms. As long as that interval keeps running, the lock is "fresh".
+//   - Any acquirer that finds the existing lock with mtime older than `stale`
+//     ms takes it over via a compare-and-swap that is safe under concurrent
+//     attempts (the library's own contract).
+//   - If the holder dies (crash, SIGKILL, reboot) the heartbeat stops; the
+//     next acquirer sees the stale mtime and recovers automatically.
+//
+// We deliberately set `stale` larger than the default to give a working sync
+// some headroom against transient event-loop pauses (large JSON.parse, GC).
+// We pass `realpath: false` because the lock target may not exist as a file
+// — proper-lockfile creates the lock-directory at `lockPath` directly.
+const LOCK_STALE_MS = 60_000;
+const LOCK_UPDATE_MS = 10_000;
+
+async function openLock(lockPath, { quietIfLocked } = {}) {
+  // Migration path: pre-proper-lockfile versions of vibeusage created the
+  // lock as a regular *file* (fs.open with "wx"). proper-lockfile creates
+  // it as a *directory* (mkdir). If we hand a stale legacy file off to
+  // proper-lockfile, its mkdir will EEXIST and its internal rmdir-fallback
+  // will then ENOTDIR, throwing instead of returning ELOCKED. Detect and
+  // resolve that mismatch up front.
+  const migration = await migrateLegacyLockFile(lockPath);
+  if (migration === "yield-to-legacy-holder") {
+    if (!quietIfLocked) process.stdout.write("Another sync is already running.\n");
+    return null;
+  }
+
+  let release;
   try {
-    const handle = await fs.open(lockPath, "wx");
-    return {
-      async release() {
-        await handle.close().catch(() => {});
-      },
-    };
+    release = await lockfile.lock(lockPath, {
+      lockfilePath: lockPath,
+      realpath: false,
+      stale: LOCK_STALE_MS,
+      update: LOCK_UPDATE_MS,
+      retries: 0,
+    });
   } catch (e) {
-    if (e && e.code === "EEXIST") {
-      if (!quietIfLocked) {
-        process.stdout.write("Another sync is already running.\n");
-      }
+    if (e && e.code === "ELOCKED") {
+      if (!quietIfLocked) process.stdout.write("Another sync is already running.\n");
       return null;
     }
     throw e;
+  }
+  return {
+    async release() {
+      try {
+        await release();
+      } catch (_e) {
+        // Best-effort cleanup. proper-lockfile throws if the lock was already
+        // compromised (e.g. taken over by another process while we were
+        // running) — there is nothing useful to do at that point.
+      }
+    },
+  };
+}
+
+// Detect a leftover lock file from the previous wx-based scheme. Three cases:
+//   - "orphan"        — proven dead by PID liveness; safe to unlink and migrate.
+//   - "alive"         — recorded PID is still running; yield with the standard
+//                       "another sync running" UX.
+//   - "indeterminate" — empty / corrupt / unreadable file. The original
+//                       production openLock wrote a *zero-byte* file (it never
+//                       called writeFile after fs.open(path, "wx")), so this
+//                       is the **expected** legacy format. We cannot prove
+//                       its holder is dead and we MUST NOT auto-delete: a
+//                       still-running legacy sync would lose its lock and a
+//                       new-format sync would start in parallel. Yield and
+//                       print an actionable manual-cleanup notice.
+async function migrateLegacyLockFile(lockPath) {
+  let stat;
+  try {
+    stat = await fs.lstat(lockPath);
+  } catch (e) {
+    if (e && e.code === "ENOENT") return "no-legacy";
+    throw e;
+  }
+  if (stat.isDirectory()) return "no-legacy"; // already in proper-lockfile format
+
+  const verdict = await classifyLegacyFileLock(lockPath);
+  if (verdict === "orphan") {
+    await fs.unlink(lockPath).catch(() => {});
+    return "migrated";
+  }
+  if (verdict === "indeterminate") {
+    process.stderr.write(
+      `vibeusage: legacy sync.lock at ${lockPath} carries no PID payload, ` +
+        `so we cannot prove its owner is dead. Auto-deletion is unsafe — a ` +
+        `still-running legacy sync would lose its lock. If no legacy ` +
+        `vibeusage sync is actually running, remove it manually: rm ${JSON.stringify(
+          lockPath,
+        )}\n`,
+    );
+  }
+  return "yield-to-legacy-holder";
+}
+
+async function classifyLegacyFileLock(lockPath) {
+  let raw;
+  try {
+    raw = await fs.readFile(lockPath, "utf8");
+  } catch (_e) {
+    return "indeterminate";
+  }
+  if (!raw) return "indeterminate";
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_e) {
+    return "indeterminate";
+  }
+  const pid = parsed?.pid;
+  if (!Number.isFinite(pid)) return "indeterminate";
+  try {
+    process.kill(pid, 0);
+    return "alive";
+  } catch (e) {
+    if (e && e.code === "ESRCH") return "orphan";
+    return "alive"; // EPERM = pid exists but belongs to another user
   }
 }
 

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -1,6 +1,11 @@
 const fs = require("node:fs/promises");
 const path = require("node:path");
-const lockfile = require("proper-lockfile");
+
+// proper-lockfile is required lazily inside openLock(): some callers copy
+// src/lib/fs.js into sandboxes that have no node_modules (e.g. the openclaw
+// session plugin test, which materializes src/ under a tmp dir to test the
+// ledger). Those callers only use ensureDir/readJson/etc and would crash on
+// a top-level require.
 
 async function ensureDir(p) {
   await fs.mkdir(p, { recursive: true });
@@ -67,6 +72,9 @@ const LOCK_STALE_MS = 60_000;
 const LOCK_UPDATE_MS = 10_000;
 
 async function openLock(lockPath, { quietIfLocked } = {}) {
+  // Lazy require: see top-of-file note about sandboxed callers.
+  const lockfile = require("proper-lockfile");
+
   // Migration path: pre-proper-lockfile versions of vibeusage created the
   // lock as a regular *file* (fs.open with "wx"). proper-lockfile creates
   // it as a *directory* (mkdir). If we hand a stale legacy file off to

--- a/test/cursor-scrub.test.js
+++ b/test/cursor-scrub.test.js
@@ -1,0 +1,183 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { scrubSourceCursors, listSupportedSources } = require("../src/lib/cursor-scrub");
+
+const HOME = "/home/test";
+const ENV = {};
+
+function makeCursors() {
+  return {
+    version: 1,
+    files: {
+      [path.join(HOME, ".claude", "projects", "p1", "a.jsonl")]: { offset: 100 },
+      [path.join(HOME, ".claude", "projects", "p2", "b.jsonl")]: { offset: 200 },
+      [path.join(HOME, ".codex", "sessions", "s1.jsonl")]: { offset: 300 },
+      [path.join(HOME, ".gemini", "tmp", "g1.jsonl")]: { offset: 400 },
+      "/some/unrelated/path/x.jsonl": { offset: 999 },
+    },
+    hourly: {
+      buckets: {
+        "claude|claude-opus-4-7|2026-04-26T05:00:00.000Z": { totals: { total_tokens: 1000 } },
+        "claude|claude-sonnet-4-6|2026-04-26T05:30:00.000Z": { totals: { total_tokens: 500 } },
+        "codex|gpt-5-codex|2026-04-26T05:00:00.000Z": { totals: { total_tokens: 700 } },
+        "gemini|gemini-pro|2026-04-26T05:00:00.000Z": { totals: { total_tokens: 200 } },
+      },
+      groupQueued: {
+        "claude|2026-04-26T05:00:00.000Z": "key1",
+        "claude|2026-04-26T05:30:00.000Z": "key2",
+        "codex|2026-04-26T05:00:00.000Z": "key3",
+      },
+    },
+    projectHourly: {
+      version: 2,
+      buckets: {
+        "victorgpt/vibeusage|claude|2026-04-26T05:00:00.000Z": { totals: { total_tokens: 800 } },
+        "victorgpt/vibeusage|claude|2026-04-26T05:30:00.000Z": { totals: { total_tokens: 400 } },
+        "victorgpt/vibeusage|codex|2026-04-26T05:00:00.000Z": { totals: { total_tokens: 600 } },
+        "spacedriveapp/spacedrive|claude|2026-04-26T05:00:00.000Z": { totals: { total_tokens: 300 } },
+      },
+      projects: {
+        "victorgpt/vibeusage": { displayName: "vibeusage" },
+        "spacedriveapp/spacedrive": { displayName: "spacedrive" },
+      },
+    },
+    opencode: { lastSeen: "2026-04-26T00:00:00Z" },
+    opencodeSqlite: { offset: 12345 },
+    hermesLedger: { offset: 678 },
+    openclawLedger: { offset: 901 },
+  };
+}
+
+test("scrubSourceCursors removes claude files / buckets / groupQueued / projectBuckets and leaves others alone", async () => {
+  const cursors = makeCursors();
+  const result = scrubSourceCursors({ cursors, sourceId: "claude", home: HOME, env: ENV });
+
+  assert.equal(result.filesRemoved, 2, "both .claude/projects entries gone");
+  assert.equal(result.bucketsRemoved, 2, "both claude| buckets gone");
+  assert.equal(result.groupsRemoved, 2, "both claude| groupQueued entries gone");
+  assert.equal(result.projectBucketsRemoved, 3, "all claude project buckets gone (across both projects)");
+  assert.deepEqual(result.extraCursorsCleared, [], "claude has no top-level cursor field");
+
+  // Other sources untouched (global hourly)
+  assert.ok(cursors.files[path.join(HOME, ".codex", "sessions", "s1.jsonl")]);
+  assert.ok(cursors.files[path.join(HOME, ".gemini", "tmp", "g1.jsonl")]);
+  assert.ok(cursors.files["/some/unrelated/path/x.jsonl"]);
+  assert.ok(cursors.hourly.buckets["codex|gpt-5-codex|2026-04-26T05:00:00.000Z"]);
+  assert.ok(cursors.hourly.buckets["gemini|gemini-pro|2026-04-26T05:00:00.000Z"]);
+  assert.ok(cursors.hourly.groupQueued["codex|2026-04-26T05:00:00.000Z"]);
+  assert.ok(cursors.opencode);
+  assert.ok(cursors.hermesLedger);
+
+  // Other sources' project buckets untouched, project metadata preserved.
+  assert.ok(
+    cursors.projectHourly.buckets["victorgpt/vibeusage|codex|2026-04-26T05:00:00.000Z"],
+    "codex project bucket survives a claude rebuild",
+  );
+  assert.deepEqual(
+    Object.keys(cursors.projectHourly.projects).sort(),
+    ["spacedriveapp/spacedrive", "victorgpt/vibeusage"],
+    "projectHourly.projects metadata is preserved (no token totals there)",
+  );
+});
+
+test("scrubSourceCursors handles env-overridden session roots (CODEX_HOME)", async () => {
+  // With CODEX_HOME=/custom/codex, the helper looks under /custom/codex/sessions.
+  // The default-path entry (~/.codex/sessions/s1.jsonl) does not match the
+  // configured prefix and stays put. This is the right behavior: when the
+  // user has redirected CODEX_HOME, the live data lives at the new location
+  // and the legacy default-path entry is not part of "this source's" state.
+  const env = { CODEX_HOME: "/custom/codex" };
+  const cursors = makeCursors();
+  cursors.files["/custom/codex/sessions/x.jsonl"] = { offset: 1 };
+
+  const result = scrubSourceCursors({ cursors, sourceId: "codex", home: HOME, env });
+  assert.equal(result.filesRemoved, 1, "only the env-prefixed file matches");
+  assert.equal(cursors.files["/custom/codex/sessions/x.jsonl"], undefined);
+  assert.ok(
+    cursors.files[path.join(HOME, ".codex", "sessions", "s1.jsonl")],
+    "default-path entry stays when CODEX_HOME is overridden — not part of the active source root",
+  );
+});
+
+test("scrubSourceCursors clears opencode top-level cursors but no files prefix matches", async () => {
+  const cursors = makeCursors();
+  const result = scrubSourceCursors({ cursors, sourceId: "opencode", home: HOME, env: ENV });
+
+  assert.equal(result.filesRemoved, 0);
+  assert.equal(result.bucketsRemoved, 0);
+  assert.equal(result.groupsRemoved, 0);
+  assert.deepEqual(
+    result.extraCursorsCleared.sort(),
+    ["opencode", "opencodeSqlite"],
+    "both opencode-specific cursor fields must be deleted",
+  );
+  assert.equal(cursors.opencode, undefined);
+  assert.equal(cursors.opencodeSqlite, undefined);
+});
+
+test("scrubSourceCursors clears hermes ledger cursor only", async () => {
+  const cursors = makeCursors();
+  const result = scrubSourceCursors({ cursors, sourceId: "hermes", home: HOME, env: ENV });
+  assert.deepEqual(result.extraCursorsCleared, ["hermesLedger"]);
+  assert.equal(cursors.hermesLedger, undefined);
+  assert.ok(cursors.openclawLedger, "openclaw ledger remains");
+});
+
+test("scrubSourceCursors throws on unknown source id", async () => {
+  assert.throws(
+    () => scrubSourceCursors({ cursors: {}, sourceId: "made-up", home: HOME, env: ENV }),
+    /unknown sourceId/,
+  );
+});
+
+test("scrubSourceCursors throws when cursors is not an object", async () => {
+  assert.throws(
+    () => scrubSourceCursors({ cursors: null, sourceId: "claude", home: HOME, env: ENV }),
+    /cursors must be an object/,
+  );
+});
+
+test("scrubSourceCursors is robust to missing cursor sub-objects", async () => {
+  const cursors = { version: 1 };
+  const result = scrubSourceCursors({ cursors, sourceId: "claude", home: HOME, env: ENV });
+  assert.equal(result.filesRemoved, 0);
+  assert.equal(result.bucketsRemoved, 0);
+  assert.equal(result.groupsRemoved, 0);
+  assert.equal(result.projectBucketsRemoved, 0);
+});
+
+test("scrubSourceCursors keys projectHourly buckets by middle segment, not substring", async () => {
+  // The split-on-`|` check guards against a project_key that *contains* the
+  // source name as a substring. e.g. a hypothetical "codexlab/foo" project
+  // key paired with a "claude" source must not be deleted by sourceId="codex".
+  const cursors = {
+    projectHourly: {
+      version: 2,
+      buckets: {
+        "codexlab/foo|claude|2026-04-26T05:00:00.000Z": { totals: { total_tokens: 1 } },
+        "myproj/bar|codex|2026-04-26T05:00:00.000Z": { totals: { total_tokens: 2 } },
+      },
+      projects: {},
+    },
+  };
+  const result = scrubSourceCursors({ cursors, sourceId: "codex", home: HOME, env: ENV });
+  assert.equal(result.projectBucketsRemoved, 1);
+  assert.ok(
+    cursors.projectHourly.buckets["codexlab/foo|claude|2026-04-26T05:00:00.000Z"],
+    "project key containing 'codex' as a substring must NOT be removed by sourceId=codex",
+  );
+  assert.equal(
+    cursors.projectHourly.buckets["myproj/bar|codex|2026-04-26T05:00:00.000Z"],
+    undefined,
+  );
+});
+
+test("listSupportedSources returns the registered set", async () => {
+  const ids = listSupportedSources();
+  assert.ok(ids.includes("claude"));
+  assert.ok(ids.includes("codex"));
+  assert.ok(ids.includes("opencode"));
+  assert.ok(ids.includes("hermes"));
+});

--- a/test/fs-open-lock.test.js
+++ b/test/fs-open-lock.test.js
@@ -1,0 +1,221 @@
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { openLock } = require("../src/lib/fs");
+
+async function tmpDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-lock-"));
+}
+
+test("openLock acquires when no lock exists, releases cleanly", async () => {
+  const dir = await tmpDir();
+  const lockPath = path.join(dir, "sync.lock");
+
+  const lock = await openLock(lockPath, { quietIfLocked: true });
+  assert.ok(lock, "should return a lock handle");
+
+  // proper-lockfile creates lockPath as a directory with the heartbeat mtime.
+  const stat = await fs.stat(lockPath);
+  assert.ok(stat.isDirectory(), "lock path is a directory while held");
+
+  await lock.release();
+
+  await assert.rejects(fs.access(lockPath), /ENOENT/);
+});
+
+test("openLock yields while another holder is alive; release lets the next caller in", async () => {
+  const dir = await tmpDir();
+  const lockPath = path.join(dir, "sync.lock");
+
+  const first = await openLock(lockPath, { quietIfLocked: true });
+  assert.ok(first);
+
+  const second = await openLock(lockPath, { quietIfLocked: true });
+  assert.equal(second, null, "concurrent acquire must yield");
+
+  await first.release();
+
+  const third = await openLock(lockPath, { quietIfLocked: true });
+  assert.ok(third, "release must clear the way for the next caller");
+  await third.release();
+});
+
+test("openLock auto-recovers from an orphan lock with a stale heartbeat mtime", async () => {
+  // Real-world scenario: a sync process died abnormally (SIGKILL, system
+  // restart) before its heartbeat could refresh. proper-lockfile detects
+  // the stale mtime on the lock directory and takes it over for us. No
+  // manual recovery code on our side.
+  const dir = await tmpDir();
+  const lockPath = path.join(dir, "sync.lock");
+
+  // Forge an "orphan" lock directory with a heartbeat mtime older than our
+  // 60s stale window. This is exactly what a crashed sync leaves behind
+  // once enough time has passed without a heartbeat refresh.
+  await fs.mkdir(lockPath);
+  const oldMtime = new Date(Date.now() - 5 * 60 * 1000);
+  await fs.utimes(lockPath, oldMtime, oldMtime);
+
+  const recovered = await openLock(lockPath, { quietIfLocked: true });
+  assert.ok(recovered, "stale orphan lock must be auto-recovered");
+  await recovered.release();
+});
+
+test("openLock yields to a live cross-process holder whose heartbeat is fresh", async () => {
+  // Spawn a child that acquires the lock and stays alive (with active timers
+  // so its heartbeat keeps refreshing). Concurrent acquire attempts from
+  // this process must yield until the child releases or dies.
+  const dir = await tmpDir();
+  const lockPath = path.join(dir, "sync.lock");
+
+  // proper-lockfile's heartbeat timer is unref'd, so the child needs its own
+  // ref'd timer to keep its event loop alive — mirroring how a real sync
+  // process stays alive via its ongoing fs/network work.
+  const childScript = `
+    const { openLock } = require(${JSON.stringify(path.resolve("src/lib/fs.js"))});
+    (async () => {
+      const lock = await openLock(${JSON.stringify(lockPath)}, { quietIfLocked: true });
+      if (!lock) { process.stdout.write("FAIL\\n"); process.exit(2); }
+      process.stdout.write("HELD\\n");
+      // Keep the event loop alive (ref'd timer); the lock heartbeat will
+      // ride along.
+      const keepalive = setInterval(() => {}, 1000);
+      process.on("SIGTERM", async () => {
+        clearInterval(keepalive);
+        await lock.release();
+        process.exit(0);
+      });
+    })();
+  `;
+  const child = spawn(process.execPath, ["-e", childScript], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  await new Promise((resolve, reject) => {
+    let buf = "";
+    const onData = (chunk) => {
+      buf += chunk.toString("utf8");
+      if (buf.includes("HELD")) {
+        child.stdout.off("data", onData);
+        resolve();
+      }
+    };
+    child.stdout.on("data", onData);
+    child.once("error", reject);
+  });
+
+  try {
+    const blocked = await openLock(lockPath, { quietIfLocked: true });
+    assert.equal(blocked, null, "fresh heartbeat from cross-process holder must keep us out");
+  } finally {
+    child.kill("SIGTERM");
+    await new Promise((resolve) => child.once("exit", resolve));
+  }
+});
+
+test("openLock migrates an orphaned legacy file lock (pre-proper-lockfile format)", async () => {
+  // Pre-upgrade vibeusage created the lock as a regular file via fs.open
+  // "wx". After upgrade, proper-lockfile expects a directory at the same
+  // path. Without explicit migration, it would mkdir-EEXIST then rmdir-
+  // ENOTDIR and throw instead of yielding. The new migration path detects
+  // the legacy file, confirms the recorded pid is dead, removes it, and
+  // hands a clean slate to proper-lockfile.
+  const dir = await tmpDir();
+  const lockPath = path.join(dir, "sync.lock");
+
+  const ghostPid = 4194303;
+  await fs.writeFile(
+    lockPath,
+    JSON.stringify({ pid: ghostPid, startedAtMs: Date.now() - 60_000 }),
+  );
+
+  const lock = await openLock(lockPath, { quietIfLocked: true });
+  assert.ok(lock, "orphaned legacy file lock must be migrated and reclaimed");
+
+  // After migration, the lock path is a directory (proper-lockfile format),
+  // not a file.
+  const stat = await fs.stat(lockPath);
+  assert.ok(stat.isDirectory(), "post-migration lock path must be a directory");
+
+  await lock.release();
+});
+
+test("openLock refuses to auto-delete a zero-byte legacy lock (the actual pre-fix prod format)", async () => {
+  // The original openLock did `fs.open(path, "wx")` and never called
+  // writeFile, so the lock file it left behind was always 0 bytes. With no
+  // PID payload we cannot prove its holder is dead, and auto-deleting would
+  // race a still-running legacy sync. Migration must yield + warn, not
+  // unlink.
+  const dir = await tmpDir();
+  const lockPath = path.join(dir, "sync.lock");
+  await fs.writeFile(lockPath, "");
+
+  const captured = [];
+  const realStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => {
+    captured.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+    return true;
+  };
+  let lock;
+  try {
+    lock = await openLock(lockPath, { quietIfLocked: true });
+  } finally {
+    process.stderr.write = realStderrWrite;
+  }
+
+  assert.equal(lock, null, "must yield rather than auto-delete an empty legacy lock");
+
+  const stat = await fs.stat(lockPath);
+  assert.ok(stat.isFile(), "zero-byte legacy lock must remain in place for manual cleanup");
+  assert.equal(stat.size, 0);
+
+  const stderr = captured.join("");
+  assert.match(stderr, /no PID payload/);
+  assert.match(stderr, new RegExp(`rm .*${path.basename(lockPath)}`));
+});
+
+test("openLock yields to a still-alive legacy file lock holder rather than crashing", async () => {
+  // Worst-case upgrade scenario: an old-format vibeusage sync is genuinely
+  // still running while a new-format sync starts. We must not delete the
+  // legacy holder's file, and we must not let proper-lockfile's mkdir+rmdir
+  // path throw ENOTDIR. Yield with the standard "another sync running" UX.
+  const dir = await tmpDir();
+  const lockPath = path.join(dir, "sync.lock");
+
+  await fs.writeFile(
+    lockPath,
+    JSON.stringify({ pid: process.pid, startedAtMs: Date.now() }),
+  );
+
+  const lock = await openLock(lockPath, { quietIfLocked: true });
+  assert.equal(lock, null, "must yield to a live legacy holder");
+
+  // Legacy file must remain untouched — we did not create it, we do not
+  // get to delete it while its holder is alive.
+  const stat = await fs.stat(lockPath);
+  assert.ok(stat.isFile(), "live legacy file lock must remain in place");
+});
+
+test("openLock does not flag a long-running, still-beating holder as stale", async () => {
+  // Regression check: the previous wall-clock-age implementation would have
+  // misclassified a long-running but actively beating lock as orphaned.
+  // proper-lockfile's heartbeat is the correctness signal, so a holder with
+  // a fresh mtime must not be taken over no matter how long ago it started.
+  const dir = await tmpDir();
+  const lockPath = path.join(dir, "sync.lock");
+
+  const first = await openLock(lockPath, { quietIfLocked: true });
+  assert.ok(first);
+
+  // The holder has been "running" for hours, but the heartbeat keeps the
+  // mtime fresh — proper-lockfile's update interval ticks during the test.
+  // Even if we forcibly age the directory, the next heartbeat will refresh
+  // it; instead we just verify that a peer attempt yields immediately.
+  const peer = await openLock(lockPath, { quietIfLocked: true });
+  assert.equal(peer, null, "peer must yield to a beating holder");
+
+  await first.release();
+});

--- a/test/sync-openclaw-trigger.test.js
+++ b/test/sync-openclaw-trigger.test.js
@@ -51,6 +51,50 @@ test("sync --from-openclaw records last OpenClaw trigger marker", async () => {
   }
 });
 
+test("sync --rebuild=openclaw forces fromOpenclaw so the ledger is actually re-aggregated", async () => {
+  // Regression: argv validation accepting --rebuild=openclaw without
+  // turning on the OpenClaw parsing branch would scrub the OpenClaw
+  // cursors and persist the cleared state, leaving totals stale until
+  // a later plugin-triggered sync. The signal file is the load-bearing
+  // proof that fromOpenclaw was set: it is only written by the sync
+  // entry path when opts.fromOpenclaw is truthy.
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-sync-rebuild-openclaw-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevCodeHome = process.env.CODE_HOME;
+  const prevGeminiHome = process.env.GEMINI_HOME;
+  const prevOpencodeHome = process.env.OPENCODE_HOME;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    process.env.CODE_HOME = path.join(tmp, ".code");
+    process.env.GEMINI_HOME = path.join(tmp, ".gemini");
+    process.env.OPENCODE_HOME = path.join(tmp, ".opencode");
+
+    await cmdSync(["--rebuild=openclaw"]);
+
+    const markerPath = path.join(tmp, ".vibeusage", "tracker", "openclaw.signal");
+    const marker = (await fs.readFile(markerPath, "utf8")).trim();
+    assert.ok(
+      marker.length > 0,
+      "rebuild=openclaw must write the openclaw.signal marker (proves fromOpenclaw was forced on)",
+    );
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (prevCodeHome === undefined) delete process.env.CODE_HOME;
+    else process.env.CODE_HOME = prevCodeHome;
+    if (prevGeminiHome === undefined) delete process.env.GEMINI_HOME;
+    else process.env.GEMINI_HOME = prevGeminiHome;
+    if (prevOpencodeHome === undefined) delete process.env.OPENCODE_HOME;
+    else process.env.OPENCODE_HOME = prevOpencodeHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("sync --from-openclaw ignores transcript files and previous-total fallback env", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-sync-openclaw-hard-cut-"));
   const prevHome = process.env.HOME;


### PR DESCRIPTION
# What does this PR do?

- Replaces the wx-based `sync.lock` with `proper-lockfile`'s heartbeat-driven lock so abnormally-killed syncs auto-recover instead of leaving the pipeline frozen for hours.
- Adds `vibeusage sync --rebuild=<source>` to atomically scrub every cursor surface that participates in re-aggregation, fixing the doubling bug behind the recent Claude DB drift.
- Keeps `src/lib/fs.js` loadable in callers that materialize `src/` into sandboxes without `node_modules` (openclaw plugin tests) by lazy-requiring `proper-lockfile`.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- Replace `openLock` in `src/lib/fs.js` with a `proper-lockfile`-backed implementation (10s heartbeat / 60s stale window) plus a safe legacy-migration path that refuses to auto-delete pre-upgrade zero-byte lock files (an old wx holder may still be running and own that file).
- Add `src/lib/cursor-scrub.js` and `vibeusage sync --rebuild=<source>` (`src/commands/sync.js`). The scrub clears `cursors.files`, `cursors.hourly.buckets`, `cursors.hourly.groupQueued`, `cursors.projectHourly.buckets` (middle-segment match against `<project>|<source>|<hour>` so substring collisions like `codexlab/...` are not stripped), and per-source ledger fields (`opencode`, `opencodeSqlite`, `hermesLedger`, `openclawLedger`).
- Update `doctor --audit-tokens` failure hint to point operators at `--rebuild=<source>` instead of the misleading manual cursors.json scrub instructions that triggered the doubling.
- Lazy-load `proper-lockfile` inside `openLock` so `src/lib/fs.js` keeps loading from sandboxes without node_modules.
- New tests: `test/fs-open-lock.test.js` (clean acquire/release, concurrent yield, stale-mtime auto-recovery, cross-process mutex with live heartbeat, legacy migration of zero-byte and PID-bearing files), `test/cursor-scrub.test.js` (per-source isolation, env-overridden session roots, project-bucket substring guard, missing sub-objects).

## Affected Modules / Contracts

- **Modules touched:** `src/lib/fs.js`, `src/lib/cursor-scrub.js` (new), `src/commands/sync.js`, `src/commands/doctor.js`, `test/fs-open-lock.test.js` (new), `test/cursor-scrub.test.js` (new), `package.json`, `package-lock.json`.
- **Dependencies / contracts touched:** Adds `proper-lockfile@4.x` as a runtime dependency. New CLI surface: `vibeusage sync --rebuild=<source>` (sources: `claude|codex|every-code|gemini|kimi|opencode|hermes|openclaw`); implicitly enables `--drain` so the rebuilt buckets actually upload. `sync.lock` on disk transitions from a regular file to a directory while held; legacy file-format leftovers are preserved (yield + warn) for safety on upgrade.
- **Repo sitemap evidence:** `not required` — no public-facing API or schema change; internal refactor with new CLI flag.

## Validation

### Automated

- `npm test` passes 830/830 locally on darwin (Node 25.2.1) including the previously-failing 4 openclaw-session-plugin cases that surfaced the lazy-require regression.

### Manual / smoke

- Reproduced the original `sync.lock` orphan deadlock on a real `~/.vibeusage/tracker/sync.lock` left over by an aborted sync at 01:50 UTC: `vibeusage sync` now recovers via the heartbeat window without operator intervention.
- Ran `vibeusage sync --rebuild=claude` end-to-end against the local tracker workspace; `doctor --audit-tokens --source claude --days 14` dropped Claude max drift from 100% (post-doubling-bug) to 0.51% after one rebuild + drain.

### Uncovered scope

- Did not exercise non-darwin platforms; `proper-lockfile`'s mtime-heartbeat semantics are platform-portable but the regression run was macOS-only. Filesystems with second-resolution mtime may experience slightly noisier heartbeats but still inside the 60s stale window.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** the `cursor-scrub` middle-segment matcher (`src/lib/cursor-scrub.js`) — it must clear in lockstep across all four cursor surfaces, and the `projectHourly.buckets` substring guard is what keeps a `codex` rebuild from accidentally deleting a `codexlab/...|claude|...` bucket.
- **Delta since last review:** N/A — first review of this branch.
- **Depends on:** none.
- **Known gaps / follow-ups:** Heartbeat unref'd timer means a holder whose event loop is wedged for >60s (laptop suspend, runaway GC) can lose the lock to a peer; the user accepted this trade-off versus the alternatives (Node O\_EXLOCK is a no-op cross-process; native flock binding is more invasive).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `vibeusage sync --rebuild=<source>` for cursor-correct re-aggregation with proper-lockfile
> - Adds `--rebuild <source>` / `--rebuild=<source>` CLI flag to `sync` that clears all cursor state for a given source (files, hourly buckets, group queues, project hourly) and runs a full drain pass, replacing the previous manual cursor-editing workflow.
> - Introduces [cursor-scrub.js](https://github.com/victorGPT/vibeusage/pull/186/files#diff-183c8c3a557c2ced985df232b9be98b6aec8cce3c76937388ca00e930895fcbd) with `scrubSourceCursors` and `listSupportedSources`; source ids are validated at parse time, and `--rebuild=openclaw` auto-enables OpenClaw parsing.
> - Rewrites `openLock` in [fs.js](https://github.com/victorGPT/vibeusage/pull/186/files#diff-b951fe567e9e8bf2231fef049051d06d633d9cac1e53b89bf029b44d5daf8fd4) to use `proper-lockfile` (heartbeat-based directory locks) with auto-recovery from stale locks and a migration path for legacy file locks containing dead PIDs.
> - Updates the `doctor` threshold-exceeded error message to instruct `vibeusage sync --rebuild <source>` instead of manual cursor scrubbing.
> - Behavioral Change: legacy lock files with a live PID or zero-byte content now print a warning and yield instead of throwing; stale orphan locks are auto-deleted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5e187f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->