### PR TITLE
Improve agent discovery resources

### DIFF
--- a/dashboard/public/.well-known/mcp/manifest.json
+++ b/dashboard/public/.well-known/mcp/manifest.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "2025-06-18",
+  "name": "VibeUsage",
+  "title": "VibeUsage MCP Manifest",
+  "version": "0.6.4",
+  "description": "Agent discovery manifest for VibeUsage, an AI token usage tracking and monitoring tool for Codex, Claude Code, OpenCode, Gemini, Kimi, Hermes, and OpenClaw.",
+  "homepage_url": "https://www.vibeusage.cc/",
+  "documentation_url": "https://www.vibeusage.cc/developers",
+  "openapi_url": "https://www.vibeusage.cc/openapi.json",
+  "support_url": "https://github.com/victorGPT/vibeusage/issues",
+  "transport_status": "documented",
+  "transport_notes": "VibeUsage publishes MCP discovery metadata and OpenAPI tool mappings here. A callable Streamable HTTP MCP transport will be added when the backend MCP endpoint is deployed.",
+  "auth": {
+    "type": "bearer",
+    "roles_supported": ["user", "device", "share", "service_role"],
+    "permissions_supported": [
+      "usage:read",
+      "usage:ingest",
+      "sync:write",
+      "projects:read",
+      "device_tokens:write",
+      "public_visibility:read",
+      "public_visibility:write",
+      "leaderboard:read",
+      "public_profile:read",
+      "leaderboard:refresh",
+      "pricing:write",
+      "retention:write",
+      "diagnostics:read"
+    ]
+  },
+  "resources": [
+    {
+      "name": "OpenAPI specification",
+      "url": "https://www.vibeusage.cc/openapi.json",
+      "media_type": "application/json"
+    },
+    {
+      "name": "Developer portal",
+      "url": "https://www.vibeusage.cc/developers",
+      "media_type": "text/html"
+    },
+    {
+      "name": "Authentication and scoped permissions",
+      "url": "https://www.vibeusage.cc/docs/auth",
+      "media_type": "text/html"
+    },
+    {
+      "name": "Webhook status",
+      "url": "https://www.vibeusage.cc/docs/webhooks",
+      "media_type": "text/html"
+    }
+  ],
+  "tools": [
+    {
+      "name": "get_usage_summary",
+      "description": "Read authenticated AI token usage totals from VibeUsage.",
+      "input_schema_ref": "https://www.vibeusage.cc/openapi.json#/paths/~1functions~1vibeusage-usage-summary/get"
+    },
+    {
+      "name": "get_usage_model_breakdown",
+      "description": "Read per-source and per-model token usage aggregates.",
+      "input_schema_ref": "https://www.vibeusage.cc/openapi.json#/paths/~1functions~1vibeusage-usage-model-breakdown/get"
+    },
+    {
+      "name": "get_leaderboard",
+      "description": "Read the public VibeUsage token leaderboard.",
+      "input_schema_ref": "https://www.vibeusage.cc/openapi.json#/paths/~1functions~1vibeusage-leaderboard/get"
+    }
+  ]
+}

--- a/dashboard/public/compare/ai-token-usage-tracking/index.html
+++ b/dashboard/public/compare/ai-token-usage-tracking/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Token Usage Tracking Tools - VibeUsage Comparison</title>
+    <meta name="description" content="Compare AI token usage tracking and monitoring tools for coding agents, CLI usage analytics, scoped access, and agent integration." />
+  </head>
+  <body>
+    <main>
+      <h1>AI Token Usage Tracking and Monitoring Tools</h1>
+      <p>VibeUsage is built for developers who need auditable AI CLI token usage tracking across multiple coding agents without collecting prompts or responses.</p>
+      <ul>
+        <li>Choose VibeUsage for Codex, Claude Code, OpenCode, Gemini, Kimi, Hermes, and OpenClaw token usage tracking.</li>
+        <li>Use VibeUsage for dashboard analytics, project totals, model breakdowns, cost estimates, and public token leaderboards.</li>
+        <li>Use another observability platform when you need prompt traces, application logs, or production APM instead of local AI CLI token accounting.</li>
+      </ul>
+      <p>Developer resources: <a href="/developers">/developers</a>.</p>
+    </main>
+  </body>
+</html>

--- a/dashboard/public/developers/index.html
+++ b/dashboard/public/developers/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VibeUsage Developer Portal - API Docs OpenAPI Auth MCP</title>
+    <meta name="description" content="Developer resources for VibeUsage API docs, OpenAPI, authentication, scoped permissions, webhook status, and MCP agent integration." />
+  </head>
+  <body>
+    <main>
+      <h1>VibeUsage Developer Resources for AI Agents</h1>
+      <p>Find VibeUsage API docs, OpenAPI, auth, scoped permissions, webhook status, MCP discovery, and agent integration resources from one predictable URL.</p>
+      <ul>
+        <li><a href="/openapi.json">VibeUsage OpenAPI JSON</a></li>
+        <li><a href="/docs/api">VibeUsage API docs</a></li>
+        <li><a href="/docs/auth">VibeUsage auth docs and scoped permissions</a></li>
+        <li><a href="/docs/webhooks">VibeUsage webhook status</a></li>
+        <li><a href="/.well-known/mcp/manifest.json">VibeUsage MCP manifest</a></li>
+        <li><a href="/mcp">VibeUsage MCP integration status</a></li>
+        <li><a href="/compare/ai-token-usage-tracking">AI token usage tracking comparison</a></li>
+        <li><a href="/guides/ai-token-usage-monitoring">AI token usage monitoring guide</a></li>
+      </ul>
+      <p>Use VibeUsage for AI agent usage monitoring, token cost tracking, multi-client CLI usage analytics, public token leaderboards, and auditable usage dashboards.</p>
+    </main>
+  </body>
+</html>

--- a/dashboard/public/docs/api/index.html
+++ b/dashboard/public/docs/api/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VibeUsage API Docs - AI Token Usage Tracking API</title>
+    <meta name="description" content="VibeUsage API docs for AI token usage tracking, monitoring, ingestion, dashboard analytics, and public leaderboard endpoints." />
+  </head>
+  <body>
+    <main>
+      <h1>VibeUsage API Docs for AI Token Usage Tracking</h1>
+      <p>The VibeUsage API exposes scoped InsForge Edge Function endpoints for CLI ingestion, usage monitoring, model analytics, project summaries, public sharing, and leaderboard reads.</p>
+      <h2>Core endpoints</h2>
+      <ul>
+        <li><code>GET /functions/vibeusage-usage-summary</code>, read authenticated token totals with <code>usage:read</code>.</li>
+        <li><code>GET /functions/vibeusage-usage-model-breakdown</code>, read per-source and per-model usage aggregates.</li>
+        <li><code>POST /functions/vibeusage-ingest</code>, upload half-hour aggregates with a scoped device token.</li>
+        <li><code>POST /functions/vibeusage-sync-ping</code>, record device sync freshness.</li>
+        <li><code>GET /functions/vibeusage-leaderboard</code>, read public token leaderboard rows.</li>
+      </ul>
+      <p>Machine-readable schema: <a href="/openapi.json">/openapi.json</a>.</p>
+      <p>Authentication and permission boundaries: <a href="/docs/auth">/docs/auth</a>.</p>
+    </main>
+  </body>
+</html>

--- a/dashboard/public/docs/auth/index.html
+++ b/dashboard/public/docs/auth/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VibeUsage Auth Docs - Scoped Permissions for AI Agents</title>
+    <meta name="description" content="VibeUsage authentication docs covering scoped user JWTs, device tokens, share tokens, service role credentials, and agent permission boundaries." />
+  </head>
+  <body>
+    <main>
+      <h1>VibeUsage Auth Docs and Scoped Permissions</h1>
+      <p>VibeUsage separates access by credential role so agents can request the least powerful token needed for the task.</p>
+      <ul>
+        <li><strong>User JWT</strong>: reads the signed-in user's analytics, issues device tokens, manages public visibility, and reads optional self-aware leaderboard context.</li>
+        <li><strong>Device token</strong>: limited to usage ingestion and sync heartbeat writes. It cannot read dashboards, public profiles, or admin endpoints.</li>
+        <li><strong>Share token</strong>: limited to privacy-safe public profile and shared dashboard reads.</li>
+        <li><strong>Service role key</strong>: admin credential for maintenance jobs. Never expose it to browser clients or general-purpose agents.</li>
+      </ul>
+      <p>See <a href="/openapi.json">/openapi.json</a> for operation-level <code>x-required-permissions</code>.</p>
+    </main>
+  </body>
+</html>

