### PR TITLE
fix(dashboard): transform shared .cjs imports via esbuild in Vite dev

### DIFF
--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
+import { transformSync } from "esbuild";
 import { defineConfig, loadEnv } from "vite";
 import copyRegistryModule from "../src/shared/copy-registry.cjs";
 
@@ -130,6 +131,28 @@ function richLinkMetaPlugin() {
   };
 }
 
+// Transform `.cjs` files imported from outside the dashboard root into ESM
+// during dev. Vite 7 stopped doing this automatically for files served via
+// `/@fs/`, so the dashboard hits a "module does not provide default export"
+// error on `import x from "../../../src/shared/*.cjs"`.
+function cjsToEsmPlugin() {
+  return {
+    name: "vibeusage-cjs-to-esm",
+    enforce: "pre",
+    transform(code, id) {
+      if (!id.endsWith(".cjs")) return null;
+      const result = transformSync(code, {
+        loader: "js",
+        format: "esm",
+        target: "esnext",
+        sourcefile: id,
+        sourcemap: false,
+      });
+      return { code: result.code, map: null };
+    },
+  };
+}
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, ROOT_DIR, "VITE_");
   const fallbackVersion = loadAppVersion();
@@ -140,7 +163,7 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
-    plugins: [react(), richLinkMetaPlugin()],
+    plugins: [cjsToEsmPlugin(), react(), richLinkMetaPlugin()],
     ...(Object.keys(define).length ? { define } : {}),
     build: {
       rollupOptions: {


### PR DESCRIPTION
# What does this PR do?

- Restores the dashboard dev server: pre-existing CJS-to-ESM bug had crashed the entire React tree on the very first import in `src/lib/copy.ts` (followed by `config.ts` / `vibeusage-api.ts`). Symptom was "TREND module not showing" but actually nothing was — React never mounted.
- Adds a 12-line inline Vite plugin (`cjsToEsmPlugin`) that runs `.cjs` files through `esbuild.transformSync` with `loader: "js"` + `format: "esm"`. esbuild synthesizes a default export for the `module.exports = {...}` pattern, which is exactly what the existing default-import-then-destructure consumers in dashboard need.

## Related Issue

Fixes nothing yet (no GitHub issue filed). Surfaced when user reported "TREND 模块怎么没显示了" while running `npm run dev` locally.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- `dashboard/vite.config.js`: add `cjsToEsmPlugin()` to the plugin chain (placed first via `enforce: "pre"` so it runs before React's transform). Imports `transformSync` from esbuild.

## Affected Modules / Contracts

- **Modules touched:** dashboard/vite.config.js (dev-only build config)
- **Dependencies / contracts touched:** none — esbuild is a transitive dep of Vite, no new package needed
- **Repo sitemap evidence:** not required (dev-only build config)

## Validation

### Automated

- `npm run build` ✓ (Rollup handled this all along — production was never broken)
- `npm test` ✓ 108/108 (incl. `shared-browser-compat.test.ts` which guards against CJS markers in the prod browser bundle)

### Manual / smoke

- `npm run dev` → http://localhost:5173/dashboard reload → no SyntaxError, React tree mounts (rootChildren=2, bodyText 1477 chars, redirects to landing as expected without auth)
- Console clean except expected 401 from auth-gated API calls

### Uncovered scope

- This PR doesn't change the .cjs files themselves or the consumer import patterns. Only the Vite dev transform.
- A different long-term path (collapse the SSOT to ESM, or move into `dashboard/src/shared/` where the default loader works) is not attempted here — out of scope.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** the `cjsToEsmPlugin` matches every `.cjs` transform — verify the broad match doesn't accidentally double-transform anything Vite has already handled. The `enforce: "pre"` placement should make this safe (we run before Vite's own CJS handling, which is now a no-op for `/@fs/` files anyway).
- **Why dev-only**: Vite 7 dev serves `/@fs/...` source as-is for `.cjs` files; production `vite build` (Rollup) has its own `commonjs` plugin that handles this correctly.
- **Depends on:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Transform shared .cjs imports to ESM via esbuild in Vite dev server
> Adds a `cjsToEsmPlugin` in [vite.config.js](https://github.com/victorGPT/vibeusage/pull/187/files#diff-dbdcdfc02335932cb391dee1229364d5b3080919b8615ce9bdc8da4b73dc8168) that runs in the `pre` phase and converts `.cjs` files to ESM using esbuild's `transformSync` with `format=esm`. The plugin is registered before `react()` and `richLinkMetaPlugin()` to ensure transformation happens early in the pipeline. Risk: only applies during dev; production builds are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19a8069.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->