### PR TITLE
fix(design-system): align type-display meta annotations with actual CSS

### DIFF
--- a/design-system/preview/type-display.html
+++ b/design-system/preview/type-display.html
@@ -10,8 +10,8 @@
 .s2 { font-size: 28px; line-height: 1.05; letter-spacing: -0.02em; font-weight: 900; }
 .s3 { font-size: 20px; line-height: 1.10; letter-spacing: -0.02em; font-weight: 900; }
 </style></head><body><div class="card spec">
-<div class="row"><div class="tok">display-0</div><div class="specimen s0">142,892</div><div class="meta">96/.95/-0.03</div></div>
-<div class="row"><div class="tok">display-1</div><div class="specimen s1">VibeUsage</div><div class="meta">60/1.0/-0.02</div></div>
-<div class="row"><div class="tok">display-2</div><div class="specimen s2">$58.21 USD</div><div class="meta">40/1.05/-0.02</div></div>
-<div class="row"><div class="tok">display-3</div><div class="specimen s3">NEO.SYST_3M</div><div class="meta">28/1.1/-0.02</div></div>
+<div class="row"><div class="tok">display-0</div><div class="specimen s0">142,892</div><div class="meta">56/.95/-0.03</div></div>
+<div class="row"><div class="tok">display-1</div><div class="specimen s1">VibeUsage</div><div class="meta">40/1.0/-0.02</div></div>
+<div class="row"><div class="tok">display-2</div><div class="specimen s2">$58.21 USD</div><div class="meta">28/1.05/-0.02</div></div>
+<div class="row"><div class="tok">display-3</div><div class="specimen s3">NEO.SYST_3M</div><div class="meta">20/1.1/-0.02</div></div>
 </div></body></html>


### PR DESCRIPTION
# What does this PR do?

- Follow-up to #185: the `[Low]` review on `design-system/preview/type-display.html:13-16` (Macroscope, 2026-04-28T04:14:50Z) was correctly diagnosed but #185 merged before its fix landed. This PR carries the fix forward so main matches the reviewer's diff.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- Update `design-system/preview/type-display.html` lines 13–16 so the `.meta` spec annotations match the actual CSS:
  - `display-0`: `96/.95/-0.03` → `56/.95/-0.03` (matches `.s0 { font-size: 56px }`)
  - `display-1`: `60/1.0/-0.02` → `40/1.0/-0.02` (matches `.s1 { font-size: 40px }`)
  - `display-2`: `40/1.05/-0.02` → `28/1.05/-0.02` (matches `.s2 { font-size: 28px }`)
  - `display-3`: `28/1.1/-0.02` → `20/1.1/-0.02` (matches `.s3 { font-size: 20px }`)

## Affected Modules / Contracts

- **Modules touched:** `design-system/preview/type-display.html` only.
- **Dependencies / contracts touched:** none — pure documentation correction inside the design-system bundle.
- **Repo sitemap evidence:** `not required` — single-file static spec card; no module boundary change.

## Validation

### Automated

- No code path under test exercises the static preview HTML; `npm test` was not rerun for this change.

### Manual / smoke

- Visual diff of `design-system/preview/type-display.html` confirms the four `<div class="meta">` annotations now match the CSS in `<style>` directly above (lines 8–11).

### Uncovered scope

- None — single-file documentation fix.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** verify the four `.meta` numbers against the four `.s0..s3` rules in the same file's `<style>` block.
- **Delta since last review:** N/A — first review of this branch.
- **Depends on:** #185 (merged).
- **Known gaps / follow-ups:** None.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix type-display preview meta annotations to match actual CSS values
> Corrects the size descriptors shown in [type-display.html](https://github.com/victorGPT/vibeusage/pull/189/files#diff-ea728b6c454477b442ec493b8b0def52bb0995c6295b20b709a169e1d45d924a) for display-0 through display-3. The displayed values were mismatched with the actual CSS: sizes now read 56, 40, 28, and 20 instead of 96, 60, 40, and 28 respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddc3483.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->