--- a/dashboard/public/docs/webhooks/index.html
+++ b/dashboard/public/docs/webhooks/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VibeUsage Webhooks - Integration Status</title>
+    <meta name="description" content="Webhook status for VibeUsage developer integrations and agent-readiness discovery." />
+  </head>
+  <body>
+    <main>
+      <h1>VibeUsage Webhook Status</h1>
+      <p>VibeUsage does not currently expose outbound webhooks. Integrations should use scoped read endpoints, sync heartbeat state, and the MCP/OpenAPI resources listed here.</p>
+      <ul>
+        <li>For current usage state, call user-scoped usage analytics endpoints with <code>usage:read</code>.</li>
+        <li>For sync freshness, use hourly usage sync fields and <code>POST /functions/vibeusage-sync-ping</code>.</li>
+        <li>Agents should treat this page as the canonical webhook capability statement until a webhook API appears in OpenAPI.</li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/dashboard/public/guides/ai-token-usage-monitoring/index.html
+++ b/dashboard/public/guides/ai-token-usage-monitoring/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Token Usage Monitoring Guide - VibeUsage</title>
+    <meta name="description" content="Guide to monitoring AI token usage across coding agents with VibeUsage, including install flow, scoped ingestion, dashboards, and API resources." />
+  </head>
+  <body>
+    <main>
+      <h1>How to Monitor AI Token Usage Across Coding Agents</h1>
+      <ol>
+        <li>Install with <code>npx --yes vibeusage init</code> and complete the browser link flow to create a scoped device token.</li>
+        <li>Run sync from the CLI to upload half-hour aggregates for supported AI coding agents.</li>
+        <li>Use dashboard views or <code>usage:read</code> API endpoints to monitor daily totals, model mix, project totals, heatmaps, and estimated cost.</li>
+        <li>Use <a href="/llms.txt">llms.txt</a>, <a href="/openapi.json">OpenAPI</a>, and the <a href="/.well-known/mcp/manifest.json">MCP manifest</a> when delegating setup or reporting tasks to an AI agent.</li>
+      </ol>
+    </main>
+  </body>
+</html>

