### PR TITLE
design: collapse ink ladder from 3 to 2 stops

### DIFF
--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -61,10 +61,9 @@ never for prose, accents, or surfaces (see §2.4).
 | `ink-bright` | `text-ink-bright`                     | `#E8FFE9`                    | display emphasis, selection foreground    |
 | `ink-text`   | `text-ink-text`                       | `rgba(0, 255, 65, 0.60)`     | body text, value label                    |
 | `ink-muted`  | `text-ink-muted` `border-ink-muted`   | `rgba(0, 255, 65, 0.35)`     | secondary text, hover line                |
-| `ink-line`   | `border-ink-line`                     | `rgba(0, 255, 65, 0.18)`     | default separator, panel border           |
-| `ink-faint`  | `border-ink-faint` `bg-ink-faint`     | `rgba(0, 255, 65, 0.08)`     | weakest rule, subtle hover background     |
+| `ink-line`   | `border-ink-line` `bg-ink-line`       | `rgba(0, 255, 65, 0.18)`     | default separator, panel border, weak rule |
 
-**6 alpha stops. That's it.** No `/5`, `/12`, `/25`, `/45`. Pick one.
+**5 alpha stops. That's it.** No `/5`, `/8`, `/12`, `/25`, `/45`. Pick one.
 
 ### 2.2 `surface.*` — background ground
 
@@ -164,12 +163,11 @@ the surrounding layout instead.
 
 ### Border
 
-| Usage          | Class                   |
-| -------------- | ----------------------- |
-| weak rule      | `border border-ink-faint` |
-| panel, table   | `border border-ink-line`  |
-| hover          | `border-ink-muted`      |
-| active, selected | `border-ink`          |
+| Usage              | Class                    |
+| ------------------ | ------------------------ |
+| panel, table, weak rule | `border border-ink-line` |
+| hover              | `border-ink-muted`       |
+| active, selected   | `border-ink`             |
 
 All borders are **1px solid**. No dashed / dotted. No `border-[Npx]`.
 
@@ -242,7 +240,7 @@ All respect `prefers-reduced-motion: reduce` and `screenshot-capture` mode.
 - `:hover` of an element it's attached to (manual user)
 - a 7-second `data-glitch-tick` event (rare ambient signal — only on `display-0`)
 
-`deco-katakana` uses font family `font-katakana` (defined below), is `text-ink-faint`, and never carries semantic meaning. If removed, no information is lost — purely chrome.
+`deco-katakana` uses font family `font-katakana` (defined below), is `text-ink-line`, and never carries semantic meaning. If removed, no information is lost — purely chrome.
 
 ### Font families
 
@@ -287,7 +285,7 @@ All respect `prefers-reduced-motion: reduce` and `screenshot-capture` mode.
 **Weight ladder** (DESIGN.md §6 v3):
 - `primary` — double-line ASCII (`╔ ╗ ╚ ╝ ═ ║`), frame `text-ink`, `shadow-glow-sm`. Reserved for **the** hero panel of any view (one per route).
 - `secondary` — default single-line (`┌ ┐ └ ┘ ─ │`), `text-ink-muted`. The everyday panel.
-- `tertiary` — dotted (`·`), `text-ink-faint`. Stacked / supporting / footer panels.
+- `tertiary` — dotted (`·`), `text-ink-line`. Stacked / supporting / footer panels.
 
 Use **at most one** `primary` per visible viewport. Two primaries cancel each other out.
 
@@ -296,7 +294,7 @@ Use **at most one** `primary` per visible viewport. Two primaries cancel each ot
 - upper-right: `{period}` — time scope (e.g. `WEEK · 2025-W52`)
 - lower-right: `{logo}` — origin watermark, defaults to `vibeusage.cc`
 
-Stamps use `text-micro` `tracking-caps` `text-ink-muted/faint` so they read as instrumentation, not as decoration.
+Stamps use `text-micro` `tracking-caps` `text-ink-muted` / `text-ink-line` so they read as instrumentation, not as decoration.
 
 - `ascii`: ASCII box drawing + corner-cross (signature).
 - `plain`: 1px ink-line border + surface-raised bg + backdrop blur.
@@ -313,7 +311,7 @@ Stamps use `text-micro` `tracking-caps` `text-ink-muted/faint` so they read as i
 | ------- | ---------------------------------------------------------------------- | ------- |
 | `size`  | `display-1` \| `display-2` \| `heading` \| `body` \| `data` \| `caption` \| `micro` | required |
 | `as`    | any HTML tag                                                           | `span`  |
-| `tone`  | `ink` \| `ink-bright` \| `ink-text` \| `ink-muted` \| `ink-line` \| `ink-faint` | `ink-text` |
+| `tone`  | `ink` \| `ink-bright` \| `ink-text` \| `ink-muted` \| `ink-line` | `ink-text` |
 | `glow`  | `boolean`                                                              | `false` |
 
 Enforces typography + color tokens at the component boundary.
@@ -378,16 +376,16 @@ historical reviewer guide — do not author legacy names into new code.
 | `border-matrix-primary`         | `border-ink`                         |
 | `border-matrix-primary/30`      | `border-ink-muted`                   |
 | `border-matrix-primary/20`      | `border-ink-line`                    |
-| `border-matrix-primary/10`      | `border-ink-faint`                   |
-| `border-matrix-ghost`           | `border-ink-faint`                   |
+| `border-matrix-primary/10`      | `border-ink-line`                    |
+| `border-matrix-ghost`           | `border-ink-line`                    |
 | `border-matrix-dim`             | `border-ink-muted`                   |
 | `border-matrix-muted`           | `border-ink-muted`                   |
 | `bg-matrix-dark`                | `bg-surface`                         |
 | `bg-matrix-panel`               | `bg-surface-raised`                  |
 | `bg-matrix-panelStrong`         | `bg-surface-strong`                  |
 | `bg-matrix-primary`             | `bg-ink`                             |
-| `bg-matrix-primary/10`          | `bg-ink-faint`                       |
-| `bg-matrix-primary/5`           | `bg-ink-faint`                       |
+| `bg-matrix-primary/10`          | `bg-ink-line`                        |
+| `bg-matrix-primary/5`           | `bg-ink-line`                        |
 | `font-matrix`                   | `font-mono` (Geist Mono is default)  |
 | `shadow-matrix-glow`            | `shadow-glow`                        |
 | `shadow-matrix-gold`            | `shadow-gold`                        |
@@ -396,8 +394,7 @@ historical reviewer guide — do not author legacy names into new code.
 
 | Deleted alpha                   | Replacement                          |
 | ------------------------------- | ------------------------------------ |
-| `/5`, `/8`, `/10`, `/12`        | `bg-ink-faint` / `border-ink-faint`  |
-| `/18`, `/20`, `/25`             | `border-ink-line`                    |
+| `/5`, `/8`, `/10`, `/12`, `/18`, `/20`, `/25` | `bg-ink-line` / `border-ink-line`    |
 | `/30`, `/32`, `/40`             | `border-ink-muted`                   |
 | `/60`, `/70`, `/80`, `/90`      | `text-ink-text` or `text-ink`        |
 

