### PR TITLE
release: 0.6.4 — Hermes usage field name fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-04-30
+
+### Fixed
+
+- **Hermes usage field name fallback.** The `post_api_request` hook in Hermes may pass usage dicts with short field names (`output`, `input`, `cache_read`, etc.) instead of the expected long names (`output_tokens`, `input_tokens`, `cache_read_tokens`, etc.). The plugin template now falls back from the long name to the short name for all six fields (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `reasoning_tokens`, `total_tokens`). This fixes the bug where `output_tokens` was permanently 0 in the ledger because the plugin only looked for the long field name while Hermes passed the short name.
+- **Sync total_tokens safety net.** `parseHermesUsageLedger` now routes `total_tokens` into `output_tokens` when all fine-grained channels are 0 but `total_tokens > 0`. This prevents events from being silently dropped when an upstream plugin only reports the total.
+
 ## [0.6.3] - 2026-04-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeusage",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Codex CLI token usage tracker (macOS-first, notify-driven).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

This release fixes the Hermes usage field name mismatch bug where `output_tokens` was permanently 0.

## Changes

### Fixed
- **Hermes usage field name fallback.** The `post_api_request` hook in Hermes may pass usage dicts with short field names (`output`, `input`, `cache_read`, etc.) instead of the expected long names (`output_tokens`, `input_tokens`, `cache_read_tokens`, etc.). The plugin template now falls back from the long name to the short name for all six fields.
- **Sync total_tokens safety net.** `parseHermesUsageLedger` now routes `total_tokens` into `output_tokens` when all fine-grained channels are 0 but `total_tokens > 0`.

## Verification
- Regression: 831 tests pass (0 fail)

## Version bump
- package.json: 0.6.3 → 0.6.4


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.6.4 with Hermes usage field name fallback fixes
> - The plugin template now falls back from long to short Hermes usage field names across six token fields.
> - `parseHermesUsageLedger` maps `total_tokens` into `output_tokens` when all fine-grained channels are zero but `total_tokens` is positive.
> - Version bumped from `0.6.3` to `0.6.4` in [package.json](https://github.com/victorGPT/vibeusage/pull/195/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1606e38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->