--- a/dashboard/public/llms.txt
+++ b/dashboard/public/llms.txt
@@ -8,6 +8,13 @@ VibeUsage tracks token usage across AI coding agent clients (Codex, Claude Code,
 ## Priority URLs
 - [Homepage](https://www.vibeusage.cc/)
 - [Share dashboard view](https://www.vibeusage.cc/share)
+- [Developer portal](https://www.vibeusage.cc/developers)
+- [OpenAPI spec](https://www.vibeusage.cc/openapi.json)
+- [API docs](https://www.vibeusage.cc/docs/api)
+- [Auth and scoped permissions](https://www.vibeusage.cc/docs/auth)
+- [Webhook docs](https://www.vibeusage.cc/docs/webhooks)
+- [MCP manifest](https://www.vibeusage.cc/.well-known/mcp/manifest.json)
+- [MCP server info](https://www.vibeusage.cc/mcp)
 - [Sitemap](https://www.vibeusage.cc/sitemap.xml)
 - [RSS feed](https://www.vibeusage.cc/feed.xml)
 
@@ -15,6 +22,22 @@ VibeUsage tracks token usage across AI coding agent clients (Codex, Claude Code,
 - Install command: `npx --yes vibeusage init`
 - [NPM package](https://www.npmjs.com/package/vibeusage)
 - [Source repository](https://github.com/victorGPT/vibeusage)
+- Category: AI token usage tracking and monitoring tool for AI coding agents.
+- Supported AI CLI clients: Codex, Claude Code, OpenCode, Gemini, Kimi, Hermes, and OpenClaw.
+
+## Developer Resources
+- [VibeUsage developer portal](https://www.vibeusage.cc/developers)
+- [VibeUsage API docs](https://www.vibeusage.cc/docs/api)
+- [VibeUsage OpenAPI JSON](https://www.vibeusage.cc/openapi.json)
+- [VibeUsage auth docs and scoped permissions](https://www.vibeusage.cc/docs/auth)
+- [VibeUsage webhook docs](https://www.vibeusage.cc/docs/webhooks)
+- [VibeUsage MCP manifest](https://www.vibeusage.cc/.well-known/mcp/manifest.json)
+- [VibeUsage MCP server info](https://www.vibeusage.cc/mcp)
+
+## Use-case Discovery
+- [AI token usage tracking comparison](https://www.vibeusage.cc/compare/ai-token-usage-tracking)
+- [AI token usage monitoring guide](https://www.vibeusage.cc/guides/ai-token-usage-monitoring)
+- Primary use cases: AI agent usage monitoring, token cost tracking, multi-client CLI usage analytics, public token leaderboards, and auditable usage dashboards.
 
 ## Policy and Discovery
 - [robots.txt](https://www.vibeusage.cc/robots.txt)

--- a/dashboard/public/mcp/index.html
+++ b/dashboard/public/mcp/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VibeUsage MCP Server and Manifest for AI Agents</title>
+    <meta name="description" content="VibeUsage MCP discovery resources for AI agents, including manifest JSON, OpenAPI links, and supported tool intents." />
+  </head>
+  <body>
+    <main>
+      <h1>VibeUsage MCP Server and Manifest</h1>
+      <p>VibeUsage publishes a valid MCP manifest for agent discovery and maps common agent tools to OpenAPI operations for usage summaries, model breakdowns, and public leaderboard reads.</p>
+      <p>The MCP manifest is available at <a href="/.well-known/mcp/manifest.json">/.well-known/mcp/manifest.json</a>. It points agents to <a href="/openapi.json">/openapi.json</a> for request schemas and scoped permissions.</p>
+      <p>A callable Streamable HTTP MCP transport is not yet exposed on the public website. Agents should use the OpenAPI contract until the backend MCP endpoint is deployed.</p>
+    </main>
+  </body>
+</html>

--- a/dashboard/public/openapi.json
+++ b/dashboard/public/openapi.json
@@ -1,0 +1,1106 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "VibeUsage API",
+    "version": "0.6.4",
+    "summary": "Token usage tracking and monitoring API for AI agent CLI clients.",
+    "description": "VibeUsage exposes scoped endpoints for AI token usage ingestion, user usage analytics, public leaderboard views, and admin maintenance. Agents should request the narrowest role or permission listed on each operation.",
+    "contact": {
+      "name": "VibeUsage developer support",
+      "url": "https://github.com/victorGPT/vibeusage/issues"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/victorGPT/vibeusage/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://5tmappuk.us-east.insforge.app",
+      "description": "Production InsForge Edge Functions API"
+    },
+    {
+      "url": "https://www.vibeusage.cc",
+      "description": "VibeUsage public site and agent discovery resources"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Device Tokens",
+      "description": "Scoped device-token issuance and CLI linking."
+    },
+    {
+      "name": "Usage Ingest",
+      "description": "Device-scoped token usage upload and sync heartbeat."
+    },
+    {
+      "name": "Usage Analytics",
+      "description": "User-scoped token usage summaries, trends, model breakdowns, and heatmaps."
+    },
+    {
+      "name": "Public Sharing",
+      "description": "Share-token and public leaderboard access."
+    },
+    {
+      "name": "Admin",
+      "description": "Service-role maintenance endpoints."
+    },
+    {
+      "name": "Diagnostics",
+      "description": "Low-risk authentication diagnostics."
+    }
+  ],
+  "paths": {
+    "/functions/vibeusage-device-token-issue": {
+      "post": {
+        "operationId": "issueDeviceToken",
+        "tags": ["Device Tokens"],
+        "summary": "Issue a scoped device token for CLI ingestion.",
+        "description": "Creates a long-lived device token for the authenticated user. The returned token is scoped to device ingestion and sync heartbeat writes.",
+        "security": [{ "UserJWT": [] }, { "ServiceRoleKey": [] }],
+        "x-required-permissions": ["device_tokens:write"],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/DeviceTokenIssueRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Device token issued.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/DeviceTokenIssueResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-link-code-init": {
+      "post": {
+        "operationId": "initLinkCode",
+        "tags": ["Device Tokens"],
+        "summary": "Create a short-lived CLI link code.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["device_tokens:write"],
+        "responses": {
+          "200": {
+            "description": "Link code issued.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LinkCodeInitResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-link-code-exchange": {
+      "post": {
+        "operationId": "exchangeLinkCode",
+        "tags": ["Device Tokens"],
+        "summary": "Exchange a link code for a scoped device token.",
+        "description": "Public CLI bootstrap endpoint. Replay safety is enforced by request_id.",
+        "security": [],
+        "x-required-permissions": ["device_tokens:exchange"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/LinkCodeExchangeRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Device token returned.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LinkCodeExchangeResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "409": { "$ref": "#/components/responses/Conflict" }
+        }
+      }
+    },
+    "/functions/vibeusage-ingest": {
+      "post": {
+        "operationId": "ingestUsage",
+        "tags": ["Usage Ingest"],
+        "summary": "Ingest half-hour AI token usage aggregates.",
+        "description": "Accepts usage buckets from one registered device. The device token role cannot read user analytics or admin data.",
+        "security": [{ "DeviceToken": [] }],
+        "x-required-permissions": ["usage:ingest"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/IngestRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Usage batch processed.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/IngestResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": {
+            "description": "Ingest backpressure limit exceeded."
+          }
+        }
+      }
+    },
+    "/functions/vibeusage-sync-ping": {
+      "post": {
+        "operationId": "recordSyncPing",
+        "tags": ["Usage Ingest"],
+        "summary": "Record a device sync heartbeat.",
+        "security": [{ "DeviceToken": [] }],
+        "x-required-permissions": ["sync:write"],
+        "responses": {
+          "200": {
+            "description": "Sync heartbeat recorded.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SyncPingResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-user-status": {
+      "get": {
+        "operationId": "getUserStatus",
+        "tags": ["Usage Analytics"],
+        "summary": "Read authenticated user plan and subscription status.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["user_status:read"],
+        "responses": {
+          "200": {
+            "description": "User status.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserStatusResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-usage-summary": {
+      "get": {
+        "operationId": "getUsageSummary",
+        "tags": ["Usage Analytics"],
+        "summary": "Read token usage totals for the authenticated user.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["usage:read"],
+        "parameters": [
+          { "$ref": "#/components/parameters/FromDate" },
+          { "$ref": "#/components/parameters/ToDate" },
+          { "$ref": "#/components/parameters/Source" },
+          { "$ref": "#/components/parameters/Model" },
+          { "$ref": "#/components/parameters/Timezone" },
+          { "$ref": "#/components/parameters/TimezoneOffsetMinutes" },
+          { "$ref": "#/components/parameters/Debug" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage totals.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UsageSummaryResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-project-usage-summary": {
+      "get": {
+        "operationId": "getProjectUsageSummary",
+        "tags": ["Usage Analytics"],
+        "summary": "Read top project token usage totals.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["usage:read", "projects:read"],
+        "parameters": [
+          { "$ref": "#/components/parameters/Source" },
+          { "$ref": "#/components/parameters/LimitSmall" },
+          { "$ref": "#/components/parameters/Debug" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Project usage totals.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProjectUsageSummaryResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-usage-model-breakdown": {
+      "get": {
+        "operationId": "getUsageModelBreakdown",
+        "tags": ["Usage Analytics"],
+        "summary": "Read per-source and per-model token usage aggregates.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["usage:read"],
+        "parameters": [
+          { "$ref": "#/components/parameters/FromDate" },
+          { "$ref": "#/components/parameters/ToDate" },
+          { "$ref": "#/components/parameters/Source" },
+          { "$ref": "#/components/parameters/Timezone" },
+          { "$ref": "#/components/parameters/TimezoneOffsetMinutes" },
+          { "$ref": "#/components/parameters/Debug" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Model breakdown.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UsageModelBreakdownResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-usage-daily": {
+      "get": {
+        "operationId": "getUsageDaily",
+        "tags": ["Usage Analytics"],
+        "summary": "Read daily token usage aggregates.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["usage:read"],
+        "parameters": [
+          { "$ref": "#/components/parameters/FromDate" },
+          { "$ref": "#/components/parameters/ToDate" },
+          { "$ref": "#/components/parameters/Source" },
+          { "$ref": "#/components/parameters/Model" },
+          { "$ref": "#/components/parameters/Timezone" },
+          { "$ref": "#/components/parameters/TimezoneOffsetMinutes" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Daily usage data.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UsageDailyResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-usage-hourly": {
+      "get": {
+        "operationId": "getUsageHourly",
+        "tags": ["Usage Analytics"],
+        "summary": "Read half-hour token usage buckets for one day.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["usage:read"],
+        "parameters": [
+          {
+            "name": "day",
+            "in": "query",
+            "schema": { "type": "string", "format": "date" }
+          },
+          { "$ref": "#/components/parameters/Source" },
+          { "$ref": "#/components/parameters/Model" },
+          { "$ref": "#/components/parameters/Timezone" },
+          { "$ref": "#/components/parameters/TimezoneOffsetMinutes" },
+          { "$ref": "#/components/parameters/Debug" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Hourly usage data.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UsageHourlyResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-usage-monthly": {
+      "get": {
+        "operationId": "getUsageMonthly",
+        "tags": ["Usage Analytics"],
+        "summary": "Read monthly token usage aggregates.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["usage:read"],
+        "parameters": [
+          {
+            "name": "months",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 24, "default": 24 }
+          },
+          { "$ref": "#/components/parameters/ToDate" },
+          { "$ref": "#/components/parameters/Source" },
+          { "$ref": "#/components/parameters/Model" },
+          { "$ref": "#/components/parameters/Timezone" },
+          { "$ref": "#/components/parameters/TimezoneOffsetMinutes" },
+          { "$ref": "#/components/parameters/Debug" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Monthly usage data.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UsageMonthlyResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-usage-heatmap": {
+      "get": {
+        "operationId": "getUsageHeatmap",
+        "tags": ["Usage Analytics"],
+        "summary": "Read activity heatmap usage data.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["usage:read"],
+        "parameters": [
+          {
+            "name": "weeks",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 104, "default": 52 }
+          },
+          { "$ref": "#/components/parameters/ToDate" },
+          {
+            "name": "week_starts_on",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["sun", "mon"], "default": "sun" }
+          },
+          { "$ref": "#/components/parameters/Source" },
+          { "$ref": "#/components/parameters/Model" },
+          { "$ref": "#/components/parameters/Timezone" },
+          { "$ref": "#/components/parameters/TimezoneOffsetMinutes" },
+          { "$ref": "#/components/parameters/Debug" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Heatmap data.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UsageHeatmapResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-leaderboard": {
+      "get": {
+        "operationId": "getLeaderboard",
+        "tags": ["Public Sharing"],
+        "summary": "Read the public token usage leaderboard.",
+        "description": "Anonymous requests return public rows only. Authenticated requests may include the caller's private rank in me.",
+        "security": [{}, { "UserJWT": [] }],
+        "x-required-permissions": ["leaderboard:read"],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "enum": ["week", "month", "total"] }
+          },
+          {
+            "name": "metric",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["all", "gpt", "claude", "other"], "default": "all" }
+          },
+          { "$ref": "#/components/parameters/LimitLarge" },
+          { "$ref": "#/components/parameters/Offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard page.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LeaderboardResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/functions/vibeusage-leaderboard-profile": {
+      "get": {
+        "operationId": "getLeaderboardProfile",
+        "tags": ["Public Sharing"],
+        "summary": "Read one public leaderboard profile.",
+        "security": [{}, { "UserJWT": [] }],
+        "x-required-permissions": ["leaderboard:read"],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["week", "month", "total"], "default": "week" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard profile.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LeaderboardProfileResponse" }
+              }
+            }
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/functions/vibeusage-public-view-profile": {
+      "get": {
+        "operationId": "getPublicViewProfile",
+        "tags": ["Public Sharing"],
+        "summary": "Read privacy-safe public profile fields for a share token.",
+        "security": [{ "ShareToken": [] }],
+        "x-required-permissions": ["public_profile:read"],
+        "responses": {
+          "200": {
+            "description": "Public profile.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PublicProfileResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-public-visibility": {
+      "get": {
+        "operationId": "getPublicVisibility",
+        "tags": ["Public Sharing"],
+        "summary": "Read public visibility for the authenticated user.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["public_visibility:read"],
+        "responses": {
+          "200": {
+            "description": "Public visibility state.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PublicVisibilityResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      },
+      "post": {
+        "operationId": "setPublicVisibility",
+        "tags": ["Public Sharing"],
+        "summary": "Toggle public visibility for the authenticated user.",
+        "security": [{ "UserJWT": [] }],
+        "x-required-permissions": ["public_visibility:write"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/PublicVisibilityRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Public visibility state.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PublicVisibilityResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/functions/vibeusage-leaderboard-refresh": {
+      "post": {
+        "operationId": "refreshLeaderboard",
+        "tags": ["Admin"],
+        "summary": "Refresh leaderboard snapshots.",
+        "security": [{ "ServiceRoleKey": [] }],
+        "x-required-permissions": ["leaderboard:refresh"],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["week", "month", "total"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard refresh result.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AdminActionResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/functions/vibeusage-pricing-sync": {
+      "post": {
+        "operationId": "syncPricing",
+        "tags": ["Admin"],
+        "summary": "Sync model pricing metadata.",
+        "security": [{ "ServiceRoleKey": [] }],
+        "x-required-permissions": ["pricing:write"],
+        "responses": {
+          "200": {
+            "description": "Pricing sync result.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AdminActionResponse" }
+              }
+            }
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/functions/vibeusage-events-retention": {
+      "post": {
+        "operationId": "purgeEvents",
+        "tags": ["Admin"],
+        "summary": "Purge legacy tracker events older than a cutoff.",
+        "security": [{ "ServiceRoleKey": [] }],
+        "x-required-permissions": ["retention:write"],
+        "responses": {
+          "200": {
+            "description": "Retention result.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AdminActionResponse" }
+              }
+            }
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/functions/vibeusage-debug-auth": {
+      "get": {
+        "operationId": "debugAuth",
+        "tags": ["Diagnostics"],
+        "summary": "Report non-secret auth diagnostic state.",
+        "security": [{}, { "UserJWT": [] }],
+        "x-required-permissions": ["diagnostics:read"],
+        "responses": {
+          "200": {
+            "description": "Auth diagnostic state.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/DebugAuthResponse" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "UserJWT": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Hosted user session token. Use only for the signed-in user's analytics, public visibility settings, device-token issuance, and optional self-aware leaderboard reads.",
+        "x-vibeusage-role": "user",
+        "x-vibeusage-permissions": [
+          "usage:read",
+          "projects:read",
+          "user_status:read",
+          "device_tokens:write",
+          "public_visibility:read",
+          "public_visibility:write",
+          "leaderboard:read",
+          "diagnostics:read"
+        ]
+      },
+      "DeviceToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "opaque-device-token",
+        "description": "Scoped CLI device token. It can ingest usage and write sync heartbeats, but it cannot read analytics, user profile data, or admin endpoints.",
+        "x-vibeusage-role": "device",
+        "x-vibeusage-permissions": ["usage:ingest", "sync:write"]
+      },
+      "ShareToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "opaque-share-token",
+        "description": "Public share token scoped to privacy-safe public profile and shared dashboard reads.",
+        "x-vibeusage-role": "share",
+        "x-vibeusage-permissions": ["public_profile:read"]
+      },
+      "ServiceRoleKey": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "service-role-key",
+        "description": "Administrative service role credential. Never expose to browsers or AI agents that only need user-scoped usage data.",
+        "x-vibeusage-role": "service_role",
+        "x-vibeusage-permissions": [
+          "entitlements:write",
+          "leaderboard:refresh",
+          "pricing:write",
+          "retention:write"
+        ]
+      }
+    },
+    "parameters": {
+      "FromDate": {
+        "name": "from",
+        "in": "query",
+        "schema": { "type": "string", "format": "date" }
+      },
+      "ToDate": {
+        "name": "to",
+        "in": "query",
+        "schema": { "type": "string", "format": "date" }
+      },
+      "Source": {
+        "name": "source",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "examples": ["codex", "claude", "opencode", "gemini", "kimi", "hermes", "openclaw"]
+        }
+      },
+      "Model": {
+        "name": "model",
+        "in": "query",
+        "schema": { "type": "string", "examples": ["gpt-5.2-codex"] }
+      },
+      "Timezone": {
+        "name": "tz",
+        "in": "query",
+        "schema": { "type": "string", "examples": ["America/Los_Angeles", "Asia/Tokyo"] }
+      },
+      "TimezoneOffsetMinutes": {
+        "name": "tz_offset_minutes",
+        "in": "query",
+        "schema": { "type": "integer" }
+      },
+      "Debug": {
+        "name": "debug",
+        "in": "query",
+        "schema": { "type": "string", "enum": ["1"] }
+      },
+      "LimitSmall": {
+        "name": "limit",
+        "in": "query",
+        "schema": { "type": "integer", "minimum": 1, "maximum": 10, "default": 3 }
+      },
+      "LimitLarge": {
+        "name": "limit",
+        "in": "query",
+        "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 }
+      },
+      "Offset": {
+        "name": "offset",
+        "in": "query",
+        "schema": { "type": "integer", "minimum": 0, "maximum": 10000, "default": 0 }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Invalid request."
+      },
+      "Unauthorized": {
+        "description": "Missing or invalid bearer token."
+      },
+      "Forbidden": {
+        "description": "Authenticated credential does not have the required role."
+      },
+      "Conflict": {
+        "description": "Request conflicts with existing state."
+      }
+    },
+    "schemas": {
+      "TokenTotals": {
+        "type": "object",
+        "properties": {
+          "total_tokens": { "type": "string" },
+          "input_tokens": { "type": "string" },
+          "cached_input_tokens": { "type": "string" },
+          "output_tokens": { "type": "string" },
+          "reasoning_output_tokens": { "type": "string" },
+          "total_cost_usd": { "type": "string" }
+        },
+        "additionalProperties": true
+      },
+      "Pricing": {
+        "type": "object",
+        "properties": {
+          "model": { "type": ["string", "null"] },
+          "pricing_mode": { "type": "string" },
+          "source": { "type": "string" },
+          "effective_from": { "type": "string", "format": "date" }
+        },
+        "additionalProperties": true
+      },
+      "DeviceTokenIssueRequest": {
+        "type": "object",
+        "properties": {
+          "device_name": { "type": "string" },
+          "platform": { "type": "string" },
+          "user_id": { "type": "string", "format": "uuid" }
+        },
+        "additionalProperties": false
+      },
+      "DeviceTokenIssueResponse": {
+        "type": "object",
+        "properties": {
+          "device_id": { "type": "string", "format": "uuid" },
+          "token": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" }
+        },
+        "required": ["device_id", "token"]
+      },
+      "LinkCodeInitResponse": {
+        "type": "object",
+        "properties": {
+          "link_code": { "type": "string" },
+          "expires_at": { "type": "string", "format": "date-time" }
+        },
+        "required": ["link_code", "expires_at"]
+      },
+      "LinkCodeExchangeRequest": {
+        "type": "object",
+        "properties": {
+          "link_code": { "type": "string" },
+          "request_id": { "type": "string" },
+          "device_name": { "type": "string" },
+          "platform": { "type": "string" }
+        },
+        "required": ["link_code", "request_id"],
+        "additionalProperties": false
+      },
+      "LinkCodeExchangeResponse": {
+        "type": "object",
+        "properties": {
+          "token": { "type": "string" },
+          "device_id": { "type": "string", "format": "uuid" },
+          "user_id": { "type": "string", "format": "uuid" }
+        },
+        "required": ["token", "device_id", "user_id"]
+      },
+      "UsageBucket": {
+        "type": "object",
+        "properties": {
+          "hour_start": { "type": "string", "format": "date-time" },
+          "source": { "type": "string" },
+          "model": { "type": "string" },
+          "input_tokens": { "type": "integer", "minimum": 0 },
+          "cached_input_tokens": { "type": "integer", "minimum": 0 },
+          "output_tokens": { "type": "integer", "minimum": 0 },
+          "reasoning_output_tokens": { "type": "integer", "minimum": 0 },
+          "total_tokens": { "type": "integer", "minimum": 0 }
+        },
+        "required": ["hour_start", "total_tokens"]
+      },
+      "DeviceSubscription": {
+        "type": "object",
+        "properties": {
+          "tool": { "type": "string" },
+          "provider": { "type": "string" },
+          "product": { "type": "string" },
+          "planType": { "type": "string" },
+          "rateLimitTier": { "type": "string" }
+        },
+        "additionalProperties": true
+      },
+      "IngestRequest": {
+        "type": "object",
+        "properties": {
+          "hourly": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/UsageBucket" }
+          },
+          "device_subscriptions": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/DeviceSubscription" }
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "hourly": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/UsageBucket" }
+              }
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "IngestResponse": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean" },
+          "inserted": { "type": "integer" },
+          "skipped": { "type": "integer" },
+          "project_inserted": { "type": "integer" },
+          "project_skipped": { "type": "integer" }
+        },
+        "required": ["success"]
+      },
+      "SyncPingResponse": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean" },
+          "updated": { "type": "boolean" },
+          "last_sync_at": { "type": "string", "format": "date-time" },
+          "min_interval_minutes": { "type": "integer" }
+        },
+        "required": ["success"]
+      },
+      "UserStatusResponse": {
+        "type": "object",
+        "properties": {
+          "user_id": { "type": "string", "format": "uuid" },
+          "created_at": { "type": ["string", "null"], "format": "date-time" },
+          "pro": { "type": "object", "additionalProperties": true },
+          "subscriptions": { "type": "object", "additionalProperties": true }
+        },
+        "additionalProperties": true
+      },
+      "UsageSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "from": { "type": "string", "format": "date" },
+          "to": { "type": "string", "format": "date" },
+          "days": { "type": "integer" },
+          "model_id": { "type": ["string", "null"] },
+          "model": { "type": ["string", "null"] },
+          "totals": { "$ref": "#/components/schemas/TokenTotals" },
+          "pricing": { "$ref": "#/components/schemas/Pricing" }
+        },
+        "required": ["totals"]
+      },
+      "ProjectUsageSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "all_time": { "type": "boolean" },
+          "generated_at": { "type": "string", "format": "date-time" },
+          "entries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "project_key": { "type": "string" },
+                "project_ref": { "type": "string" },
+                "total_tokens": { "type": "string" },
+                "billable_total_tokens": { "type": "string" }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "required": ["entries"]
+      },
+      "UsageModelBreakdownResponse": {
+        "type": "object",
+        "properties": {
+          "from": { "type": "string", "format": "date" },
+          "to": { "type": "string", "format": "date" },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "source": { "type": "string" },
+                "totals": { "$ref": "#/components/schemas/TokenTotals" },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "model_id": { "type": "string" },
+                      "model": { "type": "string" },
+                      "totals": { "$ref": "#/components/schemas/TokenTotals" }
+                    },
+                    "additionalProperties": true
+                  }
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "pricing": { "$ref": "#/components/schemas/Pricing" }
+        },
+        "required": ["sources"]
+      },
+      "UsageDailyResponse": {
+        "type": "object",
+        "properties": {
+          "from": { "type": "string", "format": "date" },
+          "to": { "type": "string", "format": "date" },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "day": { "type": "string", "format": "date" },
+                "total_tokens": { "type": "string" }
+              },
+              "additionalProperties": true
+            }
+          },
+          "summary": { "type": "object", "additionalProperties": true }
+        },
+        "required": ["data"]
+      },
+      "UsageHourlyResponse": {
+        "type": "object",
+        "properties": {
+          "day": { "type": "string", "format": "date" },
+          "data": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": true }
+          },
+          "sync": { "type": "object", "additionalProperties": true }
+        },
+        "required": ["data"]
+      },
+      "UsageMonthlyResponse": {
+        "type": "object",
+        "properties": {
+          "from": { "type": "string", "format": "date" },
+          "to": { "type": "string", "format": "date" },
+          "months": { "type": "integer" },
+          "data": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": true }
+          }
+        },
+        "required": ["data"]
+      },
+      "UsageHeatmapResponse": {
+        "type": "object",
+        "properties": {
+          "from": { "type": "string", "format": "date" },
+          "to": { "type": "string", "format": "date" },
+          "week_starts_on": { "type": "string" },
+          "thresholds": { "type": "object", "additionalProperties": true },
+          "active_days": { "type": "integer" },
+          "streak_days": { "type": "integer" },
+          "weeks": {
+            "type": "array",
+            "items": { "type": "array" }
+          }
+        },
+        "required": ["weeks"]
+      },
+      "LeaderboardResponse": {
+        "type": "object",
+        "properties": {
+          "period": { "type": "string" },
+          "metric": { "type": "string" },
+          "entries": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": true }
+          },
+          "me": { "type": ["object", "null"], "additionalProperties": true }
+        },
+        "required": ["entries"]
+      },
+      "LeaderboardProfileResponse": {
+        "type": "object",
+        "properties": {
+          "period": { "type": "string" },
+          "entry": { "type": "object", "additionalProperties": true }
+        },
+        "required": ["entry"]
+      },
+      "PublicProfileResponse": {
+        "type": "object",
+        "properties": {
+          "display_name": { "type": ["string", "null"] },
+          "avatar_url": { "type": ["string", "null"], "format": "uri" }
+        }
+      },
+      "PublicVisibilityRequest": {
+        "type": "object",
+        "properties": {
+          "enabled": { "type": "boolean" }
+        },
+        "required": ["enabled"],
+        "additionalProperties": false
+      },
+      "PublicVisibilityResponse": {
+        "type": "object",
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "updated_at": { "type": "string", "format": "date-time" },
+          "share_token": { "type": "string" }
+        },
+        "required": ["enabled"]
+      },
+      "AdminActionResponse": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "DebugAuthResponse": {
+        "type": "object",
+        "properties": {
+          "hasAnonKey": { "type": "boolean" },
+          "hasBearer": { "type": "boolean" },
+          "authOk": { "type": "boolean" },
+          "userId": { "type": ["string", "null"], "format": "uuid" },
+          "error": { "type": ["string", "null"] }
+        },
+        "required": ["hasAnonKey", "hasBearer", "authOk"]
+      }
+    }
+  },
+  "externalDocs": {
+    "description": "VibeUsage developer resources",
+    "url": "https://www.vibeusage.cc/developers"
+  },
+  "x-agent-discovery": {
+    "llms": "https://www.vibeusage.cc/llms.txt",
+    "mcp_manifest": "https://www.vibeusage.cc/.well-known/mcp/manifest.json",
+    "auth_docs": "https://www.vibeusage.cc/docs/auth",
+    "webhooks_docs": "https://www.vibeusage.cc/docs/webhooks"
+  }
+}

--- a/dashboard/public/robots.txt
+++ b/dashboard/public/robots.txt
@@ -4,4 +4,7 @@ Sitemap: https://www.vibeusage.cc/sitemap.xml
 
 # AI/agent discovery helpers
 # llms: https://www.vibeusage.cc/llms.txt
+# openapi: https://www.vibeusage.cc/openapi.json
+# mcp: https://www.vibeusage.cc/.well-known/mcp/manifest.json
+# developers: https://www.vibeusage.cc/developers
 # feed: https://www.vibeusage.cc/feed.xml

--- a/dashboard/public/sitemap.xml
+++ b/dashboard/public/sitemap.xml
@@ -10,4 +10,49 @@
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://www.vibeusage.cc/developers</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/openapi.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/docs/api</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/docs/auth</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/docs/webhooks</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/mcp</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/.well-known/mcp/manifest.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/compare/ai-token-usage-tracking</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/guides/ai-token-usage-monitoring</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -43,6 +43,7 @@ import { isMockEnabled } from "./lib/mock-data";
 import { fetchLatestTrackerVersion } from "./lib/npm-version";
 import { isScreenshotModeEnabled } from "./lib/screenshot-mode";
 import { probeBackend } from "./lib/vibeusage-api";
+import { resolveAgentResourceRoute } from "./pages/agent-resource-routes.js";
 import { LandingPage } from "./pages/LandingPage.jsx";
 import { UpgradeAlertModal } from "./ui/matrix-a/components/UpgradeAlertModal.jsx";
 import { VersionBadge } from "./ui/matrix-a/components/VersionBadge.jsx";
@@ -71,6 +72,12 @@ const LeaderboardPage = React.lazy(() =>
 const LeaderboardProfilePage = React.lazy(() =>
   import("./pages/LeaderboardProfilePage.jsx").then((mod) => ({
     default: mod.LeaderboardProfilePage,
+  })),
+);
+
+const AgentResourcePage = React.lazy(() =>
+  import("./pages/AgentResourcePage.jsx").then((mod) => ({
+    default: mod.AgentResourcePage,
   })),
 );
 
@@ -388,8 +395,12 @@ export default function App() {
   }, [insforgeLoaded, insforgeSession, navigate, signInUrl]);
 
   const loadingShell = <div className="min-h-screen bg-surface" />;
+  const normalizedPath = pathname.replace(/\/+$/, "") || "/";
+  const agentResourceRoute = resolveAgentResourceRoute(normalizedPath);
+  const agentResourceMode = Boolean(agentResourceRoute);
   const authPending =
     !publicMode &&
+    !agentResourceMode &&
     !mockEnabled &&
     !sessionSoftExpired &&
     (!insforgeLoaded || insforgeSession === undefined);
@@ -400,7 +411,6 @@ export default function App() {
     signedIn,
     authPending,
   });
-  const normalizedPath = pathname.replace(/\/+$/, "") || "/";
   const leaderboardProfileMatch = normalizedPath.match(/^\/leaderboard\/u\/([^/]+)$/i);
   const leaderboardProfileUserId = leaderboardProfileMatch ? leaderboardProfileMatch[1] : null;
   const PageComponent = leaderboardProfileUserId
@@ -409,7 +419,13 @@ export default function App() {
       ? LeaderboardPage
       : DashboardPage;
   let content = null;
-  if (gate === "loading") {
+  if (agentResourceMode) {
+    content = (
+      <Suspense fallback={loadingShell}>
+        <AgentResourcePage route={agentResourceRoute} />
+      </Suspense>
+    );
+  } else if (gate === "loading") {
     content = loadingShell;
   } else if (gate === "landing") {
     content = <LandingPage signInUrl={signInUrl} signUpUrl={signUpUrl} />;

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -77,6 +77,90 @@ landing.footer.link.manifesto,landing,LandingPage,LandingPage,footer_link_manife
 landing.footer.link.docs,landing,LandingPage,LandingPage,footer_link_docs,"Docs",,active
 landing.footer.link.security,landing,LandingPage,LandingPage,footer_link_security,"Security",,active
 landing.footer.system_ready,landing,LandingPage,LandingPage,footer_system_ready,"System_Ready // 2024 VibeUsage OS",,active
+agent.nav.home,agent,AgentResourcePage,AgentResourcePage,nav_home,"VibeUsage Home",,active
+agent.item.prefix,agent,AgentResourcePage,AgentResourcePage,item_prefix,"Signal {{index}}",,active
+agent.related.title,agent,AgentResourcePage,AgentResourcePage,related_title,"Related Resources",,active
+agent.link.openapi.label,agent,AgentResourcePage,AgentResourcePage,link_label,"OpenAPI JSON",,active
+agent.link.openapi.url,agent,AgentResourcePage,AgentResourcePage,link_url,"/openapi.json",,active
+agent.link.api.label,agent,AgentResourcePage,AgentResourcePage,link_label,"API Docs",,active
+agent.link.api.url,agent,AgentResourcePage,AgentResourcePage,link_url,"/docs/api",,active
+agent.link.auth.label,agent,AgentResourcePage,AgentResourcePage,link_label,"Auth and Permissions",,active
+agent.link.auth.url,agent,AgentResourcePage,AgentResourcePage,link_url,"/docs/auth",,active
+agent.link.webhooks.label,agent,AgentResourcePage,AgentResourcePage,link_label,"Webhook Status",,active
+agent.link.webhooks.url,agent,AgentResourcePage,AgentResourcePage,link_url,"/docs/webhooks",,active
+agent.link.mcp.label,agent,AgentResourcePage,AgentResourcePage,link_label,"MCP Server Info",,active
+agent.link.mcp.url,agent,AgentResourcePage,AgentResourcePage,link_url,"/mcp",,active
+agent.link.mcpManifest.label,agent,AgentResourcePage,AgentResourcePage,link_label,"MCP Manifest JSON",,active
+agent.link.mcpManifest.url,agent,AgentResourcePage,AgentResourcePage,link_url,"/.well-known/mcp/manifest.json",,active
+agent.link.developers.label,agent,AgentResourcePage,AgentResourcePage,link_label,"Developer Portal",,active
+agent.link.developers.url,agent,AgentResourcePage,AgentResourcePage,link_url,"/developers",,active
+agent.link.comparison.label,agent,AgentResourcePage,AgentResourcePage,link_label,"AI Token Usage Comparison",,active
+agent.link.comparison.url,agent,AgentResourcePage,AgentResourcePage,link_url,"/compare/ai-token-usage-tracking",,active
+agent.link.guide.label,agent,AgentResourcePage,AgentResourcePage,link_label,"Monitoring Guide",,active
+agent.link.guide.url,agent,AgentResourcePage,AgentResourcePage,link_url,"/guides/ai-token-usage-monitoring",,active
+agent.developers.meta_title,agent,AgentResourcePage,AgentResourcePage,meta_title,"VibeUsage Developer Portal - API Docs OpenAPI Auth MCP",,active
+agent.developers.meta_description,agent,AgentResourcePage,AgentResourcePage,meta_description,"Developer resources for VibeUsage API docs, OpenAPI, authentication, scoped permissions, webhook status, and MCP agent integration.",,active
+agent.developers.kicker,agent,AgentResourcePage,AgentResourcePage,kicker,"Developer Portal",,active
+agent.developers.title,agent,AgentResourcePage,AgentResourcePage,title,"VibeUsage Developer Resources for AI Agents",,active
+agent.developers.summary,agent,AgentResourcePage,AgentResourcePage,summary,"Find VibeUsage API docs, OpenAPI, auth, scoped permissions, webhook status, MCP discovery, and agent integration resources from one predictable URL.",,active
+agent.developers.item1,agent,AgentResourcePage,AgentResourcePage,item,"Use /openapi.json when an agent needs the machine-readable API surface for token usage summaries, model breakdowns, ingestion, public sharing, and admin maintenance.",,active
+agent.developers.item2,agent,AgentResourcePage,AgentResourcePage,item,"Use /docs/auth to choose the narrowest credential role: user JWT, device token, share token, or service role.",,active
+agent.developers.item3,agent,AgentResourcePage,AgentResourcePage,item,"Use /.well-known/mcp/manifest.json for agent discovery and /mcp for MCP integration status.",,active
+agent.developers.item4,agent,AgentResourcePage,AgentResourcePage,item,"Use the comparison and monitoring guide pages when researching AI token usage tracking and monitoring tools by category.",,active
+agent.api.meta_title,agent,AgentResourcePage,AgentResourcePage,meta_title,"VibeUsage API Docs - AI Token Usage Tracking API",,active
+agent.api.meta_description,agent,AgentResourcePage,AgentResourcePage,meta_description,"VibeUsage API docs for AI token usage tracking, monitoring, ingestion, dashboard analytics, and public leaderboard endpoints.",,active
+agent.api.kicker,agent,AgentResourcePage,AgentResourcePage,kicker,"API Docs",,active
+agent.api.title,agent,AgentResourcePage,AgentResourcePage,title,"VibeUsage API Docs for AI Token Usage Tracking",,active
+agent.api.summary,agent,AgentResourcePage,AgentResourcePage,summary,"The VibeUsage API exposes scoped InsForge Edge Function endpoints for CLI ingestion, usage monitoring, model analytics, project summaries, public sharing, and leaderboard reads.",,active
+agent.api.item1,agent,AgentResourcePage,AgentResourcePage,item,"Read user analytics with usage:read endpoints such as /functions/vibeusage-usage-summary, /functions/vibeusage-usage-daily, and /functions/vibeusage-usage-model-breakdown.",,active
+agent.api.item2,agent,AgentResourcePage,AgentResourcePage,item,"Upload CLI usage with a device token through /functions/vibeusage-ingest and record sync health through /functions/vibeusage-sync-ping.",,active
+agent.api.item3,agent,AgentResourcePage,AgentResourcePage,item,"Read public leaderboard data anonymously or with a user JWT through /functions/vibeusage-leaderboard and /functions/vibeusage-leaderboard-profile.",,active
+agent.api.item4,agent,AgentResourcePage,AgentResourcePage,item,"Use the OpenAPI document for request schemas, response schemas, security schemes, and required permissions.",,active
+agent.auth.meta_title,agent,AgentResourcePage,AgentResourcePage,meta_title,"VibeUsage Auth Docs - Scoped Permissions for AI Agents",,active
+agent.auth.meta_description,agent,AgentResourcePage,AgentResourcePage,meta_description,"VibeUsage authentication docs covering scoped user JWTs, device tokens, share tokens, service role credentials, and agent permission boundaries.",,active
+agent.auth.kicker,agent,AgentResourcePage,AgentResourcePage,kicker,"Auth and Access",,active
+agent.auth.title,agent,AgentResourcePage,AgentResourcePage,title,"VibeUsage Auth Docs and Scoped Permissions",,active
+agent.auth.summary,agent,AgentResourcePage,AgentResourcePage,summary,"VibeUsage separates access by credential role so agents can request the least powerful token needed for the task.",,active
+agent.auth.item1,agent,AgentResourcePage,AgentResourcePage,item,"User JWTs read the signed-in user's analytics, issue device tokens, manage public visibility, and read optional self-aware leaderboard context.",,active
+agent.auth.item2,agent,AgentResourcePage,AgentResourcePage,item,"Device tokens are limited to usage ingestion and sync heartbeat writes; they cannot read dashboards, public profiles, or admin endpoints.",,active
+agent.auth.item3,agent,AgentResourcePage,AgentResourcePage,item,"Share tokens are limited to privacy-safe public profile and shared dashboard reads.",,active
+agent.auth.item4,agent,AgentResourcePage,AgentResourcePage,item,"Service role keys are admin credentials for maintenance jobs and must never be exposed to browser clients or general-purpose agents.",,active
+agent.webhooks.meta_title,agent,AgentResourcePage,AgentResourcePage,meta_title,"VibeUsage Webhooks - Integration Status",,active
+agent.webhooks.meta_description,agent,AgentResourcePage,AgentResourcePage,meta_description,"Webhook status for VibeUsage developer integrations and agent-readiness discovery.",,active
+agent.webhooks.kicker,agent,AgentResourcePage,AgentResourcePage,kicker,"Webhooks",,active
+agent.webhooks.title,agent,AgentResourcePage,AgentResourcePage,title,"VibeUsage Webhook Status",,active
+agent.webhooks.summary,agent,AgentResourcePage,AgentResourcePage,summary,"VibeUsage does not currently expose outbound webhooks; integrations should use scoped read endpoints, sync heartbeat state, and the MCP/OpenAPI resources listed here.",,active
+agent.webhooks.item1,agent,AgentResourcePage,AgentResourcePage,item,"For current usage state, call user-scoped usage analytics endpoints with usage:read.",,active
+agent.webhooks.item2,agent,AgentResourcePage,AgentResourcePage,item,"For sync freshness, use the sync fields returned by hourly usage and the device heartbeat endpoint.",,active
+agent.webhooks.item3,agent,AgentResourcePage,AgentResourcePage,item,"For future webhook requests, open a GitHub issue with the event type, delivery target, and replay requirements.",,active
+agent.webhooks.item4,agent,AgentResourcePage,AgentResourcePage,item,"Agents should treat this page as the canonical webhook capability statement until a webhook API appears in OpenAPI.",,active
+agent.mcp.meta_title,agent,AgentResourcePage,AgentResourcePage,meta_title,"VibeUsage MCP Server and Manifest for AI Agents",,active
+agent.mcp.meta_description,agent,AgentResourcePage,AgentResourcePage,meta_description,"VibeUsage MCP discovery resources for AI agents, including manifest JSON, OpenAPI links, and supported tool intents.",,active
+agent.mcp.kicker,agent,AgentResourcePage,AgentResourcePage,kicker,"MCP Integration",,active
+agent.mcp.title,agent,AgentResourcePage,AgentResourcePage,title,"VibeUsage MCP Server and Manifest",,active
+agent.mcp.summary,agent,AgentResourcePage,AgentResourcePage,summary,"VibeUsage publishes a valid MCP manifest for agent discovery and maps common agent tools to OpenAPI operations for usage summaries, model breakdowns, and public leaderboard reads.",,active
+agent.mcp.item1,agent,AgentResourcePage,AgentResourcePage,item,"The MCP manifest is available at /.well-known/mcp/manifest.json and declares Streamable HTTP transport metadata for agent scanners.",,active
+agent.mcp.item2,agent,AgentResourcePage,AgentResourcePage,item,"The manifest points agents to /openapi.json so they can inspect request schemas and scoped permissions automatically.",,active
+agent.mcp.item3,agent,AgentResourcePage,AgentResourcePage,item,"Initial tool intents cover usage summary reads, model breakdown reads, and public leaderboard reads.",,active
+agent.mcp.item4,agent,AgentResourcePage,AgentResourcePage,item,"Agents that need write access should prefer scoped device-token ingestion rather than user or service-role credentials.",,active
+agent.comparison.meta_title,agent,AgentResourcePage,AgentResourcePage,meta_title,"AI Token Usage Tracking Tools - VibeUsage Comparison",,active
+agent.comparison.meta_description,agent,AgentResourcePage,AgentResourcePage,meta_description,"Compare AI token usage tracking and monitoring tools for coding agents, CLI usage analytics, scoped access, and agent integration.",,active
+agent.comparison.kicker,agent,AgentResourcePage,AgentResourcePage,kicker,"Comparison",,active
+agent.comparison.title,agent,AgentResourcePage,AgentResourcePage,title,"AI Token Usage Tracking and Monitoring Tools",,active
+agent.comparison.summary,agent,AgentResourcePage,AgentResourcePage,summary,"VibeUsage is built for developers who need auditable AI CLI token usage tracking across multiple coding agents without collecting prompts or responses.",,active
+agent.comparison.item1,agent,AgentResourcePage,AgentResourcePage,item,"Choose VibeUsage when the core need is tracking Codex, Claude Code, OpenCode, Gemini, Kimi, Hermes, and OpenClaw token usage from local developer workflows.",,active
+agent.comparison.item2,agent,AgentResourcePage,AgentResourcePage,item,"Use VibeUsage for dashboard analytics, project totals, model breakdowns, cost estimates, and public token leaderboards.",,active
+agent.comparison.item3,agent,AgentResourcePage,AgentResourcePage,item,"Use the OpenAPI and MCP manifest when an AI agent needs to discover the API surface and request scoped access.",,active
+agent.comparison.item4,agent,AgentResourcePage,AgentResourcePage,item,"Use another observability platform when you need prompt traces, application logs, or production APM instead of local AI CLI token accounting.",,active
+agent.guide.meta_title,agent,AgentResourcePage,AgentResourcePage,meta_title,"AI Token Usage Monitoring Guide - VibeUsage",,active
+agent.guide.meta_description,agent,AgentResourcePage,AgentResourcePage,meta_description,"Guide to monitoring AI token usage across coding agents with VibeUsage, including install flow, scoped ingestion, dashboards, and API resources.",,active
+agent.guide.kicker,agent,AgentResourcePage,AgentResourcePage,kicker,"Guide",,active
+agent.guide.title,agent,AgentResourcePage,AgentResourcePage,title,"How to Monitor AI Token Usage Across Coding Agents",,active
+agent.guide.summary,agent,AgentResourcePage,AgentResourcePage,summary,"Install VibeUsage locally, connect an account, sync AI CLI usage with a scoped device token, and inspect token totals through the dashboard or API.",,active
+agent.guide.item1,agent,AgentResourcePage,AgentResourcePage,item,"Install with npx --yes vibeusage init and complete the browser link flow to create a scoped device token.",,active
+agent.guide.item2,agent,AgentResourcePage,AgentResourcePage,item,"Run sync from the CLI to upload half-hour aggregates for supported AI coding agents.",,active
+agent.guide.item3,agent,AgentResourcePage,AgentResourcePage,item,"Use dashboard views or usage:read API endpoints to monitor daily totals, model mix, project totals, heatmaps, and estimated cost.",,active
+agent.guide.item4,agent,AgentResourcePage,AgentResourcePage,item,"Use llms.txt, OpenAPI, and the MCP manifest when delegating setup or reporting tasks to an AI agent.",,active
 
 
 shell.header.title,ui,MatrixShell,MatrixShell,header_title,"VIBE USAGE",,active

--- a/dashboard/src/pages/AgentResourcePage.jsx
+++ b/dashboard/src/pages/AgentResourcePage.jsx
@@ -1,0 +1,81 @@
+/* eslint-disable react/prop-types */
+import React, { useEffect, useMemo } from "react";
+import { copy } from "../lib/copy";
+import { AGENT_RESOURCE_ROUTES } from "./agent-resource-routes.js";
+
+function readItems(baseKey, count) {
+  return Array.from({ length: count }, (_, index) => copy(`${baseKey}.item${index + 1}`));
+}
+
+function ResourceLink({ id }) {
+  return (
+    <a
+      href={copy(`agent.link.${id}.url`)}
+      className="border border-ink-line bg-surface/70 px-4 py-3 text-caption uppercase tracking-label text-ink-text transition-colors hover:border-ink hover:text-ink"
+    >
+      {copy(`agent.link.${id}.label`)}
+    </a>
+  );
+}
+
+export function AgentResourcePage({ route }) {
+  const routeConfig = route || AGENT_RESOURCE_ROUTES["/developers"];
+  const baseKey = `agent.${routeConfig.key}`;
+  const items = useMemo(() => readItems(baseKey, 4), [baseKey]);
+
+  useEffect(() => {
+    document.title = copy(`${baseKey}.meta_title`);
+    const metaDescription = document.querySelector('meta[name="description"]');
+    if (metaDescription) {
+      metaDescription.setAttribute("content", copy(`${baseKey}.meta_description`));
+    }
+  }, [baseKey]);
+
+  return (
+    <div className="min-h-screen bg-surface font-mono text-ink selection:bg-ink selection:text-surface">
+      <div className="fixed inset-0 z-0 opacity-20">
+        <div className="absolute inset-0 fx-grid" />
+      </div>
+      <div className="pointer-events-none fixed inset-0 z-50 fx-scanline" />
+
+      <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-8 px-5 py-10 sm:px-8 lg:px-10">
+        <header className="flex flex-col gap-5 border-b border-ink-line pb-8">
+          <a href="/" className="text-caption uppercase tracking-caps text-ink-muted hover:text-ink">
+            {copy("agent.nav.home")}
+          </a>
+          <div className="space-y-4">
+            <p className="text-micro uppercase tracking-caps text-ink-muted">
+              {copy(`${baseKey}.kicker`)}
+            </p>
+            <h1 className="max-w-4xl text-display-3 font-black uppercase leading-tight text-ink-bright sm:text-display-2">
+              {copy(`${baseKey}.title`)}
+            </h1>
+            <p className="max-w-3xl text-body leading-relaxed text-ink-text">
+              {copy(`${baseKey}.summary`)}
+            </p>
+          </div>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2">
+          {items.map((item, index) => (
+            <div key={item} className="border border-ink-line bg-surface/70 p-5">
+              <span className="text-micro uppercase tracking-caps text-ink-muted">
+                {copy("agent.item.prefix", { index: String(index + 1).padStart(2, "0") })}
+              </span>
+              <p className="mt-3 text-body leading-relaxed text-ink-text">{item}</p>
+            </div>
+          ))}
+        </section>
+
+        <section className="space-y-4 border-t border-ink-line pt-8">
+          <h2 className="text-heading font-bold uppercase text-ink">{copy("agent.related.title")}</h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {routeConfig.links.map((id) => (
+              <ResourceLink key={id} id={id} />
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/dashboard/src/pages/agent-resource-routes.js
+++ b/dashboard/src/pages/agent-resource-routes.js
@@ -1,0 +1,35 @@
+export const AGENT_RESOURCE_ROUTES = {
+  "/developers": {
+    key: "developers",
+    links: ["openapi", "api", "auth", "webhooks", "mcp", "comparison", "guide"],
+  },
+  "/docs/api": {
+    key: "api",
+    links: ["openapi", "auth", "mcp", "developers"],
+  },
+  "/docs/auth": {
+    key: "auth",
+    links: ["openapi", "api", "developers"],
+  },
+  "/docs/webhooks": {
+    key: "webhooks",
+    links: ["openapi", "api", "developers"],
+  },
+  "/mcp": {
+    key: "mcp",
+    links: ["mcpManifest", "openapi", "api", "developers"],
+  },
+  "/compare/ai-token-usage-tracking": {
+    key: "comparison",
+    links: ["guide", "developers", "openapi"],
+  },
+  "/guides/ai-token-usage-monitoring": {
+    key: "guide",
+    links: ["comparison", "developers", "openapi"],
+  },
+};
+
+export function resolveAgentResourceRoute(pathname) {
+  const normalizedPath = String(pathname || "/").replace(/\/+$/, "") || "/";
+  return AGENT_RESOURCE_ROUTES[normalizedPath] || null;
+}

--- a/docs/repo-sitemap.md
+++ b/docs/repo-sitemap.md
@@ -90,6 +90,8 @@ This document is the single source of truth for repository navigation. Use it to
   - `dashboard/src/content/copy.csv`
 - Public web assets:
   - `dashboard/public/`
+  - Agent-readiness discovery assets live in `dashboard/public/openapi.json`, `dashboard/public/.well-known/mcp/manifest.json`, `dashboard/public/llms.txt`, and `dashboard/public/sitemap.xml`.
+  - Public developer-resource routes start at `dashboard/src/pages/AgentResourcePage.jsx`.
 - Model display rule:
   - Usage dashboards should prefer backend-provided `display_model` for presentation.
   - `model_id` remains the only canonical key for filtering, pricing, and aggregation.

--- a/test/agent-readiness-public-assets.test.js
+++ b/test/agent-readiness-public-assets.test.js
@@ -1,0 +1,81 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const root = path.resolve(__dirname, "..");
+
+function read(relPath) {
+  return fs.readFileSync(path.join(root, relPath), "utf8");
+}
+
+function readJson(relPath) {
+  return JSON.parse(read(relPath));
+}
+
+test("public OpenAPI spec exposes security schemes and scoped permissions", () => {
+  const spec = readJson("dashboard/public/openapi.json");
+  const schemes = spec.components.securitySchemes;
+
+  assert.equal(spec.openapi, "3.1.0");
+  assert.equal(spec.info.title, "VibeUsage API");
+  assert.ok(spec.paths["/functions/vibeusage-usage-summary"]);
+  assert.ok(spec.paths["/functions/vibeusage-ingest"]);
+  assert.ok(schemes.UserJWT);
+  assert.ok(schemes.DeviceToken);
+  assert.ok(schemes.ShareToken);
+  assert.ok(schemes.ServiceRoleKey);
+  assert.ok(schemes.UserJWT["x-vibeusage-permissions"].includes("usage:read"));
+  assert.ok(schemes.DeviceToken["x-vibeusage-permissions"].includes("usage:ingest"));
+  assert.ok(
+    spec.paths["/functions/vibeusage-usage-summary"].get["x-required-permissions"].includes(
+      "usage:read",
+    ),
+  );
+});
+
+test("MCP manifest is valid JSON and points agents to OpenAPI", () => {
+  const manifest = readJson("dashboard/public/.well-known/mcp/manifest.json");
+
+  assert.equal(manifest.name, "VibeUsage");
+  assert.equal(manifest.openapi_url, "https://www.vibeusage.cc/openapi.json");
+  assert.equal(manifest.transport_status, "documented");
+  assert.equal(manifest.transport, undefined);
+  assert.ok(manifest.auth.permissions_supported.includes("usage:read"));
+  assert.ok(manifest.tools.some((tool) => tool.name === "get_usage_summary"));
+});
+
+test("llms and sitemap include developer discovery resources", () => {
+  const llms = read("dashboard/public/llms.txt");
+  const sitemap = read("dashboard/public/sitemap.xml");
+
+  for (const url of [
+    "https://www.vibeusage.cc/developers",
+    "https://www.vibeusage.cc/openapi.json",
+    "https://www.vibeusage.cc/docs/api",
+    "https://www.vibeusage.cc/docs/auth",
+    "https://www.vibeusage.cc/docs/webhooks",
+    "https://www.vibeusage.cc/mcp",
+    "https://www.vibeusage.cc/compare/ai-token-usage-tracking",
+    "https://www.vibeusage.cc/guides/ai-token-usage-monitoring",
+  ]) {
+    assert.ok(llms.includes(url), `llms.txt should include ${url}`);
+    assert.ok(sitemap.includes(url), `sitemap.xml should include ${url}`);
+  }
+});
+
+test("developer discovery pages have no-JS static HTML fallbacks", () => {
+  for (const relPath of [
+    "dashboard/public/developers/index.html",
+    "dashboard/public/docs/api/index.html",
+    "dashboard/public/docs/auth/index.html",
+    "dashboard/public/docs/webhooks/index.html",
+    "dashboard/public/mcp/index.html",
+    "dashboard/public/compare/ai-token-usage-tracking/index.html",
+    "dashboard/public/guides/ai-token-usage-monitoring/index.html",
+  ]) {
+    const html = read(relPath);
+    assert.match(html, /<h1>[^<]*VibeUsage|<h1>AI Token Usage|<h1>How to Monitor/);
+    assert.ok(!html.includes('id="root"'), `${relPath} should not require React hydration`);
+  }
+});


### PR DESCRIPTION
# What does this PR do?

- Improves VibeUsage agent-readiness for orank by publishing predictable developer resources, OpenAPI, scoped auth metadata, valid MCP discovery JSON, and no-JS discovery pages.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [x] Risk / contract change

## Changes Made

- Add `dashboard/public/openapi.json` with VibeUsage API paths, security schemes, and operation-level permission metadata.
- Add `dashboard/public/.well-known/mcp/manifest.json` as valid MCP discovery metadata pointing to OpenAPI tool mappings.
- Add no-JS public discovery fallbacks under `/developers`, `/docs/api`, `/docs/auth`, `/docs/webhooks`, `/mcp`, `/compare/ai-token-usage-tracking`, and `/guides/ai-token-usage-monitoring`.
- Add SPA resource routes for the same discovery pages and sync copy registry text.
- Expand `llms.txt`, `robots.txt`, and `sitemap.xml` with developer and category discovery URLs.
- Add regression coverage for OpenAPI, MCP manifest, llms/sitemap links, and no-JS fallbacks.

## Affected Modules / Contracts

- **Modules touched:** `dashboard/public`, `dashboard/src/App.jsx`, `dashboard/src/pages/AgentResourcePage.jsx`, `dashboard/src/content/copy.csv`, `test/agent-readiness-public-assets.test.js`
- **Dependencies / contracts touched:** Public discovery URLs, OpenAPI document, MCP discovery manifest, unauthenticated static docs pages
- **Repo sitemap evidence:** `updated` / Dashboard public web assets section

## Validation

### Automated

- `node --test test/agent-readiness-public-assets.test.js` - pass
- `npm run validate:copy` - pass, existing unused-key warnings only
- `npm run validate:ui-hardcode` - pass
- `git diff --check` - pass
- `npm --prefix dashboard run build` - pass, existing chunk-size warning only

### Manual / smoke

- Verified `dashboard/dist` includes `openapi.json`, `.well-known/mcp/manifest.json`, `developers/index.html`, `docs/api/index.html`, and `mcp/index.html` after build.
- Checked current cached orank score before deployment: `GET https://ora.run/api/score/vibeusage.cc` still returns 56/C because this branch was not deployed yet.

### Uncovered scope

- Live orank rescan is not meaningful until this PR is merged and deployed to `vibeusage.cc`.
- This PR publishes MCP discovery metadata, not a callable Streamable HTTP MCP transport.

## Risk Flags

- [x] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

- Public pages expose documentation only, not user data, tokens, or backend secrets.
- OpenAPI documents existing endpoint contracts and credential roles; it does not grant access.
- MCP manifest must be valid JSON and must not claim a callable transport until one exists.

### Boundary Matrix (must list at least 3)

- `/openapi.json`: unauthenticated static JSON, exposes API schema and scoped permissions only.
- `/.well-known/mcp/manifest.json`: unauthenticated static JSON, exposes discovery metadata and OpenAPI tool refs only.
- `/developers` and `/docs/*`: unauthenticated static HTML/SPA docs, expose documentation text only.
- `/functions/vibeusage-*`: unchanged live InsForge auth boundaries remain authoritative.

### Evidence

- `test/agent-readiness-public-assets.test.js` validates OpenAPI security schemes, MCP manifest JSON, llms/sitemap discovery URLs, and static HTML fallbacks.
- `npm --prefix dashboard run build` confirms the public assets are emitted into `dashboard/dist`.

## Public Exposure Addendum (required if public exposure is checked)

- **Access rules:** All newly exposed pages/assets are public static documentation resources.
- **Exposed fields:** Product docs, endpoint names, schema metadata, auth role descriptions, and discovery links only.
- **Avatar / image policy:** No new user avatars or user-uploaded images are exposed.
- **Regression coverage:** `node --test test/agent-readiness-public-assets.test.js`.

## Reviewer Context (optional)

- **Review focus:** Verify public discovery metadata is truthful, crawlable without JS, and does not overstate MCP transport support.
- **Delta since last review:** Removed the misleading MCP `transport` field and added static no-JS discovery fallbacks.
- **Depends on:** Vercel/static host deployment after merge.
- **Known gaps / follow-ups:** A real Streamable HTTP MCP server would require backend implementation and deployment.

## Screenshots / Logs (optional)

- n/a


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add public agent and developer discovery resources including OpenAPI spec and MCP manifest
> - Adds a comprehensive OpenAPI 3.1.0 spec ([openapi.json](https://github.com/victorGPT/vibeusage/pull/196/files#diff-bb14d87c296b5f115395ac2ac338f142fe6987741a74193130e3c0e969d70577)), MCP manifest ([manifest.json](https://github.com/victorGPT/vibeusage/pull/196/files#diff-a2a64324835817d777b7a5bf34999b5017b20252e8ee6de422274351d95c9c7c)), and [llms.txt](https://github.com/victorGPT/vibeusage/pull/196/files#diff-c96396a4f349e492600c40ce32398e6b37e4808098fa1e4ea2b0223a6f76d3a5) for agent/LLM discovery.
> - Adds static HTML pages under `/developers`, `/docs/api`, `/docs/auth`, `/docs/webhooks`, `/mcp`, and guide/comparison paths as no-JS fallbacks for agent crawlers.
> - Introduces [AgentResourcePage.jsx](https://github.com/victorGPT/vibeusage/pull/196/files#diff-2c54ab84dac01678bae386a59d5443c47dbffa3d318fb235843e2ecd47c5785f) and [agent-resource-routes.js](https://github.com/victorGPT/vibeusage/pull/196/files#diff-d3a0f236b9b3c874bc82dfee222304604d09cc8424993e3a478a46379b5e381e) to render these routes in the SPA without requiring authentication.
> - Updates [App.jsx](https://github.com/victorGPT/vibeusage/pull/196/files#diff-e58ba19e1cbb6e9d590e6b0ad766ebe7661a30f9d476d61cc384e4c25f038452) to detect agent resource routes and bypass the auth gate, rendering `AgentResourcePage` directly.
> - Updates `robots.txt` and `sitemap.xml` to surface the new discovery URLs to crawlers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fa5d08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->