--- a/dashboard/scripts/shadcn-retro-fit.mjs
+++ b/dashboard/scripts/shadcn-retro-fit.mjs
@@ -67,14 +67,13 @@ function splitPrefix(token) {
 // does NOT ban /N on them, so we preserve the user's alpha intent there
 // (Codex feedback: don't collapse valid alpha semantics).
 const GUARDRAIL_BANS_SLASH = new Set([
-  "ink-faint",
   "ink-line",
   "ink-muted",
   "ink-text",
 ]);
 
 function targetTokenName(replacement) {
-  // "bg-ink-faint" → "ink-faint". Used to compare against the ban list.
+  // "bg-ink-line" → "ink-line". Used to compare against the ban list.
   const m = replacement.match(
     /^(?:bg|text|border|ring|fill|stroke|from|via|to|outline)-(.+)$/,
   );
@@ -292,7 +291,7 @@ const SELF_TESTS = [
   {
     name: "data-[state=open] variant on bg-accent",
     in: 'className="data-[state=open]:bg-accent"',
-    out: 'className="data-[state=open]:bg-ink-faint"',
+    out: 'className="data-[state=open]:bg-ink-line"',
   },
   {
     name: "data-[state=closed] strips dark: chained variant",
@@ -302,7 +301,7 @@ const SELF_TESTS = [
   {
     name: "aria-selected variant",
     in: 'className="aria-selected:bg-accent"',
-    out: 'className="aria-selected:bg-ink-faint"',
+    out: 'className="aria-selected:bg-ink-line"',
   },
   {
     name: "peer-disabled variant on opacity-50 strips token",
@@ -357,12 +356,12 @@ const SELF_TESTS = [
   {
     name: "ternary with nested call inside cn — both branches and tail rewritten",
     in: 'cn(condition ? cls(x) : "bg-accent text-foreground", "border-border")',
-    out: 'cn(condition ? cls(x) : "bg-ink-faint text-ink-bright", "border-ink-line")',
+    out: 'cn(condition ? cls(x) : "bg-ink-line text-ink-bright", "border-ink-line")',
   },
   {
     name: "deeply nested cva inside cn — strings at every level rewritten",
     in: 'cn(cva({ base: "p-2 rounded-md bg-muted" })(props), "bg-primary")',
-    out: 'cn(cva({ base: "p-2 bg-ink-faint" })(props), "bg-ink")',
+    out: 'cn(cva({ base: "p-2 bg-ink-line" })(props), "bg-ink")',
   },
   {
     name: "literal containing parens does not break paren scan",
@@ -377,12 +376,12 @@ const SELF_TESTS = [
   {
     name: "opacity-slash on guardrail-banned rgba target strips /N",
     in: 'className="bg-muted/80"',
-    out: 'className="bg-ink-faint"',
+    out: 'className="bg-ink-line"',
   },
   {
     name: "opacity-slash with variant prefix on banned rgba strips /N",
     in: 'className="hover:bg-accent/50"',
-    out: 'className="hover:bg-ink-faint"',
+    out: 'className="hover:bg-ink-line"',
   },
   {
     name: "opacity-slash with variant prefix on hex target keeps /N",
@@ -412,7 +411,7 @@ const SELF_TESTS = [
   {
     name: "arbitrary-opacity bracket value stripped on banned rgba target",
     in: 'className="bg-muted/[0.32]"',
-    out: 'className="bg-ink-faint"',
+    out: 'className="bg-ink-line"',
   },
 ];
 

--- a/dashboard/src/pages/LeaderboardPage.jsx
+++ b/dashboard/src/pages/LeaderboardPage.jsx
@@ -335,7 +335,7 @@ export function LeaderboardPage({
             <col className="w-[112px]" />
           </colgroup>
           <thead className="uppercase text-ink-muted tracking-caps text-micro">
-            <tr className="border-b border-ink-faint">
+            <tr className="border-b border-ink-line">
               <th className="px-4 py-3">{copy("leaderboard.column.rank")}</th>
               <th className="px-4 py-3">{copy("leaderboard.column.user")}</th>
               <th className="px-4 py-3">{copy("leaderboard.column.total")}</th>
@@ -361,7 +361,7 @@ export function LeaderboardPage({
                 return (
                   <tr
                     key={`row-${entry?.rank}-${name}`}
-                    className="border-b border-ink-faint"
+                    className="border-b border-ink-line"
                   >
                     <td colSpan={6} className="px-0 py-2">
                       <div className="rounded-none ring-1 ring-inset ring-ink bg-surface-strong/70 backdrop-blur-panel shadow-glow">
@@ -393,7 +393,7 @@ export function LeaderboardPage({
               return (
                 <tr
                   key={`row-${entry?.rank}-${name}`}
-                  className={`border-b border-ink-faint bg-transparent ${
+                  className={`border-b border-ink-line bg-transparent ${
                     rowClickable ? "cursor-pointer hover:bg-surface-raised/40" : ""
                   }`}
                   onClick={
@@ -558,8 +558,8 @@ export function LeaderboardPage({
                       disabled={publicProfileBusy}
                       className={`relative inline-flex h-6 w-11 items-center border px-[3px] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ink disabled:opacity-60 disabled:cursor-not-allowed ${
                         publicProfileEnabled
-                          ? "border-ink bg-ink-faint"
-                          : "border-ink-faint bg-surface-strong/40"
+                          ? "border-ink bg-ink-line"
+                          : "border-ink-line bg-surface-strong/40"
                       }`}
                     >
                       <span

--- a/dashboard/src/pages/LeaderboardProfilePage.jsx
+++ b/dashboard/src/pages/LeaderboardProfilePage.jsx
@@ -152,7 +152,7 @@ export function LeaderboardProfilePage({
       <div className="w-full overflow-x-auto">
         <table className="w-full text-left text-data">
           <thead className="uppercase text-ink-muted tracking-caps text-micro">
-            <tr className="border-b border-ink-faint">
+            <tr className="border-b border-ink-line">
               <th className="px-4 py-3">{copy("leaderboard.column.rank")}</th>
               <th className="px-4 py-3">{copy("leaderboard.column.total")}</th>
               <th className="px-4 py-3">{copy("leaderboard.column.gpt")}</th>
@@ -161,7 +161,7 @@ export function LeaderboardProfilePage({
             </tr>
           </thead>
           <tbody>
-            <tr className="border-b border-ink-faint bg-transparent">
+            <tr className="border-b border-ink-line bg-transparent">
               <td className="px-4 py-3 font-bold">
                 {entry?.rank ?? copy("shared.placeholder.short")}
               </td>

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -9,13 +9,12 @@
 :root {
   color-scheme: dark;
 
-  /* Ink — green data palette (6 stops, DESIGN.md §2.1) */
+  /* Ink — green data palette (5 stops, DESIGN.md §2.1) */
   --ink: #00ff41;
   --ink-bright: #e8ffe9;
   --ink-text: rgba(0, 255, 65, 0.6);
   --ink-muted: rgba(0, 255, 65, 0.35);
   --ink-line: rgba(0, 255, 65, 0.18);
-  --ink-faint: rgba(0, 255, 65, 0.08);
   --ink-glow: rgba(0, 255, 65, 0.45);
 
   /* Surface — neutral ground (DESIGN.md §2.2) */
@@ -251,7 +250,7 @@ body {
   .deco-katakana {
     font-family: "Hiragino Sans", "Yu Gothic", "MS Gothic", "Geist Mono",
       ui-monospace, monospace;
-    color: var(--ink-faint);
+    color: var(--ink-line);
     letter-spacing: 0.18em;
     user-select: none;
     white-space: nowrap;
@@ -263,7 +262,7 @@ body {
   .heatmap-scrollbar-track {
     height: 6px;
     border-radius: 999px;
-    background: var(--ink-faint);
+    background: var(--ink-line);
     border: 1px solid var(--ink-line);
     position: relative;
     overflow: hidden;

--- a/dashboard/src/ui/foundation/MatrixAvatar.jsx
+++ b/dashboard/src/ui/foundation/MatrixAvatar.jsx
@@ -33,7 +33,7 @@ export function MatrixAvatar({
     return (
       <div
         style={{ width: size, height: size }}
-        className={`bg-surface-raised border border-ink-faint flex items-center justify-center overflow-hidden ${className}`}
+        className={`bg-surface-raised border border-ink-line flex items-center justify-center overflow-hidden ${className}`}
       >
         <span className="text-ink font-black text-body opacity-60">
           {copy("shared.placeholder.anon_mark")}

--- a/dashboard/src/ui/foundation/MatrixButton.jsx
+++ b/dashboard/src/ui/foundation/MatrixButton.jsx
@@ -16,7 +16,7 @@ const VARIANT = {
   default:
     "bg-surface-raised text-ink border border-ink-line hover:bg-surface-strong hover:border-ink-muted",
   primary: "bg-ink text-surface border border-ink hover:bg-ink-bright hover:border-ink-bright",
-  ghost: "bg-transparent text-ink border border-transparent hover:bg-ink-faint",
+  ghost: "bg-transparent text-ink border border-transparent hover:bg-ink-line",
 };
 
 const VARIANT_HEADER = {

--- a/dashboard/src/ui/foundation/MatrixInput.jsx
+++ b/dashboard/src/ui/foundation/MatrixInput.jsx
@@ -6,7 +6,7 @@ export function MatrixInput({ label, className = "", ...props }) {
     <label className={`flex flex-col gap-2 ${className}`}>
       <span className="text-caption text-ink-text uppercase font-bold">{label}</span>
       <Input
-        className="h-10 bg-surface-raised border border-ink-faint px-3 text-body text-ink-bright outline-none focus:border-ink focus:ring-2 focus:ring-ink"
+        className="h-10 bg-surface-raised border border-ink-line px-3 text-body text-ink-bright outline-none focus:border-ink focus:ring-2 focus:ring-ink"
         {...props}
       />
     </label>

--- a/dashboard/src/ui/foundation/MatrixShell.jsx
+++ b/dashboard/src/ui/foundation/MatrixShell.jsx
@@ -61,7 +61,7 @@ export function MatrixShell({
                 </div>
                 <span
                   aria-hidden="true"
-                  className="hidden md:inline text-micro tracking-caps text-ink-faint whitespace-nowrap select-none"
+                  className="hidden md:inline text-micro tracking-caps text-ink-line whitespace-nowrap select-none"
                 >
                   {copy("system.header.katakana_deco")}
                 </span>
@@ -78,13 +78,13 @@ export function MatrixShell({
 
         <main className="flex-1">{children}</main>
 
-        <footer className="mt-6 pt-3 border-t border-ink-faint flex justify-between items-center text-micro text-ink-muted shrink-0">
+        <footer className="mt-6 pt-3 border-t border-ink-line flex justify-between items-center text-micro text-ink-muted shrink-0">
           <div className="flex gap-8 items-center">
             {footerLeft || <span>{copy("shell.footer.help")}</span>}
           </div>
           <span
             aria-hidden="true"
-            className="hidden md:inline font-mono tracking-caps text-ink-faint select-none"
+            className="hidden md:inline font-mono tracking-caps text-ink-line select-none"
           >
             {copy("shell.footer.observer_mascot")}
           </span>

--- a/dashboard/src/ui/foundation/Panel.jsx
+++ b/dashboard/src/ui/foundation/Panel.jsx
@@ -15,7 +15,7 @@ const ASCII_WEIGHT = {
 const FRAME_TONE = {
   primary: "text-ink",
   secondary: "text-ink-muted",
-  tertiary: "text-ink-faint",
+  tertiary: "text-ink-line",
 };
 
 const VARIANT = {
@@ -52,7 +52,7 @@ function CornerStamps({ stamped, stampHandle, stampPeriod, stampLogo = "vibeusag
       {stampLogo ? (
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute right-3 bottom-0 translate-y-1/2 bg-surface-strong px-2 text-micro uppercase tracking-caps text-ink-faint"
+          className="pointer-events-none absolute right-3 bottom-0 translate-y-1/2 bg-surface-strong px-2 text-micro uppercase tracking-caps text-ink-line"
         >
           {stampLogo}
         </span>
@@ -99,7 +99,7 @@ export function Panel({
         <div className="flex items-center leading-none">
           <span className={`shrink-0 ${frameTone}`}>{ASCII.TL}</span>
           {title ? (
-            <span className="mx-3 shrink-0 px-2 py-1 text-heading text-ink uppercase bg-surface-strong border border-ink-faint">
+            <span className="mx-3 shrink-0 px-2 py-1 text-heading text-ink uppercase bg-surface-strong border border-ink-line">
               {title}
             </span>
           ) : null}

--- a/dashboard/src/ui/foundation/Text.jsx
+++ b/dashboard/src/ui/foundation/Text.jsx
@@ -21,7 +21,6 @@ const TONE = {
   "ink-text": "text-ink-text",
   "ink-muted": "text-ink-muted",
   "ink-line": "text-ink-line",
-  "ink-faint": "text-ink-faint",
 };
 
 export function Text({

--- a/dashboard/src/ui/matrix-a/components/ActivityHeatmap.jsx
+++ b/dashboard/src/ui/matrix-a/components/ActivityHeatmap.jsx
@@ -474,7 +474,7 @@ export function ActivityHeatmap({
                           unit: copy("heatmap.unit.tokens"),
                           tz: tzDetail,
                         })}
-                        className="rounded-[2px] border border-ink-faint"
+                        className="rounded-[2px] border border-ink-line"
                         style={{
                           width: CELL_SIZE,
                           height: CELL_SIZE,
@@ -493,7 +493,7 @@ export function ActivityHeatmap({
       {/* Custom Scrollbar Track */}
       <div
         ref={trackRef}
-        className="heatmap-scrollbar-track relative h-[6px] rounded-full bg-surface-strong border border-ink-faint overflow-visible mt-1 transition-opacity duration-150"
+        className="heatmap-scrollbar-track relative h-[6px] rounded-full bg-surface-strong border border-ink-line overflow-visible mt-1 transition-opacity duration-150"
         style={{
           opacity: showScrollbar ? 1 : 0,
           pointerEvents: showScrollbar ? "auto" : "none",
@@ -517,14 +517,14 @@ export function ActivityHeatmap({
       </div>
 
       {!hideLegend ? (
-        <div className="flex justify-between items-center text-caption border-t border-ink-faint pt-2 text-ink-text font-bold uppercase">
+        <div className="flex justify-between items-center text-caption border-t border-ink-line pt-2 text-ink-text font-bold uppercase">
           <div className="flex items-center gap-2">
             <span>{copy("heatmap.legend.less")}</span>
             <div className="flex gap-1">
               {[0, 1, 2, 3, 4].map((level) => (
                 <span
                   key={level}
-                  className="rounded-[2px] border border-ink-faint"
+                  className="rounded-[2px] border border-ink-line"
                   style={{
                     width: 10,
                     height: 10,

--- a/dashboard/src/ui/matrix-a/components/ArchiveHeatmap.jsx
+++ b/dashboard/src/ui/matrix-a/components/ArchiveHeatmap.jsx
@@ -23,7 +23,7 @@ export function ArchiveHeatmap({
           </div>
         ) : null}
         {showFooter ? (
-          <div className="mt-auto pt-3 border-t border-ink-faint text-caption text-ink-text flex justify-between uppercase">
+          <div className="mt-auto pt-3 border-t border-ink-line text-caption text-ink-text flex justify-between uppercase">
             <span>{footerLeft}</span>
             {footerRight ? <span>{footerRight}</span> : null}
           </div>

--- a/dashboard/src/ui/matrix-a/components/ClientLogoRow.jsx
+++ b/dashboard/src/ui/matrix-a/components/ClientLogoRow.jsx
@@ -7,7 +7,7 @@ export function ClientLogoRow({ className = "" }) {
       {CLIENTS.map(({ id, name, Icon }) => (
         <div
           key={id}
-          className="flex items-center gap-1.5 px-2 py-1 rounded border border-ink-faint bg-surface-raised/50"
+          className="flex items-center gap-1.5 px-2 py-1 rounded border border-ink-line bg-surface-raised/50"
           title={name}
         >
           <Icon className="w-4 h-4 text-ink" />

--- a/dashboard/src/ui/matrix-a/components/CostAnalysisModal.jsx
+++ b/dashboard/src/ui/matrix-a/components/CostAnalysisModal.jsx
@@ -65,7 +65,7 @@ export const CostAnalysisModal = React.memo(function CostAnalysisModal({
       >
         <AsciiBox title={copy("dashboard.cost_breakdown.title")}>
           <div className="space-y-8 py-4">
-            <div className="text-center pb-6 border-b border-ink-faint">
+            <div className="text-center pb-6 border-b border-ink-line">
               <div className="text-caption text-ink-text uppercase mb-2 font-bold">
                 {copy("dashboard.cost_breakdown.total_label")}
               </div>
@@ -77,7 +77,7 @@ export const CostAnalysisModal = React.memo(function CostAnalysisModal({
             <div className="space-y-6 max-h-[45vh] overflow-y-auto no-scrollbar pr-2">
               {normalizedFleet.map((fleet, index) => (
                 <div key={`${fleet.label}-${index}`} className="space-y-3">
-                  <div className="flex justify-between items-baseline border-b border-ink-faint pb-2">
+                  <div className="flex justify-between items-baseline border-b border-ink-line pb-2">
                     <span className="text-body font-black text-ink-bright uppercase tracking-caps">
                       {fleet.label}
                     </span>
@@ -105,7 +105,7 @@ export const CostAnalysisModal = React.memo(function CostAnalysisModal({
               ))}
             </div>
 
-            <div className="pt-6 border-t border-ink-faint flex justify-between items-center">
+            <div className="pt-6 border-t border-ink-line flex justify-between items-center">
               <DialogClose
                 type="button"
                 className="text-caption font-bold uppercase text-ink border border-ink-muted px-6 py-2 hover:bg-ink hover:text-surface transition-all"

--- a/dashboard/src/ui/matrix-a/components/DataRow.jsx
+++ b/dashboard/src/ui/matrix-a/components/DataRow.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export function DataRow({ label, value, subValue, valueClassName = "" }) {
   return (
-    <div className="flex justify-between items-center border-b border-ink-faint py-2 group hover:bg-surface-raised transition-colors px-2">
+    <div className="flex justify-between items-center border-b border-ink-line py-2 group hover:bg-surface-raised transition-colors px-2">
       <span className="text-caption text-ink-text uppercase font-bold leading-none">
         {label}
       </span>

--- a/dashboard/src/ui/matrix-a/components/GithubStar.jsx
+++ b/dashboard/src/ui/matrix-a/components/GithubStar.jsx
@@ -40,7 +40,7 @@ export const GithubStar = ({
   const baseClasses =
     size === "header"
       ? "btn-chip text-caption uppercase font-bold tracking-caps select-none group gap-3 no-underline overflow-hidden"
-      : "group flex items-center gap-3 px-4 py-2 bg-surface-raised border border-ink-faint backdrop-blur-md transition-all duration-300 hover:border-ink hover:bg-surface-strong no-underline overflow-hidden";
+      : "group flex items-center gap-3 px-4 py-2 bg-surface-raised border border-ink-line backdrop-blur-md transition-all duration-300 hover:border-ink hover:bg-surface-strong no-underline overflow-hidden";
   const positionClasses = isFixed ? "fixed top-6 right-6 z-[100]" : "relative";
 
   return (

--- a/dashboard/src/ui/matrix-a/components/IdentityCard.jsx
+++ b/dashboard/src/ui/matrix-a/components/IdentityCard.jsx
@@ -138,13 +138,13 @@ export function IdentityCard({
 
             {shouldShowStats ? (
               <div className="grid grid-cols-2 gap-2 pt-1">
-                <div className="bg-surface-raised p-2 border border-ink-faint text-center">
+                <div className="bg-surface-raised p-2 border border-ink-line text-center">
                   <div className="text-caption text-ink-text uppercase font-bold">
                     {copy("identity_card.rank_label")}
                   </div>
                   <div className="text-gold font-black text-body">{rankValue}</div>
                 </div>
-                <div className="bg-surface-raised p-2 border border-ink-faint text-center">
+                <div className="bg-surface-raised p-2 border border-ink-line text-center">
                   <div className="text-caption text-ink-text uppercase font-bold">
                     {copy("identity_card.streak_label")}
                   </div>
@@ -162,7 +162,7 @@ export function IdentityCard({
                   {subscriptionItems.map((entry, index) => (
                     <span
                       key={`${entry.tool}:${entry.plan}:${index}`}
-                      className="inline-flex items-center px-2 py-1 border border-ink-faint bg-surface-raised text-micro uppercase tracking-label text-ink-bright"
+                      className="inline-flex items-center px-2 py-1 border border-ink-line bg-surface-raised text-micro uppercase tracking-label text-ink-bright"
                     >
                       {copy("identity_card.subscription_item", {
                         tool: entry.tool,

--- a/dashboard/src/ui/matrix-a/components/IdentityPanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/IdentityPanel.jsx
@@ -17,7 +17,7 @@ export function IdentityPanel({ auth, streakDays = 0, rankLabel }) {
   return (
     <div className="flex items-center space-x-6">
       <div className="relative group">
-        <div className="w-20 h-20 border border-ink-faint flex items-center justify-center text-body font-black bg-surface-raised shadow-glow-faint">
+        <div className="w-20 h-20 border border-ink-line flex items-center justify-center text-body font-black bg-surface-raised shadow-glow-faint">
           {copy("identity_panel.badge")}
         </div>
         <div className="absolute -bottom-1 -right-1 bg-ink-bright text-surface text-caption px-1 font-black uppercase">
@@ -33,13 +33,13 @@ export function IdentityPanel({ auth, streakDays = 0, rankLabel }) {
         </div>
 
         <div className="grid grid-cols-2 gap-2">
-          <div className="bg-surface-raised p-2 border border-ink-faint text-center">
+          <div className="bg-surface-raised p-2 border border-ink-line text-center">
             <div className="text-caption text-ink-text uppercase font-bold">
               {copy("identity_panel.rank_label")}
             </div>
             <div className="text-ink font-black text-body">{rankValue}</div>
           </div>
-          <div className="bg-surface-raised p-2 border border-ink-faint text-center">
+          <div className="bg-surface-raised p-2 border border-ink-line text-center">
             <div className="text-caption text-ink-text uppercase font-bold">
               {copy("identity_panel.streak_label")}
             </div>

--- a/dashboard/src/ui/matrix-a/components/KeyboardCheatsheet.jsx
+++ b/dashboard/src/ui/matrix-a/components/KeyboardCheatsheet.jsx
@@ -48,7 +48,7 @@ export function KeyboardCheatsheet({ open, onClose }) {
             </span>
             <DialogClose
               aria-label={copy("keyboard.cheatsheet.close_aria")}
-              className="text-caption text-ink uppercase tracking-caps border border-ink-muted bg-surface px-2 py-0.5 hover:bg-ink-faint focus:outline-none focus-visible:border-ink"
+              className="text-caption text-ink uppercase tracking-caps border border-ink-muted bg-surface px-2 py-0.5 hover:bg-ink-line focus:outline-none focus-visible:border-ink"
             >
               {copy("keyboard.cheatsheet.close_label")}
             </DialogClose>
@@ -69,7 +69,7 @@ export function KeyboardCheatsheet({ open, onClose }) {
             </li>
           ))}
         </ul>
-        <div className="mt-5 pt-3 border-t border-ink-faint text-micro text-ink-faint uppercase tracking-caps">
+        <div className="mt-5 pt-3 border-t border-ink-line text-micro text-ink-line uppercase tracking-caps">
           {copy("keyboard.cheatsheet.footer_note")}
         </div>
       </DialogContent>

--- a/dashboard/src/ui/matrix-a/components/LiveSniffer.jsx
+++ b/dashboard/src/ui/matrix-a/components/LiveSniffer.jsx
@@ -50,7 +50,7 @@ export const LiveSniffer = () => {
   return (
     <div className="font-mono text-caption text-ink-text space-y-2 h-full flex flex-col justify-end">
       {logs.map((log, idx) => (
-        <div key={idx} className="animate-pulse border-l-2 border-ink-faint pl-2 truncate">
+        <div key={idx} className="animate-pulse border-l-2 border-ink-line pl-2 truncate">
           {log}
         </div>
       ))}

--- a/dashboard/src/ui/matrix-a/components/NeuralAdaptiveFleet.jsx
+++ b/dashboard/src/ui/matrix-a/components/NeuralAdaptiveFleet.jsx
@@ -25,7 +25,7 @@ export const NeuralAdaptiveFleet = React.memo(function NeuralAdaptiveFleet({
 
   return (
     <div className="w-full space-y-4">
-      <div className="flex justify-between items-baseline border-b border-ink-faint pb-2">
+      <div className="flex justify-between items-baseline border-b border-ink-line pb-2">
         <div className="flex items-baseline gap-2">
           <span className="text-heading font-black text-ink uppercase">{label}</span>
           <span className="text-caption text-ink-text">{usageLabel}</span>
@@ -36,7 +36,7 @@ export const NeuralAdaptiveFleet = React.memo(function NeuralAdaptiveFleet({
         </div>
       </div>
 
-      <div className="h-1 w-full bg-ink-faint flex overflow-hidden relative">
+      <div className="h-1 w-full bg-ink-line flex overflow-hidden relative">
         {models.map((model, index) => {
           const styleConfig = TEXTURES[index % TEXTURES.length];
           const modelKey = model?.id ? String(model.id) : `${model.name}-${index}`;
@@ -64,7 +64,7 @@ export const NeuralAdaptiveFleet = React.memo(function NeuralAdaptiveFleet({
           return (
             <div key={modelKey} className="flex items-center space-x-2">
               <div
-                className="w-2 h-2 border border-ink-faint shrink-0"
+                className="w-2 h-2 border border-ink-line shrink-0"
                 style={{
                   backgroundColor: styleConfig.bg,
                   backgroundImage: styleConfig.pattern,

--- a/dashboard/src/ui/matrix-a/components/NeuralDivergenceMap.jsx
+++ b/dashboard/src/ui/matrix-a/components/NeuralDivergenceMap.jsx
@@ -34,7 +34,7 @@ export const NeuralDivergenceMap = React.memo(function NeuralDivergenceMap({
         })}
       </div>
       {footer ? (
-        <div className="mt-auto pt-3 border-t border-ink-faint text-caption uppercase text-center italic leading-none text-ink-muted">
+        <div className="mt-auto pt-3 border-t border-ink-line text-caption uppercase text-center italic leading-none text-ink-muted">
           {footer}
         </div>
       ) : null}

--- a/dashboard/src/ui/matrix-a/components/ProjectUsagePanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/ProjectUsagePanel.jsx
@@ -160,7 +160,7 @@ export function ProjectUsagePanel({
             </Select.Trigger>
             <Select.Portal>
               <Select.Positioner align="end" side="bottom" sideOffset={8} className="z-50">
-                <Select.Popup className="w-40 border border-ink-faint bg-surface-strong backdrop-blur-md pointer-events-auto">
+                <Select.Popup className="w-40 border border-ink-line bg-surface-strong backdrop-blur-md pointer-events-auto">
                   <Select.List aria-label={limitAria} role="listbox">
                     {LIMIT_OPTIONS.map((value) => (
                       <Select.Item
@@ -243,7 +243,7 @@ function ProjectUsageCard({
       href={projectRef || (repoId ? `https://github.com/${repoId}` : "#")}
       target="_blank"
       rel="noopener noreferrer"
-      className="group relative flex h-full min-h-[152px] flex-col gap-3 border border-ink-faint bg-surface-raised px-4 py-5 transition-all duration-200 hover:border-ink hover:shadow-glow"
+      className="group relative flex h-full min-h-[152px] flex-col gap-3 border border-ink-line bg-surface-raised px-4 py-5 transition-all duration-200 hover:border-ink hover:shadow-glow"
       data-project-card="true"
     >
       <div
@@ -275,7 +275,7 @@ function ProjectUsageCard({
         className="flex items-center gap-3 min-w-0 pr-12"
         data-card-line="identity"
       >
-        <div className="relative h-12 w-12 rounded-full border border-ink-faint overflow-hidden">
+        <div className="relative h-12 w-12 rounded-full border border-ink-line overflow-hidden">
           {avatarUrl ? (
             <img
               src={avatarUrl}
@@ -327,14 +327,14 @@ function ProjectUsageCard({
 function ProjectUsagePlaceholderCard({ placeholder }) {
   return (
     <div
-      className="relative flex h-full min-h-[152px] flex-col gap-3 border border-ink-faint bg-surface-raised px-4 py-5 opacity-60"
+      className="relative flex h-full min-h-[152px] flex-col gap-3 border border-ink-line bg-surface-raised px-4 py-5 opacity-60"
       data-project-card-placeholder="true"
     >
       <div className="flex items-start gap-3">
-        <div className="h-10 w-10 rounded-full border border-ink-faint bg-surface-strong" />
+        <div className="h-10 w-10 rounded-full border border-ink-line bg-surface-strong" />
         <div className="flex min-w-0 flex-1 flex-col gap-2">
-          <div className="h-4 w-24 border border-ink-faint bg-surface-strong" />
-          <div className="h-3 w-32 border border-ink-faint bg-surface-strong" />
+          <div className="h-4 w-24 border border-ink-line bg-surface-strong" />
+          <div className="h-3 w-32 border border-ink-line bg-surface-strong" />
         </div>
       </div>
       <div className="mt-auto flex items-center justify-between gap-4 text-caption uppercase tracking-caps text-ink-text">

--- a/dashboard/src/ui/matrix-a/components/RollingUsagePanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/RollingUsagePanel.jsx
@@ -43,7 +43,7 @@ export const RollingUsagePanel = React.memo(function RollingUsagePanel({
         {items.map((item) => (
           <div
             key={item.key}
-            className="flex flex-col items-center text-center gap-2 border border-ink-faint px-3 py-4"
+            className="flex flex-col items-center text-center gap-2 border border-ink-line px-3 py-4"
           >
             <span className="text-caption uppercase font-bold text-ink-text tracking-caps">
               {item.label}

--- a/dashboard/src/ui/matrix-a/components/SystemHeader.jsx
+++ b/dashboard/src/ui/matrix-a/components/SystemHeader.jsx
@@ -13,7 +13,7 @@ export function SystemHeader({
 }) {
   return (
     <header
-      className={`flex justify-between border-b border-ink-faint p-4 items-center shrink-0 bg-surface-raised ${className}`}
+      className={`flex justify-between border-b border-ink-line p-4 items-center shrink-0 bg-surface-raised ${className}`}
     >
       <div className="flex items-center space-x-4">
         <div className="bg-ink text-surface px-2 py-1 font-black text-heading uppercase skew-x-[-10deg] border border-ink shadow-glow-sm">
@@ -26,7 +26,7 @@ export function SystemHeader({
         ) : null}
         <span
           aria-hidden="true"
-          className="hidden md:inline text-micro tracking-caps text-ink-faint whitespace-nowrap select-none"
+          className="hidden md:inline text-micro tracking-caps text-ink-line whitespace-nowrap select-none"
         >
           {copy("system.header.katakana_deco")}
         </span>

--- a/dashboard/src/ui/matrix-a/components/TopModelsPanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/TopModelsPanel.jsx
@@ -35,7 +35,7 @@ export const TopModelsPanel = React.memo(function TopModelsPanel({ rows = [], cl
           return (
             <div
               key={rowKey}
-              className="flex items-center justify-between border-b border-ink-faint py-2 px-2 last:border-b-0"
+              className="flex items-center justify-between border-b border-ink-line py-2 px-2 last:border-b-0"
             >
               <div className="flex items-center gap-3 min-w-0">
                 <span className="text-caption text-ink-muted font-bold tracking-caps">

--- a/dashboard/src/ui/matrix-a/components/TrendChart.jsx
+++ b/dashboard/src/ui/matrix-a/components/TrendChart.jsx
@@ -21,11 +21,11 @@ export function TrendChart({
 
   return (
     <div className="flex flex-col space-y-2">
-      <div className="flex items-end h-24 space-x-1 border-b border-ink-faint pb-2 relative">
+      <div className="flex items-end h-24 space-x-1 border-b border-ink-line pb-2 relative">
         <div className="absolute inset-0 flex flex-col justify-between pointer-events-none opacity-10">
-          <div className="border-t border-ink-faint w-full"></div>
-          <div className="border-t border-ink-faint w-full"></div>
-          <div className="border-t border-ink-faint w-full"></div>
+          <div className="border-t border-ink-line w-full"></div>
+          <div className="border-t border-ink-line w-full"></div>
+          <div className="border-t border-ink-line w-full"></div>
         </div>
         {values.map((val, i) => (
           <div key={i} className="flex-1 bg-surface-raised relative group">

--- a/dashboard/src/ui/matrix-a/components/TrendMonitor.jsx
+++ b/dashboard/src/ui/matrix-a/components/TrendMonitor.jsx
@@ -350,7 +350,7 @@ export function TrendMonitor({
         </div>
       </div>
 
-      <div className="flex-1 relative overflow-hidden border border-ink-faint bg-surface-raised">
+      <div className="flex-1 relative overflow-hidden border border-ink-line bg-surface-raised">
         <div
           className="absolute inset-0 opacity-10 pointer-events-none"
           style={{
@@ -362,7 +362,7 @@ export function TrendMonitor({
           }}
         />
 
-        <div className="absolute inset-0 bg-gradient-to-r from-transparent via-ink-faint to-transparent w-[50%] h-full animate-[scan-x_3s_linear_infinite] pointer-events-none mix-blend-screen" />
+        <div className="absolute inset-0 bg-gradient-to-r from-transparent via-ink-line to-transparent w-[50%] h-full animate-[scan-x_3s_linear_infinite] pointer-events-none mix-blend-screen" />
 
         <svg
           viewBox={`0 0 ${width} ${height}`}
@@ -414,7 +414,7 @@ export function TrendMonitor({
 
         <div
           ref={axisRef}
-          className="absolute right-0 top-0 bottom-0 flex flex-col justify-between py-1 px-1 text-caption text-ink-text pointer-events-none bg-surface-strong border-l border-ink-faint w-10 text-right"
+          className="absolute right-0 top-0 bottom-0 flex flex-col justify-between py-1 px-1 text-caption text-ink-text pointer-events-none bg-surface-strong border-l border-ink-line w-10 text-right"
         >
           <span>{formatCompact(max)}</span>
           <span>{formatCompact(max * 0.75)}</span>
@@ -446,7 +446,7 @@ export function TrendMonitor({
               ></div>
             </div>
             <div
-              className="absolute z-30 px-3 py-2 text-caption bg-surface-strong border border-ink-faint text-ink-bright pointer-events-none"
+              className="absolute z-30 px-3 py-2 text-caption bg-surface-strong border border-ink-line text-ink-bright pointer-events-none"
               style={{
                 left: Math.min(hover.x + 10, hover.rectWidth - hover.axisWidthPx - 120),
                 top: Math.max(hover.y - 24, 6),
@@ -468,7 +468,7 @@ export function TrendMonitor({
         ) : null}
       </div>
 
-      <div className="h-5 flex justify-between items-center px-1 text-caption text-ink-text border-t border-ink-faint pt-2">
+      <div className="h-5 flex justify-between items-center px-1 text-caption text-ink-text border-t border-ink-line pt-2">
         {xLabels.map((labelText, idx) => (
           <span
             key={`${labelText}-${idx}`}

--- a/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/UsagePanel.jsx
@@ -66,7 +66,7 @@ export const UsagePanel = React.memo(function UsagePanel({
   if (showSummaryLoadingPlaceholder) {
     summaryDisplay = (
       <span
-        className="inline-flex h-12 w-24 items-center justify-center border border-ink-faint bg-surface-strong md:h-20 md:w-40"
+        className="inline-flex h-12 w-24 items-center justify-center border border-ink-line bg-surface-strong md:h-20 md:w-40"
         data-testid="usage-summary-loading"
         aria-label={copy("usage.button.loading")}
       >
@@ -129,7 +129,7 @@ export const UsagePanel = React.memo(function UsagePanel({
       stampLogo={stampLogo}
     >
       {!hideHeader ? (
-        <div className="flex flex-wrap items-center justify-between border-b border-ink-faint mb-3 pb-2 gap-4 px-2">
+        <div className="flex flex-wrap items-center justify-between border-b border-ink-line mb-3 pb-2 gap-4 px-2">
           <div className="overflow-x-auto no-scrollbar min-w-0 max-w-full">
             <div className="flex gap-4">
               {tabs.map((p) => (
@@ -228,14 +228,14 @@ export const UsagePanel = React.memo(function UsagePanel({
 
           {!breakdownCollapsed && breakdownRows.length ? (
             <div className="w-full px-6">
-              <div className="grid grid-cols-2 gap-3 border-t border-b border-ink-faint py-4 relative">
-                <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[1px] h-full bg-ink-faint"></div>
+              <div className="grid grid-cols-2 gap-3 border-t border-b border-ink-line py-4 relative">
+                <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[1px] h-full bg-ink-line"></div>
                 <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-4 h-[1px] bg-ink-muted"></div>
 
                 {breakdownRows.map((row, idx) => (
                   <div
                     key={`${row.label}-${idx}`}
-                    className="flex flex-col items-center p-3 bg-surface-raised border border-ink-faint"
+                    className="flex flex-col items-center p-3 bg-surface-raised border border-ink-line"
                   >
                     <span className="text-caption text-ink-text uppercase mb-1">
                       {row.label}
@@ -254,7 +254,7 @@ export const UsagePanel = React.memo(function UsagePanel({
           {metrics.map((row, idx) => (
             <div
               key={`${row.label}-${idx}`}
-              className="border border-ink-faint bg-surface-raised p-4 text-center"
+              className="border border-ink-line bg-surface-raised p-4 text-center"
             >
               <div className="text-caption uppercase text-ink-text mb-2">{row.label}</div>
               <div

--- a/dashboard/src/ui/matrix-a/components/VersionBadge.jsx
+++ b/dashboard/src/ui/matrix-a/components/VersionBadge.jsx
@@ -5,7 +5,7 @@ export function VersionBadge({ version }) {
   const value = typeof version === "string" ? version.trim() : "";
   if (!value) return null;
   return (
-    <div className="fixed bottom-4 right-4 z-50 bg-surface-raised border border-ink-faint px-3 py-2 shadow-glow-faint">
+    <div className="fixed bottom-4 right-4 z-50 bg-surface-raised border border-ink-line px-3 py-2 shadow-glow-faint">
       <div className="text-caption text-ink-text uppercase font-bold">
         {copy("dashboard.version.label")}
       </div>

--- a/dashboard/src/ui/matrix-a/views/DashboardView.jsx
+++ b/dashboard/src/ui/matrix-a/views/DashboardView.jsx
@@ -297,7 +297,7 @@ export function DashboardView(props) {
                             title={publicViewToggleLabel}
                             className={`relative inline-flex h-6 w-11 items-center border px-[3px] transition-colors ${
                               publicViewEnabled
-                                ? "border-ink bg-ink-faint"
+                                ? "border-ink bg-ink-line"
                                 : "border-ink-muted bg-surface/40"
                             } disabled:opacity-50 disabled:cursor-not-allowed`}
                           >
@@ -421,14 +421,14 @@ export function DashboardView(props) {
                       </div>
                     ) : null}
                     <div
-                      className="overflow-auto max-h-[520px] border border-ink-faint"
+                      className="overflow-auto max-h-[520px] border border-ink-line"
                       role="region"
                       aria-label={copy("daily.table.aria_label")}
                       tabIndex={0}
                     >
                       <table className="w-full border-collapse">
                         <thead className="sticky top-0 bg-surface/90">
-                          <tr className="border-b border-ink-faint">
+                          <tr className="border-b border-ink-line">
                             {detailsColumns.map((c) => (
                               <th
                                 key={c.key}
@@ -439,7 +439,7 @@ export function DashboardView(props) {
                                   type="button"
                                   onClick={() => toggleSort(c.key)}
                                   title={c.title}
-                                  className="w-full px-3 py-2 text-left text-micro uppercase tracking-caps font-black opacity-70 hover:opacity-100 hover:bg-ink-faint focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-muted flex items-center justify-start"
+                                  className="w-full px-3 py-2 text-left text-micro uppercase tracking-caps font-black opacity-70 hover:opacity-100 hover:bg-ink-line focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-muted flex items-center justify-start"
                                 >
                                   <span className="inline-flex items-center gap-2">
                                     <span>{c.label}</span>
@@ -456,7 +456,7 @@ export function DashboardView(props) {
                               key={String(
                                 r?.[detailsDateKey] || r?.day || r?.hour || r?.month || "",
                               )}
-                              className={`border-b border-ink-faint hover:bg-ink-faint ${
+                              className={`border-b border-ink-line hover:bg-ink-line ${
                                 r.missing
                                   ? "text-ink-muted"
                                   : r.future

--- a/dashboard/src/ui/matrix-a/views/LandingView.jsx
+++ b/dashboard/src/ui/matrix-a/views/LandingView.jsx
@@ -40,7 +40,7 @@ function TerminalCommand({ command, copied, onCopy, label, helper }) {
           <button
             type="button"
             onClick={onCopy}
-            className="shrink-0 px-4 py-3 border-l border-ink-line text-ink-text hover:text-ink hover:bg-ink-faint transition-colors duration-200"
+            className="shrink-0 px-4 py-3 border-l border-ink-line text-ink-text hover:text-ink hover:bg-ink-line transition-colors duration-200"
             title={copied ? "Copied!" : "Copy to clipboard"}
           >
             {copied ? (
@@ -92,8 +92,8 @@ export function LandingView({
   };
   const extrasSkeleton = (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-3xl">
-      <div className="h-44 border border-ink-faint bg-ink-faint animate-pulse" />
-      <div className="h-44 border border-ink-faint bg-ink-faint animate-pulse" />
+      <div className="h-44 border border-ink-line bg-ink-line animate-pulse" />
+      <div className="h-44 border border-ink-line bg-ink-line animate-pulse" />
     </div>
   );
 

--- a/dashboard/tailwind.config.cjs
+++ b/dashboard/tailwind.config.cjs
@@ -63,7 +63,6 @@ module.exports = {
           text: "rgba(0, 255, 65, 0.60)",
           muted: "rgba(0, 255, 65, 0.35)",
           line: "rgba(0, 255, 65, 0.18)",
-          faint: "rgba(0, 255, 65, 0.08)",
         },
         surface: {
           DEFAULT: "#050505",

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -91,7 +91,7 @@ The user feels **seen and slightly called out** — like an old terminal friend 
 ### Colors
 
 - **Two tracks for prose / surfaces / accents**: green ink (data) and neutral surface (ground). One accent (`gold #FFD700`) reserved for **leaderboard #1** and total-cost callouts.
-- **Green ink** has exactly **6 alpha stops**: `#00FF41` (ink), `#E8FFE9` (ink-bright), `60%` (ink-text), `35%` (ink-muted), `18%` (ink-line), `8%` (ink-faint). No `/5`, `/12`, `/25`, `/45` — pick one.
+- **Green ink** has exactly **5 alpha stops**: `#00FF41` (ink), `#E8FFE9` (ink-bright), `60%` (ink-text), `35%` (ink-muted), `18%` (ink-line). No `/5`, `/8`, `/12`, `/25`, `/45` — pick one.
 - **Surfaces** are near-black: `#050505` (page), `rgba(0,10,0,0.70)` (panel), `rgba(0,10,0,0.82)` (chip / modal). Always paired with `backdrop-filter: blur(10px)` on raised surfaces.
 - **Status escape hatch**: `warn #FFB300` and `err #FF3344` (with matching `--warn-glow` / `--err-glow`) are reserved for status indicators **only** — connection state, error banners. Never as prose / accent / surface. They are the only hue extension allowed beyond the green-ink + gold palette.
 - **No fourth hue**, no purple-pink-cyan dapp gradient, no SaaS navy/slate. Information layering does **not** depend on color discrimination — alpha-stop ladder carries hierarchy.
@@ -117,7 +117,7 @@ The user feels **seen and slightly called out** — like an old terminal friend 
 
 ### Borders
 
-All borders are **1px solid**. No dashed / dotted / `border-[Npx]`. Ladder: `border-ink-faint` (weak), `border-ink-line` (default panel), `border-ink-muted` (hover), `border-ink` (active / selected).
+All borders are **1px solid**. No dashed / dotted / `border-[Npx]`. Ladder: `border-ink-line` (default panel + weak rule), `border-ink-muted` (hover), `border-ink` (active / selected).
 
 ### Cards
 

--- a/design-system/colors_and_type.css
+++ b/design-system/colors_and_type.css
@@ -38,13 +38,12 @@
 
 :root {
   /* === Color: ink (Matrix Green data ink) =========================== */
-  /* Six alpha stops only. No /5, /12, /25, /45. Pick one. */
+  /* Five alpha stops only. No /5, /12, /25, /45. Pick one. */
   --ink:        #00FF41;                    /* primary data, active state, primary btn */
   --ink-bright: #E8FFE9;                    /* display emphasis, selection foreground  */
   --ink-text:   rgba(0, 255, 65, 0.60);     /* body text, value label                  */
   --ink-muted:  rgba(0, 255, 65, 0.35);     /* secondary text, hover line              */
-  --ink-line:   rgba(0, 255, 65, 0.18);     /* default separator, panel border         */
-  --ink-faint:  rgba(0, 255, 65, 0.08);     /* weakest rule, subtle hover bg           */
+  --ink-line:   rgba(0, 255, 65, 0.18);     /* default separator, panel border, weakest rule */
   --ink-glow:   rgba(0, 255, 65, 0.40);     /* shadow color used by .glow-text         */
 
   /* === Color: surface (background ground) =========================== */
@@ -102,7 +101,6 @@
   --radius-dot: 999px;     /* status dot only */
 
   /* === Borders — 1px solid, no dashed, no dotted ==================== */
-  --border-faint: 1px solid var(--ink-faint);
   --border-line:  1px solid var(--ink-line);
   --border-muted: 1px solid var(--ink-muted);
   --border-ink:   1px solid var(--ink);
@@ -223,7 +221,7 @@ a {
 }
 a:hover { color: var(--ink-bright); border-color: var(--ink); }
 
-hr { border: 0; border-top: var(--border-faint); margin: var(--sp-6) 0; }
+hr { border: 0; border-top: var(--border-line); margin: var(--sp-6) 0; }
 
 /* --- Glow text utility (signature) -------------------------------- */
 .glow-text      { text-shadow: 0 0 16px var(--ink-glow); }
@@ -232,7 +230,7 @@ hr { border: 0; border-top: var(--border-faint); margin: var(--sp-6) 0; }
 /* --- Decorative katakana band (chrome only, no signal) ------------ */
 .deco-katakana {
   font-family: var(--font-katakana);
-  color: var(--ink-faint);
+  color: var(--ink-line);
   letter-spacing: var(--tracking-caps);
   white-space: nowrap;
   user-select: none;

--- a/design-system/preview/_card.css
+++ b/design-system/preview/_card.css
@@ -16,6 +16,6 @@ html, body {
 }
 .row { display: flex; align-items: center; gap: 12px; }
 .col { display: flex; flex-direction: column; gap: 4px; }
-.divider { height: 1px; background: var(--ink-faint); margin: 12px 0; }
+.divider { height: 1px; background: var(--ink-line); margin: 12px 0; }
 .label { font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ink-muted); font-weight: 700; }
 .mono { font-family: var(--font-mono); }

--- a/design-system/preview/avatar.html
+++ b/design-system/preview/avatar.html
@@ -4,7 +4,7 @@
 .av svg { width: 100%; height: 100%; filter: drop-shadow(0 0 5px rgba(0,255,65,0.6)); }
 .av.gold { border-color: #FFD700; }
 .av.gold svg rect { fill: #FFD700 !important; }
-.av.anon { border-color: var(--ink-faint); }
+.av.anon { border-color: var(--ink-line); }
 .av.anon::after { content: "?"; display: flex; height: 100%; align-items: center; justify-content: center; color: var(--ink); font-size: 24px; font-weight: 900; }
 .col { display: flex; flex-direction: column; gap: 6px; }
 .label { color: var(--ink-muted); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700; }

--- a/design-system/preview/borders.html
+++ b/design-system/preview/borders.html
@@ -2,14 +2,12 @@
 .row { display: grid; grid-template-columns: 100px 1fr 130px; align-items: center; gap: 16px; padding: 12px 0; }
 .tok { color: var(--ink); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700; }
 .demo { height: 32px; background: rgba(0,10,0,0.70); }
-.faint { border: 1px solid rgba(0,255,65,0.08); }
 .line { border: 1px solid rgba(0,255,65,0.18); }
 .muted { border: 1px solid rgba(0,255,65,0.35); }
 .active { border: 1px solid #00FF41; box-shadow: 0 0 6px rgba(0,255,65,0.35); }
 .use { color: var(--ink-muted); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600; text-align: right; }
 </style></head><body><div class="card">
-<div class="row"><div class="tok">faint</div><div class="demo faint"></div><div class="use">weak rule</div></div>
-<div class="row"><div class="tok">line</div><div class="demo line"></div><div class="use">panel default</div></div>
+<div class="row"><div class="tok">line</div><div class="demo line"></div><div class="use">panel default · weak rule</div></div>
 <div class="row"><div class="tok">muted</div><div class="demo muted"></div><div class="use">hover</div></div>
 <div class="row"><div class="tok">ink</div><div class="demo active"></div><div class="use">active / selected</div></div>
 </div></body></html>

--- a/design-system/preview/brand-clients.html
+++ b/design-system/preview/brand-clients.html
@@ -1,11 +1,11 @@
 <!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
 .frame { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; padding: 18px 18px 22px; }
 .tile { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 16px;
-  border: 1px solid var(--ink-faint); background: var(--surface-raised); }
+  border: 1px solid var(--ink-line); background: var(--surface-raised); }
 .logo { width: 44px; height: 44px; display: block; }
 .lbl { font-size: 10px; letter-spacing: 0.22em; color: var(--ink); text-transform: uppercase; font-weight: 700; }
 .note { font-size: 10px; color: var(--ink-muted); letter-spacing: 0.18em; text-transform: uppercase;
-  text-align: center; padding-top: 8px; border-top: 1px solid var(--ink-faint); margin-top: 8px; }
+  text-align: center; padding-top: 8px; border-top: 1px solid var(--ink-line); margin-top: 8px; }
 </style></head>
 <body>
 <div class="card-shell">

--- a/design-system/preview/breakdown.html
+++ b/design-system/preview/breakdown.html
@@ -15,7 +15,7 @@
   font-variant-numeric: tabular-nums; line-height: 1; }
 .pct .u { color: var(--ink); font-size: 12px; font-weight: 700; margin-left: 1px; }
 
-.bar  { height: 4px; background: var(--ink-faint); position: relative; }
+.bar  { height: 4px; background: var(--ink-line); position: relative; }
 .fill { height: 100%; background: var(--ink); box-shadow: 0 0 6px rgba(0,255,65,0.35);
   transition: width 400ms ease; }
 

--- a/design-system/preview/colors-gold.html
+++ b/design-system/preview/colors-gold.html
@@ -2,7 +2,7 @@
 .wrap { display: flex; gap: 16px; align-items: stretch; }
 .chip { width: 120px; height: 90px; background: #FFD700; box-shadow: 0 0 18px rgba(255,215,0,0.35); }
 .col { flex: 1; min-width: 0; gap: 8px; }
-.use { display: flex; align-items: baseline; gap: 12px; padding: 10px 12px; background: var(--surface-strong); border: 1px solid var(--ink-faint); }
+.use { display: flex; align-items: baseline; gap: 12px; padding: 10px 12px; background: var(--surface-strong); border: 1px solid var(--ink-line); }
 .crown { color: #FFD700; font-size: 28px; font-weight: 900; text-shadow: 0 0 20px rgba(255,215,0,0.4); }
 .cost { color: #FFD700; font-size: 28px; font-weight: 900; font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .lbl { color: var(--ink-muted); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700; }

--- a/design-system/preview/colors-ink.html
+++ b/design-system/preview/colors-ink.html
@@ -1,15 +1,14 @@
 <!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
 .swatch { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0; }
-.chip { height: 56px; border: 1px solid var(--ink-faint); position: relative; }
+.chip { height: 56px; border: 1px solid var(--ink-line); position: relative; }
 .chip.bg-ink { background: var(--ink); }
 .chip.bg-ink-bright { background: var(--ink-bright); }
 .chip.bg-ink-text { background: rgba(0,255,65,0.60); }
 .chip.bg-ink-muted { background: rgba(0,255,65,0.35); }
 .chip.bg-ink-line { background: rgba(0,255,65,0.18); }
-.chip.bg-ink-faint { background: rgba(0,255,65,0.08); }
 .name { font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700; color: var(--ink); }
 .val { font-size: 10px; color: var(--ink-text); letter-spacing: 0; font-variant-numeric: tabular-nums; }
-.grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; }
+.grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; }
 </style></head><body><div class="card">
 <div class="grid">
 <div class="swatch"><div class="chip bg-ink"></div><div class="name">ink</div><div class="val">#00FF41</div></div>
@@ -17,6 +16,5 @@
 <div class="swatch"><div class="chip bg-ink-text"></div><div class="name">text</div><div class="val">/ 60</div></div>
 <div class="swatch"><div class="chip bg-ink-muted"></div><div class="name">muted</div><div class="val">/ 35</div></div>
 <div class="swatch"><div class="chip bg-ink-line"></div><div class="name">line</div><div class="val">/ 18</div></div>
-<div class="swatch"><div class="chip bg-ink-faint"></div><div class="name">faint</div><div class="val">/ 8</div></div>
 </div>
 </div></body></html>

--- a/design-system/preview/keybinds.html
+++ b/design-system/preview/keybinds.html
@@ -2,7 +2,7 @@
 .row { display: flex; gap: 8px; align-items: center; padding: 6px 0; }
 .kbd { display: inline-flex; align-items: center; justify-content: center; min-width: 26px; height: 22px; padding: 0 6px; border: 1px solid var(--ink-muted); background: rgba(0,10,0,0.82); color: var(--ink); font-size: 10px; font-weight: 700; letter-spacing: 0.12em; }
 .act { color: var(--ink-text); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600; }
-.sep { color: var(--ink-faint); margin: 0 4px; }
+.sep { color: var(--ink-line); margin: 0 4px; }
 </style></head><body><div class="card">
 <div class="row"><span class="kbd">?</span><span class="sep">·</span><span class="act">toggle keyboard cheatsheet</span></div>
 <div class="row"><span class="kbd">D</span><span class="kbd">W</span><span class="kbd">M</span><span class="kbd">T</span><span class="sep">·</span><span class="act">period — day · week · month · total</span></div>

--- a/design-system/preview/panel-ascii.html
+++ b/design-system/preview/panel-ascii.html
@@ -33,7 +33,7 @@
 /* WEIGHT 3 — tertiary, sub-section / aside / empty-state.
    Same 1px solid (no dashed — the system is solid-only) but on the faintest
    ink stop so it reads as background structure, not foreground content. */
-.p3 { color: var(--ink-faint); }
+.p3 { color: var(--ink-line); }
 .p3 .chip { color: var(--ink-muted); }
 .p3 .body { color: var(--ink-muted); }
 </style></head>

--- a/design-system/preview/spacing-scale.html
+++ b/design-system/preview/spacing-scale.html
@@ -3,7 +3,7 @@
 .dot { width: 24px; height: 24px; background: var(--ink); }
 .lbl { color: var(--ink); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700; width: 30px; }
 .val { color: var(--ink-text); font-size: 11px; font-variant-numeric: tabular-nums; width: 60px; }
-.demo { flex: 1; height: 16px; background: var(--ink-faint); display: flex; align-items: center; padding: 0 4px; box-sizing: border-box; }
+.demo { flex: 1; height: 16px; background: var(--ink-line); display: flex; align-items: center; padding: 0 4px; box-sizing: border-box; }
 .usage { color: var(--ink-muted); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600; width: 130px; text-align: right; }
 </style></head><body><div class="card">
 <div class="row"><div class="lbl">0</div><div class="val">0px</div><div class="demo" style="height:0px"></div><div class="usage">collapsed</div></div>

--- a/design-system/preview/status-states.html
+++ b/design-system/preview/status-states.html
@@ -20,7 +20,7 @@
   align-items: center;
   gap: 16px;
   padding: 10px 0;
-  border-bottom: 1px solid var(--ink-faint);
+  border-bottom: 1px solid var(--ink-line);
 }
 .row:last-of-type { border-bottom: 0; }
 
@@ -77,7 +77,7 @@
 
 .legend {
   padding: 12px 20px 16px;
-  border-top: 1px solid var(--ink-faint);
+  border-top: 1px solid var(--ink-line);
   display: flex;
   gap: 16px;
   flex-wrap: wrap;

--- a/design-system/preview/type-display.html
+++ b/design-system/preview/type-display.html
@@ -1,6 +1,6 @@
 <!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
 .spec { font-family: var(--font-mono); }
-.row { display: grid; grid-template-columns: 80px 1fr 100px; align-items: baseline; gap: 16px; padding: 8px 0; border-bottom: 1px solid var(--ink-faint); }
+.row { display: grid; grid-template-columns: 80px 1fr 100px; align-items: baseline; gap: 16px; padding: 8px 0; border-bottom: 1px solid var(--ink-line); }
 .row:last-child { border-bottom: 0; }
 .tok { color: var(--ink); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700; }
 .specimen { color: var(--ink-bright); }

--- a/design-system/preview/type-text.html
+++ b/design-system/preview/type-text.html
@@ -6,7 +6,7 @@
   align-items: baseline;
   gap: 16px;
   padding: 12px 0;
-  border-bottom: 1px solid var(--ink-faint);
+  border-bottom: 1px solid var(--ink-line);
 }
 .row:last-child { border-bottom: 0; }
 .tok  { color: var(--ink); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700; }

--- a/design-system/preview/type-tracking.html
+++ b/design-system/preview/type-tracking.html
@@ -1,6 +1,6 @@
 <!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
 .box { padding: 16px; }
-.row { display: flex; align-items: baseline; gap: 16px; padding: 7px 0; border-bottom: 1px solid var(--ink-faint); }
+.row { display: flex; align-items: baseline; gap: 16px; padding: 7px 0; border-bottom: 1px solid var(--ink-line); }
 .tok { color: var(--ink); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700; width: 70px; flex-shrink: 0; }
 .spec { color: var(--ink-bright); flex: 1; font-weight: 700; }
 .meta { color: var(--ink-muted); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600; }

--- a/design-system/ui_kits/dashboard/styles.css
+++ b/design-system/ui_kits/dashboard/styles.css
@@ -43,7 +43,7 @@ button { font-family: inherit; cursor: pointer; }
 .vu-pip-dot { display: inline-block; width: 6px; height: 6px; border-radius: 999px; background: var(--ink);
   box-shadow: var(--shadow-glow-xs); animation: vu-pulse 1.6s infinite ease-in-out; }
 @keyframes vu-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.35 } }
-.vu-deco-band { color: var(--ink-faint); font-family: var(--font-mono); font-size: 10px;
+.vu-deco-band { color: var(--ink-line); font-family: var(--font-mono); font-size: 10px;
   letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700;
   flex: 1; min-width: 0; overflow: hidden; white-space: nowrap; padding-left: 16px; opacity: 0.6; }
 
@@ -110,7 +110,7 @@ button { font-family: inherit; cursor: pointer; }
    IDENTITY CARD
    ───────────────────────────────────────────────────────────────── */
 .vu-iden-row { display: flex; gap: 16px; align-items: flex-start; }
-.vu-iden-wrap { flex-shrink: 0; padding: 6px; background: var(--surface-strong); border: var(--border-faint); }
+.vu-iden-wrap { flex-shrink: 0; padding: 6px; background: var(--surface-strong); border: var(--border-line); }
 .vu-iden { display: block; }
 .vu-iden rect { fill: var(--ink); }
 .vu-iden.is-gold rect { fill: var(--gold); }
@@ -118,7 +118,7 @@ button { font-family: inherit; cursor: pointer; }
 .vu-iden-handle { color: var(--ink-bright); font-size: 26px; font-weight: 900; letter-spacing: -0.02em;
   text-shadow: 0 0 16px var(--ink-glow); line-height: 1; word-break: break-all; }
 .vu-iden-stats { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-.vu-stat { padding: 6px 8px; background: var(--surface-raised); border: var(--border-faint); text-align: center; }
+.vu-stat { padding: 6px 8px; background: var(--surface-raised); border: var(--border-line); text-align: center; }
 .vu-stat-lbl { color: var(--ink-text); font-size: 9px; letter-spacing: 0.22em; font-weight: 700; text-transform: uppercase; }
 .vu-stat-val { font-size: 12px; font-weight: 900; font-variant-numeric: tabular-nums; margin-top: 2px;
   white-space: nowrap; }
@@ -128,7 +128,7 @@ button { font-family: inherit; cursor: pointer; }
 .vu-subs-lbl { color: var(--ink-text); font-size: 9px; letter-spacing: 0.22em; font-weight: 700;
   text-transform: uppercase; margin-bottom: 6px; }
 .vu-subs-list { display: flex; flex-wrap: wrap; gap: 4px; }
-.vu-sub-chip { display: inline-flex; align-items: center; padding: 3px 6px; border: var(--border-faint);
+.vu-sub-chip { display: inline-flex; align-items: center; padding: 3px 6px; border: var(--border-line);
   background: var(--surface-raised); color: var(--ink-bright); font-size: 9px; letter-spacing: 0.12em;
   font-weight: 700; text-transform: uppercase; white-space: nowrap; }
 
@@ -136,7 +136,7 @@ button { font-family: inherit; cursor: pointer; }
    ROLLING USAGE — 3 tiles
    ───────────────────────────────────────────────────────────────── */
 .vu-rolling { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
-.vu-rolling-tile { padding: 10px 6px; border: var(--border-faint); background: var(--surface-raised); text-align: center; }
+.vu-rolling-tile { padding: 10px 6px; border: var(--border-line); background: var(--surface-raised); text-align: center; }
 .vu-rolling-lbl { color: var(--ink-text); font-size: 9px; letter-spacing: 0.22em; font-weight: 700; text-transform: uppercase; }
 .vu-rolling-val { color: var(--ink-bright); font-size: 26px; font-weight: 900; letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums; margin-top: 4px; line-height: 1; text-shadow: 0 0 12px var(--ink-glow); }
@@ -146,7 +146,7 @@ button { font-family: inherit; cursor: pointer; }
    ───────────────────────────────────────────────────────────────── */
 .vu-tm { display: flex; flex-direction: column; }
 .vu-tm-row { display: grid; grid-template-columns: auto 1fr auto; align-items: baseline; gap: 12px;
-  padding: 10px 4px; border-bottom: var(--border-faint); }
+  padding: 10px 4px; border-bottom: var(--border-line); }
 .vu-tm-row:last-child { border-bottom: 0; }
 .vu-tm-rank { color: var(--ink-muted); font-size: 11px; font-weight: 700; letter-spacing: 0.12em; font-variant-numeric: tabular-nums; }
 .vu-tm-name { color: var(--ink); font-size: 13px; font-weight: 900; letter-spacing: 0.04em; text-transform: uppercase;
@@ -184,7 +184,7 @@ button { font-family: inherit; cursor: pointer; }
 
 .vu-projs { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
 .vu-proj { position: relative; display: flex; flex-direction: column; gap: 10px; padding: 14px;
-  border: var(--border-faint); background: var(--surface-raised); text-decoration: none; min-height: 132px;
+  border: var(--border-line); background: var(--surface-raised); text-decoration: none; min-height: 132px;
   transition: var(--transition); }
 .vu-proj:hover { border-color: var(--ink); box-shadow: var(--shadow-glow-faint); }
 .vu-proj-stars { position: absolute; top: 10px; right: 12px; display: inline-flex; align-items: center; gap: 4px;
@@ -193,7 +193,7 @@ button { font-family: inherit; cursor: pointer; }
 .vu-proj-stars-num { color: var(--ink-bright); font-variant-numeric: tabular-nums; }
 
 .vu-proj-id { display: flex; align-items: center; gap: 8px; padding-right: 60px; }
-.vu-proj-avatar { width: 28px; height: 28px; border: var(--border-faint); border-radius: 999px; overflow: hidden;
+.vu-proj-avatar { width: 28px; height: 28px; border: var(--border-line); border-radius: 999px; overflow: hidden;
   display: flex; align-items: center; justify-content: center; flex-shrink: 0; background: var(--surface-strong); }
 .vu-proj-avatar svg { width: 22px !important; height: 22px !important; }
 .vu-proj-avatar img { width: 100%; height: 100%; object-fit: cover; }
@@ -232,7 +232,7 @@ button { font-family: inherit; cursor: pointer; }
 .vu-key { color: var(--ink-muted); font-size: 10px; letter-spacing: 0.22em; font-weight: 700; margin-left: 6px; vertical-align: middle; }
 
 .vu-core-foot { color: var(--ink-muted); font-size: 10px; letter-spacing: 0.18em; text-align: center;
-  padding-top: 12px; margin-top: 12px; border-top: var(--border-faint); font-weight: 600; text-transform: uppercase; }
+  padding-top: 12px; margin-top: 12px; border-top: var(--border-line); font-weight: 600; text-transform: uppercase; }
 
 /* ─────────────────────────────────────────────────────────────────
    MODEL BREAKDOWN — grouped per source
@@ -244,7 +244,7 @@ button { font-family: inherit; cursor: pointer; }
 .vu-mbd-usage { color: var(--ink-text); font-size: 10px; letter-spacing: 0.22em; font-weight: 700; text-transform: uppercase; }
 .vu-mbd-pct { margin-left: auto; color: var(--ink); font-size: 18px; font-weight: 900; font-variant-numeric: tabular-nums; }
 .vu-mbd-pct-unit { color: var(--ink); font-size: 12px; font-weight: 700; margin-left: 1px; }
-.vu-mbd-bar { height: 4px; background: var(--ink-faint); position: relative; }
+.vu-mbd-bar { height: 4px; background: var(--ink-line); position: relative; }
 .vu-mbd-fill { height: 100%; background: var(--ink); box-shadow: var(--shadow-glow-xs); transition: width 400ms ease; }
 .vu-mbd-subs { display: grid; grid-template-columns: repeat(2, 1fr); gap: 4px 16px; padding-top: 4px; }
 .vu-mbd-sub { display: flex; align-items: center; gap: 6px; color: var(--ink-text); font-size: 11px;
@@ -257,15 +257,15 @@ button { font-family: inherit; cursor: pointer; }
 /* ─────────────────────────────────────────────────────────────────
    DETAILS TABLE
    ───────────────────────────────────────────────────────────────── */
-.vu-details { border: var(--border-faint); overflow-x: auto; }
+.vu-details { border: var(--border-line); overflow-x: auto; }
 .vu-details table { width: 100%; border-collapse: collapse; }
-.vu-details th { padding: 0; background: var(--surface-strong); border-bottom: var(--border-faint); }
+.vu-details th { padding: 0; background: var(--surface-strong); border-bottom: var(--border-line); }
 .vu-details th button { width: 100%; display: inline-flex; align-items: center; justify-content: flex-start;
   gap: 6px; padding: 10px 14px; background: transparent; border: 0; color: var(--ink-text); font-size: 10px;
   letter-spacing: 0.22em; font-weight: 900; text-transform: uppercase; cursor: pointer; transition: var(--transition); font-family: var(--font-mono); }
 .vu-details th button:hover { color: var(--ink); background: rgba(0,255,65,0.04); }
 .vu-th-arrow { color: var(--ink-bright); font-size: 10px; }
-.vu-details td { padding: 10px 14px; border-bottom: var(--border-faint); color: var(--ink-text); font-size: 12px;
+.vu-details td { padding: 10px 14px; border-bottom: var(--border-line); color: var(--ink-text); font-size: 12px;
   font-variant-numeric: tabular-nums; font-weight: 600; }
 .vu-details tr:last-child td { border-bottom: 0; }
 .vu-details tr:hover td { background: rgba(0,255,65,0.03); }
@@ -295,13 +295,13 @@ button { font-family: inherit; cursor: pointer; }
   font-size: 8px; letter-spacing: 0.18em; font-weight: 700; text-transform: uppercase; align-items: center; }
 .vu-heat-grid { display: grid; gap: 2px; }
 .vu-heat-c { aspect-ratio: 1; min-width: 0; }
-.vu-heat-l0 { background: var(--ink-faint); }
+.vu-heat-l0 { background: var(--ink-line); }
 .vu-heat-l1 { background: rgba(0,255,65,0.18); }
 .vu-heat-l2 { background: rgba(0,255,65,0.35); }
 .vu-heat-l3 { background: rgba(0,255,65,0.6); }
 .vu-heat-l4 { background: var(--ink); box-shadow: var(--shadow-glow-xs); }
 .vu-heat-foot { display: flex; justify-content: space-between; align-items: center; padding-top: 8px;
-  border-top: var(--border-faint); color: var(--ink-text); font-size: 9px; letter-spacing: 0.22em;
+  border-top: var(--border-line); color: var(--ink-text); font-size: 9px; letter-spacing: 0.22em;
   font-weight: 700; text-transform: uppercase; }
 .vu-heat-legend { display: inline-flex; align-items: center; gap: 4px; }
 .vu-heat-foot .vu-heat-c { display: inline-block; width: 10px; height: 10px; aspect-ratio: auto; }
@@ -317,7 +317,7 @@ button { font-family: inherit; cursor: pointer; }
 .vu-fab:hover { border-color: var(--ink); box-shadow: var(--shadow-glow-xs); color: var(--ink-bright); }
 
 .vu-version { position: fixed; bottom: 16px; right: 16px; z-index: 35; display: flex; flex-direction: column;
-  align-items: flex-end; padding: 6px 10px; border: var(--border-faint); background: var(--surface-strong); }
+  align-items: flex-end; padding: 6px 10px; border: var(--border-line); background: var(--surface-strong); }
 .vu-version-lbl { color: var(--ink-muted); font-size: 9px; letter-spacing: 0.22em; font-weight: 700; text-transform: uppercase; }
 .vu-version-num { color: var(--ink); font-size: 12px; font-weight: 900; font-variant-numeric: tabular-nums; }
 
@@ -328,7 +328,7 @@ button { font-family: inherit; cursor: pointer; }
   display: flex; align-items: center; justify-content: center; }
 .vu-modal-panel { width: min(360px, 90vw); }
 .vu-cheats { display: flex; flex-direction: column; gap: 6px; }
-.vu-cheats-row { display: flex; align-items: center; gap: 12px; padding: 6px 4px; border-bottom: var(--border-faint); }
+.vu-cheats-row { display: flex; align-items: center; gap: 12px; padding: 6px 4px; border-bottom: var(--border-line); }
 .vu-cheats-row:last-child { border-bottom: 0; }
 .vu-cheats kbd { display: inline-flex; align-items: center; justify-content: center; min-width: 28px; height: 24px;
   padding: 0 6px; border: var(--border-muted); background: var(--surface-strong); color: var(--ink);
@@ -339,7 +339,7 @@ button { font-family: inherit; cursor: pointer; }
    FOOTER + TOAST
    ───────────────────────────────────────────────────────────────── */
 .vu-footer { display: flex; justify-content: space-between; align-items: center; margin-top: 24px; padding-top: 12px;
-  border-top: var(--border-faint); color: var(--ink-faint); font-size: 10px; letter-spacing: 0.22em;
+  border-top: var(--border-line); color: var(--ink-line); font-size: 10px; letter-spacing: 0.22em;
   font-weight: 700; text-transform: uppercase; }
 
 .vu-toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); padding: 10px 16px;


### PR DESCRIPTION
## Summary

- 删除 `ink-faint` (8% alpha) 这一档 — 在 near-black surface 上读起来像噪点，没起到 rule 的作用
- 三档 border ladder → 两档：`line` (默认 + weak rule) / `muted` (hover) / `ink` (active)
- 5 alpha stops 总规范：`ink` `ink-bright` `ink-text` `ink-muted` `ink-line`

## Changes

**Token 删除（3 SSOT）**
- `dashboard/tailwind.config.cjs` — drop `ink.faint`
- `dashboard/src/styles.css` — drop `--ink-faint`
- `design-system/colors_and_type.css` — drop `--ink-faint` + `--border-faint`

**全局替换（46 源文件，134 处）**
- `var(--ink-faint)` → `var(--ink-line)`
- `var(--border-faint)` → `var(--border-line)`
- Tailwind: `border-ink-faint` / `bg-ink-faint` / `text-ink-faint` / `via-ink-faint` → `-line` 对应

**组件 API 收口**
- `<Text>` `tone="ink-faint"` 选项移除（无调用方）
- `shadcn-retro-fit.mjs` `GUARDRAIL_BANS_SLASH` 移除 `ink-faint`

**文档**
- `dashboard/DESIGN.md` — ink ladder 表 6→5 stops、Border 表三档、`<Text>` tone 列表收口、迁移表更新
- `design-system/README.md` — 同步
- `design-system/preview/borders.html` + `colors-ink.html` — 删 faint 行，grid 6→5 列

**保留**
- `shadow-glow-faint` / `shadow-gold-faint` / `dropShadow.glow-faint`（阴影命名空间，与 ink ladder 无关）
- `boxShadow.panel` 里的 `0.08` ring 阴影（装饰，非 border token）
- `parts.jsx` SVG trend area fill 的 `0.08`（chart 装饰）
- `chats/chat1.md` / `chat2.md`（设计阶段历史快照）

## Test plan

- [x] `npm run build` 通过 (2.88s)
- [x] `dashboard/dist/assets/main-*.{css,js}` grep `ink-faint` → 0 命中
- [x] 全仓 `grep ink-faint` 在源码 + 设计 SSOT 中 → 0 命中（仅保留 chats 历史快照）

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `ink-faint` design token and consolidate weak rules onto `ink-line`
> - Removes the `--ink-faint` / `--border-faint` CSS variables and the `ink.faint` Tailwind palette entry, collapsing the ink alpha ladder from 6 to 5 stops.
> - Replaces all `ink-faint` usages (borders, backgrounds, text) with `ink-line` across dashboard components, design system previews, and the UI kit stylesheet.
> - Updates [DESIGN.md](https://github.com/victorGPT/vibeusage/pull/193/files#diff-194ef001afeb8c0d41ed8edec1d318966ebdc65d3e76b76152063ee88ec9d9f3) and [README.md](https://github.com/victorGPT/vibeusage/pull/193/files#diff-52537434051370e727ee9e4b29fdc660486fedcbb006cbc55e1513f6c331fb37) to document the five-stop ladder and revised token guidance.
> - Updates the [shadcn retrofit script](https://github.com/victorGPT/vibeusage/pull/193/files#diff-ea422570610217897ae3fbe811451ab312179a0598b061b8d4d29bc681832c7f) so low-alpha rgba mappings and slash-opacity bans target `ink-line` instead of `ink-faint`.
> - Behavioral Change: any code outside this repo that references `--ink-faint`, `--border-faint`, `border-ink-faint`, `bg-ink-faint`, or `text-ink-faint` will silently lose styling; the `Text` component's `tone='ink-faint'` prop no longer maps to any class.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 89ea0ea. 49 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>design-system/colors_and_type.css — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 46](https://github.com/victorGPT/vibeusage/blob/89ea0ea9fcd0084caae9f6a21b1edd85c2854ce2/design-system/colors_and_type.css#L46): Removing `--ink-faint` and `--border-faint` from the design-system SSOT leaves stale references in `dashboard/scripts/shadcn-mapping.json`, which still maps ~10 shadcn classes (e.g. `bg-muted` → `bg-ink-faint`, `bg-accent` → `bg-ink-faint`, `border-muted` → `border-ink-faint`, `border-accent` → `border-ink-faint`, plus `bg-gray-50`, `bg-gray-100`, `bg-slate-50`, `bg-slate-100`, `bg-zinc-50`, `border-gray-100`) to the now-deleted Tailwind utilities `bg-ink-faint` and `border-ink-faint`. The next time `shadcn-retro-fit.mjs` is run to onboard a new shadcn component, it will inject non-existent Tailwind classes into the component source, producing invisible/missing backgrounds and borders with no build-time error. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->