### PR TITLE
release: 0.6.3 — sync.lock auto-recovery + cursor rebuild command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-04-28
+
+### Fixed
+
+- **`sync.lock` orphan deadlock.** The pre-fix `openLock` used `fs.open(path, "wx")` and never wrote a payload — when a sync died abnormally (SIGKILL, system restart, panic before `release()`), the leftover zero-byte lock file froze every subsequent run with `Another sync is already running.` until the operator manually `rm`'d it. Reproduced in the wild: a 01:50 UTC crash blocked all auto-sync attempts for ~24h, so 04-27 reached the dashboard with `db=0` while local jsonl had 339 sessions. `openLock` now uses [`proper-lockfile`](https://www.npmjs.com/package/proper-lockfile) — mkdir-based atomic acquire + 10s heartbeat / 60s stale window. Holders that die abnormally release the lock automatically once the heartbeat goes stale; no operator action needed.
+- **Pre-fix legacy lock files migrate safely.** Earlier installs left zero-byte `sync.lock` *files* on disk. `proper-lockfile` expects a directory at the same path, so naive upgrade would crash with `mkdir EEXIST → rmdir ENOTDIR`. New code lstats the path on entry: directory ⇒ already migrated; file with PID payload + dead pid ⇒ unlink and migrate; file with PID payload + alive pid ⇒ yield (an old-format sync may genuinely still be running); zero-byte / corrupt payload ⇒ yield with a stderr notice including the exact `rm` command (refusing to auto-delete a file we cannot prove orphaned, since a still-running legacy holder owns that exact file).
+
+### Added
+
+- **`vibeusage sync --rebuild=<source>`** (sources: `claude | codex | every-code | gemini | kimi | opencode | hermes | openclaw`). Atomically scrubs every cursor surface that participates in re-aggregation for the named source, then drains: `cursors.files` entries under the source's session root, `cursors.hourly.buckets` keyed `<source>|...`, `cursors.hourly.groupQueued` for the source, `cursors.projectHourly.buckets` keyed `<project>|<source>|<hour>` (middle-segment match — a project key like `codexlab/foo` paired with `claude` source survives a `--rebuild=codex`), and per-source ledger fields (`opencode`, `opencodeSqlite`, `hermesLedger`, `openclawLedger`). For OpenClaw, `parseArgs` also forces `fromOpenclaw=true` so the gated ledger-parse branch actually runs on a rebuild path. Implicitly enables `--drain` so the rebuilt buckets upload immediately. Validated end-to-end: max Claude drift across the 14-day window dropped from 100% (post-doubling-bug) to 0.51% after a single rebuild + drain.
+
+### Changed
+
+- **doctor's audit-tokens failure hint** now points at `vibeusage sync --rebuild=<source>` instead of the previous "scrub the Claude/OpenCode cursor block in cursors.json and rerun sync --drain" guidance. Following the old hint literally only cleared `cursors.files` while `cursors.hourly.buckets` retained the previous accumulated totals, so the re-parse added on top of the cached values and roughly doubled every Claude row in the DB. The new flag clears all four cursor surfaces in lockstep, which is the only safe rebuild sequence.
+
 ## [0.6.2] - 2026-04-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibeusage",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibeusage",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "bundleDependencies": [
         "@insforge/sdk"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeusage",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Codex CLI token usage tracker (macOS-first, notify-driven).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
# What does this PR do?

- Patch release that ships the recent sync-lifecycle work to `npm`: `proper-lockfile`-backed `sync.lock` (auto-recovers from abnormal holder death) and the new `vibeusage sync --rebuild=<source>` command that atomically clears all four cursor surfaces participating in re-aggregation.
- Bumps `package.json` 0.6.2 → 0.6.3, lockfile in lockstep, CHANGELOG entry written under `[0.6.3] - 2026-04-28`.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- `package.json` / `package-lock.json` version 0.6.2 → 0.6.3.
- `CHANGELOG.md` `[0.6.3] - 2026-04-28` entry: documents (a) the `sync.lock` orphan deadlock fix via `proper-lockfile` and the safe legacy-file migration path, (b) the `--rebuild=<source>` flag and the four cursor surfaces it clears in lockstep, (c) the doctor audit-tokens hint correction.

## Affected Modules / Contracts

- **Modules touched:** `package.json`, `package-lock.json`, `CHANGELOG.md`.
- **Dependencies / contracts touched:** Surfaces the already-merged `proper-lockfile` runtime dependency and `--rebuild=<source>` CLI flag (introduced in #186) to a published version. No new code changes in this PR.
- **Repo sitemap evidence:** `not required` — version bump + changelog entry only.

## Validation

### Automated

- \`npm test\` passes 830/830 on the release branch (darwin, Node 25.2.1) — confirms the merged content is publishable as-is.

### Manual / smoke

- \`git log v0.6.2..origin/main --oneline\` reviewed; sync.lock + \`--rebuild\` are the user-facing items worth a release note. Other commits (design-system bundle import #185, dashboard cjs/vite fix #187, design polish #180–#184/#188, revert #190) ship alongside without a CLI/API surface change and are not separately bullet-listed in the changelog entry.
- Reproduced the orphan-lock deadlock on a real \`~/.vibeusage/tracker/sync.lock\` left over by a 01:50 UTC abnormal exit; new code's heartbeat-based recovery resolves it without operator intervention.
- \`vibeusage sync --rebuild=claude\` end-to-end against the local tracker workspace dropped Claude max drift from 100% (doubling-bug state) to 0.51% across the 14-day audit window after one rebuild + drain.

### Uncovered scope

- Did not exercise non-darwin platforms; \`proper-lockfile\`'s mtime-heartbeat semantics are platform-portable but the regression run was macOS-only.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Reviewer Context (optional)

- **Review focus:** the \`[0.6.3]\` changelog entry — verify the recovery semantics for legacy zero-byte locks (yield + warn, not auto-delete) and the four-cursor-surface invariant for \`--rebuild\` are described accurately.
- **Delta since last review:** N/A — first review of this branch.
- **Depends on:** #186 (merged), #189 (merged).
- **Known gaps / follow-ups:** Heartbeat unref'd timer means a holder whose event loop is wedged for >60s (laptop suspend, runaway GC) can lose the lock to a peer; documented in #186 review thread as accepted trade-off.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release 0.6.3 with `sync.lock` auto-recovery and `sync --rebuild` CLI command
> - Fixes a `sync.lock` orphan deadlock by switching to `proper-lockfile`, with safe migration behavior for legacy lock files.
> - Adds a new `vibeusage sync --rebuild=<source>` CLI flag that forces a full rebuild from a specified source (including forced `fromOpenclaw`) with an implicit drain.
> - Updates the `doctor` command's `audit-tokens` failure hint to point to the new rebuild command, which clears all related cursor surfaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21e7d04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->