### PR TITLE
Revert Panel: restore ASCII frame + chip-on-top-rule (rollback #181 + #188)

### DIFF
--- a/dashboard/src/ui/foundation/AsciiBox.jsx
+++ b/dashboard/src/ui/foundation/AsciiBox.jsx
@@ -1,11 +1,18 @@
 import React from "react";
 import { Panel } from "./Panel.jsx";
 
-// Back-compat shim. v3 collapsed card chrome to a single 1px hairline (Panel
-// plain), so AsciiBox just delegates. Call sites can keep using <AsciiBox>;
-// new code should import Panel directly.
+// Retained for call-site stability. New code should import Panel directly.
 // SSOT: DESIGN.md §6.
 
+export const ASCII_CHARS = {
+  TOP_LEFT: "┌",
+  TOP_RIGHT: "┐",
+  BOTTOM_LEFT: "└",
+  BOTTOM_RIGHT: "┘",
+  HORIZONTAL: "─",
+  VERTICAL: "│",
+};
+
 export function AsciiBox(props) {
-  return <Panel variant="plain" {...props} />;
+  return <Panel variant="ascii" {...props} />;
 }

--- a/dashboard/src/ui/foundation/Panel.jsx
+++ b/dashboard/src/ui/foundation/Panel.jsx
@@ -1,15 +1,14 @@
 import React from "react";
 
-// Panel — 1px hairline card with a SEPARATE little title box pinned to the
-// top-left corner (like a tab). No header bar, no chip on a horizontal rule.
-// SSOT: DESIGN.md §6 Component Contracts.
+// Panel — single 1px hairline card.
+// SSOT: DESIGN.md §6 Component Contracts (v3 — kit chat: "single 1px hairline").
 // variants: plain (default 1px border + raised surface), bare (no border, stacked sections)
 // tone:     default, strong (chip / modal elevation)
-// weight:   primary (hero — bumps border to ink-muted + adds shadow-glow-faint), secondary (default), tertiary (no-op, kept for API stability)
+// weight:   primary (hero — adds shadow-glow-sm), secondary (default), tertiary (no-op, kept for API stability)
 // stamped:  embeds corner labels (handle / period / logo) for self-contained screenshots
 
 const VARIANT = {
-  plain: "bg-surface-raised backdrop-blur-panel border border-ink-line",
+  plain: "bg-surface-raised backdrop-blur-panel border border-ink-line shadow-panel",
   bare: "bg-surface-raised backdrop-blur-panel",
 };
 
@@ -69,23 +68,9 @@ export function Panel({
   const resolvedVariant = variant === "ascii" ? "plain" : variant;
   const variantClass = VARIANT[resolvedVariant] ?? VARIANT.plain;
   const toneClass = TONE[tone] ?? TONE.default;
-  const isPrimary = weight === "primary";
-  const primaryClass = isPrimary ? "border-ink-muted shadow-glow-faint" : "";
+  const weightShadow = weight === "primary" ? "shadow-glow-sm" : "";
   const rootClass =
-    `relative flex flex-col ${variantClass} ${toneClass} ${primaryClass} ${className}`.trim();
-
-  // Title chip — independent little box pinned to the top-left corner (like
-  // a tab); subtitle takes the same look pinned to the top-right.
-  const hasTitleBox = Boolean(title || subtitle);
-  const titleChipClass = isPrimary
-    ? "border-ink-muted text-ink-bright"
-    : "border-ink-line text-ink";
-  const titleStyle = isPrimary
-    ? { textShadow: "0 0 8px var(--ink-glow)" }
-    : undefined;
-  // Push the body down so it clears the absolutely-positioned title box.
-  // Inline so it wins over caller-supplied bodyClassName (e.g. "py-3").
-  const bodyStyle = hasTitleBox ? { paddingTop: 36 } : undefined;
+    `relative flex flex-col ${variantClass} ${toneClass} ${weightShadow} ${className}`.trim();
 
   return (
     <div className={rootClass}>
@@ -95,20 +80,15 @@ export function Panel({
         stampPeriod={stampPeriod}
         stampLogo={stampLogo}
       />
-      {title ? (
-        <span
-          className={`absolute top-2.5 left-3 z-[2] inline-flex items-center gap-1 border ${titleChipClass} bg-surface-strong px-2.5 py-1 text-micro uppercase leading-none whitespace-nowrap`}
-          style={titleStyle}
-        >
-          {title}
-        </span>
+      {title || subtitle ? (
+        <div className="flex items-baseline gap-3 px-4 pt-4">
+          {title ? <span className="text-heading text-ink uppercase">{title}</span> : null}
+          {subtitle ? (
+            <span className="text-caption text-ink-text uppercase">[{subtitle}]</span>
+          ) : null}
+        </div>
       ) : null}
-      {subtitle ? (
-        <span className="absolute top-2.5 right-3 z-[2] border border-ink-line bg-surface-strong px-2.5 py-1 text-micro uppercase leading-none text-ink-text">
-          {subtitle}
-        </span>
-      ) : null}
-      <div className={`px-4 py-4 ${bodyClassName}`} style={bodyStyle}>{children}</div>
+      <div className={`px-4 py-4 ${bodyClassName}`}>{children}</div>
     </div>
   );
 }

--- a/dashboard/src/ui/foundation/Panel.jsx
+++ b/dashboard/src/ui/foundation/Panel.jsx
@@ -1,13 +1,25 @@
 import React from "react";
 
-// Panel — single 1px hairline card.
-// SSOT: DESIGN.md §6 Component Contracts (v3 — kit chat: "single 1px hairline").
-// variants: plain (default 1px border + raised surface), bare (no border, stacked sections)
+// Panel — SSOT: DESIGN.md §6 Component Contracts.
+// variants: ascii (signature), plain (default), bare (stacked sections)
 // tone:     default, strong (chip / modal elevation)
-// weight:   primary (hero — adds shadow-glow-sm), secondary (default), tertiary (no-op, kept for API stability)
+// weight:   primary (hero, double-line ASCII), secondary (default), tertiary (faint)
 // stamped:  embeds corner labels (handle / period / logo) for self-contained screenshots
 
+const ASCII_WEIGHT = {
+  primary: { TL: "╔", TR: "╗", BL: "╚", BR: "╝", H: "═", V: "║" },
+  secondary: { TL: "┌", TR: "┐", BL: "└", BR: "┘", H: "─", V: "│" },
+  tertiary: { TL: "·", TR: "·", BL: "·", BR: "·", H: "·", V: "·" },
+};
+
+const FRAME_TONE = {
+  primary: "text-ink",
+  secondary: "text-ink-muted",
+  tertiary: "text-ink-faint",
+};
+
 const VARIANT = {
+  ascii: "bg-surface-raised backdrop-blur-panel shadow-panel",
   plain: "bg-surface-raised backdrop-blur-panel border border-ink-line shadow-panel",
   bare: "bg-surface-raised backdrop-blur-panel",
 };
@@ -63,23 +75,63 @@ export function Panel({
   bodyClassName = "",
   children,
 }) {
-  // Back-compat: legacy callers pass variant="ascii". The ASCII corner glyph
-  // mode was removed in v3 — fold it into the plain hairline variant.
-  const resolvedVariant = variant === "ascii" ? "plain" : variant;
-  const variantClass = VARIANT[resolvedVariant] ?? VARIANT.plain;
+  const variantClass = VARIANT[variant] ?? VARIANT.plain;
   const toneClass = TONE[tone] ?? TONE.default;
   const weightShadow = weight === "primary" ? "shadow-glow-sm" : "";
   const rootClass =
     `relative flex flex-col ${variantClass} ${toneClass} ${weightShadow} ${className}`.trim();
 
+  const stamps = (
+    <CornerStamps
+      stamped={stamped}
+      stampHandle={stampHandle}
+      stampPeriod={stampPeriod}
+      stampLogo={stampLogo}
+    />
+  );
+
+  if (variant === "ascii") {
+    const ASCII = ASCII_WEIGHT[weight] ?? ASCII_WEIGHT.secondary;
+    const frameTone = FRAME_TONE[weight] ?? FRAME_TONE.secondary;
+    return (
+      <div className={rootClass}>
+        {stamps}
+        <div className="flex items-center leading-none">
+          <span className={`shrink-0 ${frameTone}`}>{ASCII.TL}</span>
+          {title ? (
+            <span className="mx-3 shrink-0 px-2 py-1 text-heading text-ink uppercase bg-surface-strong border border-ink-faint">
+              {title}
+            </span>
+          ) : null}
+          {subtitle ? (
+            <span className="mr-2 text-caption text-ink-text uppercase">[{subtitle}]</span>
+          ) : null}
+          <span className={`flex-1 overflow-hidden whitespace-nowrap ${frameTone}`}>
+            {ASCII.H.repeat(100)}
+          </span>
+          <span className={`shrink-0 ${frameTone}`}>{ASCII.TR}</span>
+        </div>
+
+        <div className="flex flex-1">
+          <div className="shrink-0 w-3" aria-hidden="true" />
+          <div className={`flex-1 min-w-0 relative z-10 py-4 px-4 ${bodyClassName}`}>
+            {children}
+          </div>
+          <div className="shrink-0 w-3" aria-hidden="true" />
+        </div>
+
+        <div className={`flex items-center leading-none ${frameTone}`}>
+          <span className="shrink-0">{ASCII.BL}</span>
+          <span className="flex-1 overflow-hidden whitespace-nowrap">{ASCII.H.repeat(100)}</span>
+          <span className="shrink-0">{ASCII.BR}</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={rootClass}>
-      <CornerStamps
-        stamped={stamped}
-        stampHandle={stampHandle}
-        stampPeriod={stampPeriod}
-        stampLogo={stampLogo}
-      />
+      {stamps}
       {title || subtitle ? (
         <div className="flex items-baseline gap-3 px-4 pt-4">
           {title ? <span className="text-heading text-ink uppercase">{title}</span> : null}

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -47,7 +47,7 @@ Developers active on X / Twitter who already screenshot their dev tools and year
 
 Operations Deck. **Material**: zero radius on every data surface (the only `border-radius: 999px` exceptions are the status dot, identity / project avatars, and floating action buttons — see §Visual foundations / Corner radii), thin 1px lines, low-noise surfaces, numbers as the hero. **Energy**: restrained neon green + density + a single scanline layer. **Pocket color**: Matrix Green `#00FF41` — appears only on data, active state, hover-lines, and single-glow text. Never as a filled surface larger than a button.
 
-**Signature**: single 1px hairline panel + corner-cross title chip on the top rule. (Earlier iterations used box-drawing glyphs `┌─┐│└─┘`; v3 dropped them — the seams between adjacent glyphs always read as "broken up".)
+**Signature**: ASCII-frame panel + corner-cross marks (`<Panel variant="ascii">`).
 **Signature micro-interaction**: `decoding-reveal` / scramble — characters converge on the final string. Reserved for first-paint hero title, display-2 primary number, and identity handle. Not for labels.
 
 ---
@@ -123,9 +123,9 @@ All borders are **1px solid**. No dashed / dotted / `border-[Npx]`. Ladder: `bor
 
 There is no rounded SaaS card here. Cards are:
 
-- Default `<Panel variant="plain">` — single 1px hairline (`1px solid var(--ink-line)`) on `bg-surface-raised` + `backdrop-filter: blur(10px)` + `box-shadow: var(--shadow-panel)`. Title sits in a corner-cross chip on the top rule. Pass `weight="primary"` for the hero panel — it adds a subtle `shadow-glow-sm`. Use **at most one primary** per visible viewport.
+- ASCII-framed `<Panel variant="ascii">` — top/bottom rule built from `┌ ─ ┐ │ └ ┘`, with the panel title sitting **inside** a small chip on the top rule. Three weight ladders: `primary` uses double-line `╔ ═ ╚`, `secondary` is the default single-line, `tertiary` is dotted `·`. Use **at most one primary** per visible viewport.
+- Plain `<Panel variant="plain">` — `1px solid var(--ink-line)` on `bg-surface-raised` + `backdrop-filter: blur(10px)` + `box-shadow: var(--shadow-panel)`.
 - Bare `<Panel variant="bare">` — `bg-surface-raised` only, no border (for stacked sub-sections).
-- _Legacy_: `variant="ascii"` is kept as a back-compat alias that maps to `plain`. Don't reach for it in new code.
 
 `box-shadow` always carries a 1px `0 0 0 1px rgba(0,255,65,0.08)` outline plus a deep `0 18px 40px rgba(0,0,0,0.45)` lift. Never a soft fintech shadow.
 

--- a/design-system/SKILL.md
+++ b/design-system/SKILL.md
@@ -15,7 +15,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 - **Brand**: VibeUsage — Bloomberg terminal × The Matrix. Three words: `hacker · 复古 · cyberpunk`.
 - **Pocket color**: Matrix Green `#00FF41` on `#050505`. Single gold accent `#FFD700` reserved for leaderboard #1 / cost.
 - **Font**: Geist Mono only (system fallback to ui-monospace). No exceptions.
-- **Signature**: single 1px hairline panel + corner-cross title chip on the top rule + scanline overlay. (v3 dropped the earlier box-drawing-glyph frames; see `chats/chat2.md`.)
+- **Signature**: ASCII-frame panel + corner-cross title chip + scanline overlay.
 - **Drop-in tokens**: `colors_and_type.css` — covers all colors, type, spacing, shadows, animations.
 - **Hard rules**: zero radius on every data surface (only the status dot, avatars, and floating action buttons round — see README §Corner radii), 1px solid borders only, no emoji, uppercase labels, tabular numerals.
 - **Reference recreation**: `ui_kits/dashboard/` — open `index.html` to see the product.


### PR DESCRIPTION
# What does this PR do?

- Reverts the two Panel layout iterations merged today (#181, #188) and restores yesterday's ASCII-frame signature (`┌─┐│└─┘` corner glyphs · `╔═╗` for the primary hero · chip pinned in the top horizontal rule).
- User feedback after seeing the live result: corner-tab + 1px hairline reads as "generic SaaS card" — wants the ASCII frame back as the brand signature.

## Related Issue

No tracked issue — direct user request: "把这个边框的布局的代码回滚到昨天的".

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI / workflow
- [x] Risk / contract change

## Changes Made

- `git revert 2baada38` (#188 corner-tab) → `dashboard/src/ui/foundation/Panel.jsx` reverts the absolute-positioned chip + 36px paddingTop hack
- `git revert 6e346f75` (#181 ASCII collapse) → `Panel.jsx` restores `ASCII_WEIGHT` / `FRAME_TONE` tables + the full `variant="ascii"` rendering branch; `AsciiBox.jsx` restores `ASCII_CHARS` export + `<Panel variant="ascii">` delegation

## Affected Modules / Contracts

- **Modules touched:** dashboard/src/ui/foundation/Panel, dashboard/src/ui/foundation/AsciiBox
- **Dependencies / contracts touched:** Panel API unchanged at the prop level (variant / tone / weight / stamped / title / subtitle / className / bodyClassName / children). Internal rendering reverts to the v3 ASCII frame.
- **Repo sitemap evidence:** not required (revert)

## Validation

### Automated

- `npm run build` ✓
- `npm test` ✓ 108/108
- `npm run guardrail:design` ✓

### Manual / smoke

- Local dev (`npm run dev`): all panels render with the ASCII frame back; CoreIndex hero gets `╔═╗` double-line treatment; secondary panels get `┌─┐`.

### Uncovered scope

- The DESIGN.md / design-system docs from #181 + #188 still describe the hairline + corner-tab as the v3 signature. Not reverting those in this PR — sequence is: visual revert lands first, then a separate doc PR re-aligns DESIGN.md if you want to keep the ASCII frame as the documented signature long-term.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [x] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

- Panel public API is preserved — the visual change is internal to the rendering branch.
- `variant="ascii"` resumes its full rendering (was a back-compat shim mapping to `plain`); `variant="plain"` and `variant="bare"` still work as before.
- `weight="primary" | "secondary" | "tertiary"` resumes ASCII glyph selection (`╔═╗ / ┌─┐ / ·`).

### Boundary Matrix (must list at least 3)

- **AsciiBox callers (CostAnalysisModal, TopModelsPanel, IdentityCard, NeuralDivergenceMap, ArchiveHeatmap, TrendMonitor, RollingUsagePanel, ProjectUsagePanel, DashboardView)** — render path swaps back from "1px hairline + corner-tab chip" to "ASCII corner glyphs + chip on top rule". No call-site code edits required.
- **Panel direct callers via UsagePanel** — `weight="primary"` again uses double-line `╔═╗` glyphs for the hero CoreIndex panel (was `border-ink-muted` + `shadow-glow-faint` chip).
- **Visual regression surface** — every panel in the dashboard moves back to the ASCII frame. Intentional rollback per user instruction; restored bit-for-bit via `git revert` so no drift.

### Evidence

- Local: `npm run build` ✓ · `npm test` ✓ 108/108 · `npm run guardrail:design` ✓
- Diff is a clean two-commit revert chain (`d19bb97b` reverts #188, `16076838` reverts #181) — `git diff main` shows Panel.jsx + AsciiBox.jsx restored to the pre-#181 SHA.

## Reviewer Context (optional)

- **Review focus:** confirm the revert sequence is clean (no drift vs. pre-#181 state). Walk a few panels in the live dashboard to confirm the ASCII frame is back.
- **Known gaps / follow-ups:** if the ASCII frame stays the canonical signature, DESIGN.md §6 + design-system/README.md §Cards (which both got rewritten by #181/#188) need a follow-up doc revert. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore ASCII frame variant and chip-on-top-rule layout in Panel
> - Reverts PRs #181 and #188, restoring `variant="ascii"` as a first-class `Panel` variant with weight-dependent box-drawing glyphs (double, single, dotted) and inline title/subtitle chips on the top rule.
> - Removes the legacy coercion that silently mapped `variant="ascii"` to `"plain"`; `AsciiBox` now delegates to `Panel variant="ascii"` instead of `"plain"`.
> - Non-ascii variants replace absolutely positioned title/subtitle chips with an in-flow flex header row; `variant="plain"` gains `shadow-panel`.
> - Exports `ASCII_CHARS` from [AsciiBox.jsx](https://github.com/victorGPT/vibeusage/pull/190/files#diff-de8c079c10d1794c82db2037402799375c9cf46f550d67b5124ae8ba5f546bb8) so callers can reference box-drawing characters directly.
> - Updates [design-system/README.md](https://github.com/victorGPT/vibeusage/pull/190/files#diff-52537434051370e727ee9e4b29fdc660486fedcbb006cbc55e1513f6c331fb37) and [SKILL.md](https://github.com/victorGPT/vibeusage/pull/190/files#diff-f6ce923ee0d98fd9caa5fef50574b959bea78193e28722d26db47bb0a77ca9cd) to document the ASCII-frame panel as the signature style.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dce3772.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->