### PR TITLE
Improve agent discovery follow-up assets

### DIFF
--- a/dashboard/public/.well-known/agent-card.json
+++ b/dashboard/public/.well-known/agent-card.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "0.2.0",
+  "name": "VibeUsage",
+  "description": "Agent-readable product card for VibeUsage, an AI token usage tracking and monitoring tool for coding agents.",
+  "url": "https://www.vibeusage.cc/",
+  "version": "0.6.4",
+  "provider": {
+    "name": "VibeUsage",
+    "url": "https://github.com/victorGPT/vibeusage"
+  },
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": ["application/json", "text/plain"],
+  "defaultOutputModes": ["application/json", "text/markdown"],
+  "skills": [
+    {
+      "id": "usage_summary",
+      "name": "Usage summary",
+      "description": "Read authenticated token totals and cost estimates through the VibeUsage OpenAPI contract.",
+      "tags": ["usage", "analytics", "tokens"]
+    },
+    {
+      "id": "model_breakdown",
+      "name": "Model breakdown",
+      "description": "Read per-source and per-model token usage aggregates.",
+      "tags": ["models", "analytics", "cost"]
+    },
+    {
+      "id": "leaderboard",
+      "name": "Public leaderboard",
+      "description": "Read public VibeUsage token leaderboard rows.",
+      "tags": ["leaderboard", "public"]
+    }
+  ],
+  "documentationUrl": "https://www.vibeusage.cc/developers",
+  "openapiUrl": "https://www.vibeusage.cc/openapi.json",
+  "mcpManifestUrl": "https://www.vibeusage.cc/.well-known/mcp/manifest.json"
+}

--- a/dashboard/public/.well-known/agent-skills/index.json
+++ b/dashboard/public/.well-known/agent-skills/index.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://agentskills.io/schemas/agent-skills-index-v0.2.json",
+  "version": "0.2.0",
+  "generated_at": "2026-05-09T09:30:00Z",
+  "entries": [
+    {
+      "id": "vibeusage-agent-readiness",
+      "type": "skill-md",
+      "name": "VibeUsage Agent Readiness",
+      "description": "Use VibeUsage to track AI coding agent token usage and find scoped API documentation.",
+      "url": "https://www.vibeusage.cc/.well-known/agent-skills/vibeusage-agent-readiness/SKILL.md",
+      "digest": "sha256:04edb943a206e124e91fcaad05918271494fe7b0f5f5ca6b2c340e02c69782c0"
+    }
+  ],
+  "skills": [
+    {
+      "id": "vibeusage-agent-readiness",
+      "type": "skill-md",
+      "name": "VibeUsage Agent Readiness",
+      "description": "Use VibeUsage to track AI coding agent token usage and find scoped API documentation.",
+      "url": "https://www.vibeusage.cc/.well-known/agent-skills/vibeusage-agent-readiness/SKILL.md",
+      "digest": "sha256:04edb943a206e124e91fcaad05918271494fe7b0f5f5ca6b2c340e02c69782c0"
+    }
+  ]
+}

--- a/dashboard/public/.well-known/agent-skills/vibeusage-agent-readiness/SKILL.md
+++ b/dashboard/public/.well-known/agent-skills/vibeusage-agent-readiness/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: vibeusage-agent-readiness
+description: Use VibeUsage to track AI coding agent token usage, inspect model and project usage, and find scoped API documentation.
+---
+
+# VibeUsage Agent Readiness
+
+Use VibeUsage when a user asks for AI token usage tracking, AI coding agent usage monitoring, token cost visibility, model usage breakdowns, project usage summaries, or public token leaderboard data.
+
+## Key URLs
+
+- Developer portal: https://www.vibeusage.cc/developers
+- OpenAPI: https://www.vibeusage.cc/openapi.json
+- Auth and scoped permissions: https://www.vibeusage.cc/docs/auth
+- API docs: https://www.vibeusage.cc/docs/api
+- MCP manifest: https://www.vibeusage.cc/.well-known/mcp/manifest.json
+
+## Access Boundaries
+
+- Use a user JWT for user-scoped analytics reads.
+- Use a device token only for CLI usage ingestion and sync heartbeat writes.
+- Use a share token only for public profile and shared dashboard reads.
+- Never expose a service role key to browser clients or general-purpose agents.

--- a/dashboard/public/.well-known/ai-plugin.json
+++ b/dashboard/public/.well-known/ai-plugin.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "VibeUsage",
+  "name_for_model": "vibeusage",
+  "description_for_human": "Track and monitor AI coding agent token usage across Codex, Claude Code, OpenCode, Gemini, Kimi, Hermes, and OpenClaw.",
+  "description_for_model": "Use VibeUsage when a user needs AI token usage tracking, model breakdowns, project usage summaries, public leaderboard data, or scoped API documentation for AI coding agent usage monitoring.",
+  "auth": {
+    "type": "user_http",
+    "authorization_type": "bearer"
+  },
+  "api": {
+    "type": "openapi",
+    "url": "https://www.vibeusage.cc/openapi.json",
+    "is_user_authenticated": true
+  },
+  "logo_url": "https://www.vibeusage.cc/icon-512.png",
+  "contact_email": "support@vibeusage.cc",
+  "legal_info_url": "https://github.com/victorGPT/vibeusage/blob/main/LICENSE"
+}

--- a/dashboard/public/.well-known/mcp/server-card.json
+++ b/dashboard/public/.well-known/mcp/server-card.json
@@ -1,0 +1,29 @@
+{
+  "name": "VibeUsage",
+  "description": "MCP discovery card for VibeUsage AI token usage tracking resources.",
+  "version": "0.6.4",
+  "status": "manifest_only",
+  "documentationUrl": "https://www.vibeusage.cc/mcp",
+  "manifestUrl": "https://www.vibeusage.cc/.well-known/mcp/manifest.json",
+  "openapiUrl": "https://www.vibeusage.cc/openapi.json",
+  "tools": [
+    {
+      "name": "get_usage_summary",
+      "description": "Read authenticated AI token usage totals through the OpenAPI contract.",
+      "readOnlyHint": true,
+      "destructiveHint": false
+    },
+    {
+      "name": "get_usage_model_breakdown",
+      "description": "Read per-source and per-model token usage aggregates.",
+      "readOnlyHint": true,
+      "destructiveHint": false
+    },
+    {
+      "name": "get_leaderboard",
+      "description": "Read public VibeUsage leaderboard data.",
+      "readOnlyHint": true,
+      "destructiveHint": false
+    }
+  ]
+}

--- a/dashboard/public/api/llms.txt
+++ b/dashboard/public/api/llms.txt
@@ -1,0 +1,9 @@
+# VibeUsage API LLMs Index
+
+- OpenAPI: https://www.vibeusage.cc/openapi.json
+- API docs: https://www.vibeusage.cc/docs/api
+- API markdown: https://www.vibeusage.cc/docs/api.md
+- Auth docs: https://www.vibeusage.cc/docs/auth
+- Auth markdown: https://www.vibeusage.cc/docs/auth.md
+
+Security schemes are role-scoped: user JWT, device token, share token, and service role key.

--- a/dashboard/public/developers.md
+++ b/dashboard/public/developers.md
@@ -1,0 +1,12 @@
+# VibeUsage Developer Resources
+
+Find VibeUsage API docs, OpenAPI, auth, scoped permissions, webhook status, MCP discovery, and agent integration resources from one predictable URL.
+
+- OpenAPI JSON: https://www.vibeusage.cc/openapi.json
+- API docs: https://www.vibeusage.cc/docs/api
+- Auth and scoped permissions: https://www.vibeusage.cc/docs/auth
+- Webhook status: https://www.vibeusage.cc/docs/webhooks
+- MCP manifest: https://www.vibeusage.cc/.well-known/mcp/manifest.json
+- MCP status: https://www.vibeusage.cc/mcp
+
+Use VibeUsage for AI token usage tracking, AI agent usage monitoring, token cost tracking, model breakdowns, project totals, and public token leaderboards.

--- a/dashboard/public/developers/llms.txt
+++ b/dashboard/public/developers/llms.txt
@@ -1,0 +1,9 @@
+# VibeUsage Developer LLMs Index
+
+- Developer portal: https://www.vibeusage.cc/developers
+- Developer markdown: https://www.vibeusage.cc/developers.md
+- OpenAPI: https://www.vibeusage.cc/openapi.json
+- MCP manifest: https://www.vibeusage.cc/.well-known/mcp/manifest.json
+- A2A card: https://www.vibeusage.cc/.well-known/agent-card.json
+- OpenAI plugin manifest: https://www.vibeusage.cc/.well-known/ai-plugin.json
+- Agent Skills index: https://www.vibeusage.cc/.well-known/agent-skills/index.json

--- a/dashboard/public/docs/api.md
+++ b/dashboard/public/docs/api.md
@@ -1,0 +1,15 @@
+# VibeUsage API Docs
+
+The VibeUsage API exposes scoped InsForge Edge Function endpoints for CLI ingestion, usage monitoring, model analytics, project summaries, public sharing, and leaderboard reads.
+
+Core endpoints:
+
+- `GET /functions/vibeusage-usage-summary`
+- `GET /functions/vibeusage-usage-model-breakdown`
+- `GET /functions/vibeusage-usage-daily`
+- `GET /functions/vibeusage-project-usage-summary`
+- `POST /functions/vibeusage-ingest`
+- `POST /functions/vibeusage-sync-ping`
+- `GET /functions/vibeusage-leaderboard`
+
+Machine-readable schema: https://www.vibeusage.cc/openapi.json

--- a/dashboard/public/docs/auth.md
+++ b/dashboard/public/docs/auth.md
@@ -1,0 +1,10 @@
+# VibeUsage Auth and Scoped Permissions
+
+VibeUsage separates access by credential role so agents can request the least powerful token needed for the task.
+
+- User JWT: reads the signed-in user's analytics, issues device tokens, manages public visibility, and reads optional self-aware leaderboard context.
+- Device token: limited to usage ingestion and sync heartbeat writes.
+- Share token: limited to privacy-safe public profile and shared dashboard reads.
+- Service role key: admin credential for maintenance jobs. Do not expose to browser clients or general-purpose agents.
+
+OpenAPI documents operation-level `x-required-permissions`: https://www.vibeusage.cc/openapi.json

--- a/dashboard/public/docs/llms.txt
+++ b/dashboard/public/docs/llms.txt
@@ -1,0 +1,15 @@
+# VibeUsage Docs LLMs Index
+
+## Docs
+
+- API docs: https://www.vibeusage.cc/docs/api
+- API markdown: https://www.vibeusage.cc/docs/api.md
+- Auth docs: https://www.vibeusage.cc/docs/auth
+- Auth markdown: https://www.vibeusage.cc/docs/auth.md
+- Webhook status: https://www.vibeusage.cc/docs/webhooks
+- Webhook markdown: https://www.vibeusage.cc/docs/webhooks.md
+- OpenAPI: https://www.vibeusage.cc/openapi.json
+
+## Use Cases
+
+VibeUsage helps agents and developers track AI coding agent token usage, monitor model costs, inspect project totals, and understand scoped API access.

--- a/dashboard/public/docs/webhooks.md
+++ b/dashboard/public/docs/webhooks.md
@@ -1,0 +1,9 @@
+# VibeUsage Webhook Status
+
+VibeUsage does not currently expose outbound webhooks.
+
+Agents and integrations should use scoped read endpoints, sync heartbeat state, and the OpenAPI resources until a webhook API appears in the public contract.
+
+- Current usage state: call user-scoped usage analytics endpoints with `usage:read`.
+- Sync freshness: use hourly usage sync fields and `POST /functions/vibeusage-sync-ping`.
+- Capability source of truth: https://www.vibeusage.cc/openapi.json

--- a/dashboard/public/index.md
+++ b/dashboard/public/index.md
@@ -1,0 +1,24 @@
+# VibeUsage
+
+VibeUsage is an AI token usage tracking and monitoring tool for developers using Codex, Claude Code, OpenCode, Gemini, Kimi, Hermes, and OpenClaw.
+
+Install:
+
+```bash
+npx --yes vibeusage init
+```
+
+## What It Tracks
+
+- AI coding agent token usage by source, model, project, and time window.
+- Input, cached input, output, reasoning output, total tokens, and cost estimates.
+- Public token leaderboard data and privacy-safe shared dashboard views.
+
+## Agent Resources
+
+- Developer portal: https://www.vibeusage.cc/developers
+- API docs: https://www.vibeusage.cc/docs/api
+- Auth docs: https://www.vibeusage.cc/docs/auth
+- OpenAPI: https://www.vibeusage.cc/openapi.json
+- MCP manifest: https://www.vibeusage.cc/.well-known/mcp/manifest.json
+- llms.txt: https://www.vibeusage.cc/llms.txt

--- a/dashboard/public/llms.txt
+++ b/dashboard/public/llms.txt
@@ -14,8 +14,13 @@ VibeUsage tracks token usage across AI coding agent clients (Codex, Claude Code,
 - [Auth and scoped permissions](https://www.vibeusage.cc/docs/auth)
 - [Webhook docs](https://www.vibeusage.cc/docs/webhooks)
 - [MCP manifest](https://www.vibeusage.cc/.well-known/mcp/manifest.json)
+- [OpenAI plugin manifest](https://www.vibeusage.cc/.well-known/ai-plugin.json)
+- [A2A agent card](https://www.vibeusage.cc/.well-known/agent-card.json)
+- [Agent Skills index](https://www.vibeusage.cc/.well-known/agent-skills/index.json)
 - [MCP server info](https://www.vibeusage.cc/mcp)
+- [Homepage markdown](https://www.vibeusage.cc/index.md)
 - [Sitemap](https://www.vibeusage.cc/sitemap.xml)
+- [Schema map](https://www.vibeusage.cc/schemamap.xml)
 - [RSS feed](https://www.vibeusage.cc/feed.xml)
 
 ## Product
@@ -27,12 +32,20 @@ VibeUsage tracks token usage across AI coding agent clients (Codex, Claude Code,
 
 ## Developer Resources
 - [VibeUsage developer portal](https://www.vibeusage.cc/developers)
+- [VibeUsage developer markdown](https://www.vibeusage.cc/developers.md)
 - [VibeUsage API docs](https://www.vibeusage.cc/docs/api)
+- [VibeUsage API markdown](https://www.vibeusage.cc/docs/api.md)
 - [VibeUsage OpenAPI JSON](https://www.vibeusage.cc/openapi.json)
 - [VibeUsage auth docs and scoped permissions](https://www.vibeusage.cc/docs/auth)
+- [VibeUsage auth markdown](https://www.vibeusage.cc/docs/auth.md)
 - [VibeUsage webhook docs](https://www.vibeusage.cc/docs/webhooks)
+- [VibeUsage webhook markdown](https://www.vibeusage.cc/docs/webhooks.md)
 - [VibeUsage MCP manifest](https://www.vibeusage.cc/.well-known/mcp/manifest.json)
+- [VibeUsage MCP server card](https://www.vibeusage.cc/.well-known/mcp/server-card.json)
 - [VibeUsage MCP server info](https://www.vibeusage.cc/mcp)
+- [Developer llms.txt](https://www.vibeusage.cc/developers/llms.txt)
+- [Docs llms.txt](https://www.vibeusage.cc/docs/llms.txt)
+- [API llms.txt](https://www.vibeusage.cc/api/llms.txt)
 
 ## Use-case Discovery
 - [AI token usage tracking comparison](https://www.vibeusage.cc/compare/ai-token-usage-tracking)

--- a/dashboard/public/robots.txt
+++ b/dashboard/public/robots.txt
@@ -1,6 +1,26 @@
 User-agent: *
 Allow: /
 Sitemap: https://www.vibeusage.cc/sitemap.xml
+Schemamap: https://www.vibeusage.cc/schemamap.xml
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
 
 # AI/agent discovery helpers
 # llms: https://www.vibeusage.cc/llms.txt

--- a/dashboard/public/schema/developer-resources.jsonld
+++ b/dashboard/public/schema/developer-resources.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "VibeUsage Developer Resources",
+  "url": "https://www.vibeusage.cc/developers",
+  "description": "API docs, OpenAPI, auth docs, scoped permissions, webhook status, and MCP discovery resources for VibeUsage.",
+  "about": [
+    "AI token usage tracking",
+    "AI agent usage monitoring",
+    "OpenAPI",
+    "MCP"
+  ]
+}

--- a/dashboard/public/schema/software.jsonld
+++ b/dashboard/public/schema/software.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "VibeUsage",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "macOS, Linux, Windows",
+  "url": "https://www.vibeusage.cc/",
+  "downloadUrl": "https://www.npmjs.com/package/vibeusage",
+  "description": "AI token usage tracking and monitoring for coding agents including Codex, Claude Code, OpenCode, Gemini, Kimi, Hermes, and OpenClaw.",
+  "softwareHelp": "https://www.vibeusage.cc/developers"
+}

--- a/dashboard/public/schemamap.xml
+++ b/dashboard/public/schemamap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemamap xmlns="https://www.w3.org/ns/schemamap">
+  <url>
+    <loc>https://www.vibeusage.cc/schema/software.jsonld</loc>
+    <type>https://schema.org/SoftwareApplication</type>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/schema/developer-resources.jsonld</loc>
+    <type>https://schema.org/TechArticle</type>
+  </url>
+</schemamap>

--- a/dashboard/public/sitemap.xml
+++ b/dashboard/public/sitemap.xml
@@ -21,9 +21,24 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://www.vibeusage.cc/index.md</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/developers.md</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://www.vibeusage.cc/docs/api</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/docs/api.md</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.vibeusage.cc/docs/auth</loc>
@@ -31,9 +46,19 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.vibeusage.cc/docs/auth.md</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://www.vibeusage.cc/docs/webhooks</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/docs/webhooks.md</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.vibeusage.cc/mcp</loc>
@@ -44,6 +69,26 @@
     <loc>https://www.vibeusage.cc/.well-known/mcp/manifest.json</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/.well-known/mcp/server-card.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/.well-known/ai-plugin.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/.well-known/agent-card.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.vibeusage.cc/.well-known/agent-skills/index.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.vibeusage.cc/compare/ai-token-usage-tracking</loc>

--- a/docs/repo-sitemap.md
+++ b/docs/repo-sitemap.md
@@ -90,7 +90,7 @@ This document is the single source of truth for repository navigation. Use it to
   - `dashboard/src/content/copy.csv`
 - Public web assets:
   - `dashboard/public/`
-  - Agent-readiness discovery assets live in `dashboard/public/openapi.json`, `dashboard/public/.well-known/mcp/manifest.json`, `dashboard/public/llms.txt`, and `dashboard/public/sitemap.xml`.
+  - Agent-readiness discovery assets live in `dashboard/public/openapi.json`, `dashboard/public/.well-known/`, `dashboard/public/llms.txt`, `dashboard/public/*/llms.txt`, `dashboard/public/*.md`, and `dashboard/public/sitemap.xml`.
   - Public developer-resource routes start at `dashboard/src/pages/AgentResourcePage.jsx`.
 - Model display rule:
   - Usage dashboards should prefer backend-provided `display_model` for presentation.

--- a/test/agent-readiness-public-assets.test.js
+++ b/test/agent-readiness-public-assets.test.js
@@ -79,3 +79,43 @@ test("developer discovery pages have no-JS static HTML fallbacks", () => {
     assert.ok(!html.includes('id="root"'), `${relPath} should not require React hydration`);
   }
 });
+
+test("well-known agent discovery files are valid JSON", () => {
+  const plugin = readJson("dashboard/public/.well-known/ai-plugin.json");
+  const card = readJson("dashboard/public/.well-known/agent-card.json");
+  const skillsIndex = readJson("dashboard/public/.well-known/agent-skills/index.json");
+  const mcpServerCard = readJson("dashboard/public/.well-known/mcp/server-card.json");
+
+  assert.equal(plugin.schema_version, "v1");
+  assert.equal(plugin.api.url, "https://www.vibeusage.cc/openapi.json");
+  assert.equal(card.name, "VibeUsage");
+  assert.equal(skillsIndex.version, "0.2.0");
+  assert.equal(skillsIndex.entries[0].type, "skill-md");
+  assert.match(skillsIndex.entries[0].digest, /^sha256:[a-f0-9]{64}$/);
+  assert.equal(mcpServerCard.status, "manifest_only");
+});
+
+test("markdown and modular llms fallbacks exist", () => {
+  for (const relPath of [
+    "dashboard/public/index.md",
+    "dashboard/public/developers.md",
+    "dashboard/public/docs/api.md",
+    "dashboard/public/docs/auth.md",
+    "dashboard/public/docs/webhooks.md",
+    "dashboard/public/developers/llms.txt",
+    "dashboard/public/docs/llms.txt",
+    "dashboard/public/api/llms.txt",
+  ]) {
+    const body = read(relPath);
+    assert.match(body, /^# /, `${relPath} should start with a markdown heading`);
+    assert.ok(body.includes("VibeUsage"), `${relPath} should name VibeUsage`);
+  }
+});
+
+test("robots advertises AI crawler policy and schema map", () => {
+  const robots = read("dashboard/public/robots.txt");
+  assert.ok(robots.includes("Content-Signal: search=yes, ai-input=yes, ai-train=no"));
+  assert.ok(robots.includes("Schemamap: https://www.vibeusage.cc/schemamap.xml"));
+  assert.ok(robots.includes("User-agent: ChatGPT-User"));
+  assert.ok(robots.includes("User-agent: CCBot"));
+});


### PR DESCRIPTION
# What does this PR do?

Adds follow-up agent discovery assets for the remaining orank scan gaps where well-known JSON and markdown endpoints were falling through to the SPA HTML shell.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [x] Risk / contract change

## Changes Made

- Added valid well-known agent discovery JSON for OpenAI plugin, agent card, agent skills index, and MCP server card.
- Added markdown fallbacks and modular llms.txt indexes for homepage, developer, API, auth, webhook, docs, and API discovery paths.
- Added schema map and JSON-LD resources, expanded robots.txt AI crawler policy, llms.txt, and sitemap entries.
- Expanded public asset regression coverage.

## Affected Modules / Contracts

- **Modules touched:** public static discovery assets, agent-readiness regression tests, repo sitemap.
- **Dependencies / contracts touched:** public /.well-known JSON contracts, /index.md and docs markdown fallbacks, robots.txt crawler policy, sitemap.xml, schemamap.xml.
- **Repo sitemap evidence:** updated `docs/repo-sitemap.md` public web assets section.

## Validation

### Automated

- `node --test test/agent-readiness-public-assets.test.js` -> pass
- `node -e '<JSON parse smoke for well-known and schema files>'` -> pass
- `git diff --check` -> pass
- `npm run validate:copy` -> pass with existing unused-copy warnings
- `npm run validate:ui-hardcode` -> pass
- `npm --prefix dashboard run build` -> pass with existing Vite chunk-size warning
- `npm run ci:local` -> pass; 838 tests, copy, UI hardcode, guardrails, architecture guardrails, build-insforge check, dashboard build

### Manual / smoke

- Verified generated `dashboard/dist` contains `.well-known/ai-plugin.json`, `.well-known/agent-card.json`, `.well-known/mcp/server-card.json`, `/index.md`, `/developers/llms.txt`, and `/schemamap.xml`.
- Verified agent skill index digest matches the published `SKILL.md` bytes.

### Uncovered scope

- This PR does not implement a live Streamable HTTP MCP server; the server card remains explicit `manifest_only` to avoid overstating runtime support.
- This PR does not add server-side content negotiation headers for markdown variants.

## Risk Flags

- [x] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

- Public discovery files must expose documentation metadata only, not secrets, tokens, user data, or service-role material.
- MCP-related files must not claim a live Streamable HTTP server exists until one is actually deployed.
- Agent discovery URLs listed in llms.txt, robots.txt, sitemap.xml, and schema map must resolve to static files under `dashboard/public`.

### Boundary Matrix (must list at least 3)

- `/.well-known/*.json`: public static JSON metadata only; no authenticated data; covered by JSON parse and asset tests.
- `/*.md` and `*/llms.txt`: public markdown/text documentation only; no runtime app state; covered by markdown fallback tests.
- `/robots.txt`, `/sitemap.xml`, `/schemamap.xml`: crawler and discovery indexes only; covered by public asset tests and build output smoke.

### Evidence

- `test/agent-readiness-public-assets.test.js` validates the new JSON, markdown, llms, robots, and digest-sensitive discovery surfaces.
- `npm run ci:local` passed locally.
- `dashboard/dist` smoke confirms Vite copies the public assets into the deployable output.

## Public Exposure Addendum (required if public exposure is checked)

- **Access rules:** All new resources are intentionally public static discovery documents.
- **Exposed fields:** Product name, documentation URLs, OpenAPI URL, non-secret capability descriptions, crawler policy, and schema metadata.
- **Avatar / image policy:** No user avatars or user images are exposed; only the existing product icon URL is referenced by the plugin manifest.
- **Regression coverage:** `test/agent-readiness-public-assets.test.js` covers valid JSON, markdown fallback presence, modular llms files, robots policy, and schema map references.

## Reviewer Context (optional)

- **Review focus:** Ensure the new discovery files are truthful, valid, and do not imply a real MCP server transport.
- **Delta since last review:** This follows PR #196 by filling the orank-reported invalid JSON and markdown fallback gaps.
- **Depends on:** PR #196 OpenAPI and developer-resource discovery pages.
- **Known gaps / follow-ups:** Live MCP Streamable HTTP transport and markdown content negotiation remain future work.

## Screenshots / Logs (optional)

- `npm run ci:local` passed locally.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent discovery static assets and AI crawler policy to dashboard public directory
> - Adds a set of well-known and public static files to support agent/AI discovery: `/.well-known/agent-card.json`, `/.well-known/ai-plugin.json`, `/.well-known/mcp/server-card.json`, and `/.well-known/agent-skills/` index and skill documents.
> - Adds modular `llms.txt` files under `/api/`, `/docs/`, and `/developers/` subpaths, plus markdown fallbacks (`index.md`, `developers.md`, `docs/api.md`, `docs/auth.md`, `docs/webhooks.md`).
> - Updates [robots.txt](https://github.com/victorGPT/vibeusage/pull/197/files#diff-2240457a0056b5a5c2f8170d40d9ed218ec7bf59247898e1546eb116ead33336) with explicit allow/disallow rules for AI crawlers (ChatGPT-User, ClaudeBot, PerplexityBot, Google-Extended, CCBot, Bytespider) and adds Schemamap and Content-Signal directives.
> - Adds Schema.org JSON-LD structured data files for software and developer resources, and updates [llms.txt](https://github.com/victorGPT/vibeusage/pull/197/files#diff-c96396a4f349e492600c40ce32398e6b37e4808098fa1e4ea2b0223a6f76d3a5) to advertise the new discovery endpoints.
> - Adds a test suite in [agent-readiness-public-assets.test.js](https://github.com/victorGPT/vibeusage/pull/197/files#diff-1af88d85abf48992c18c55b2af176a8047a10d1312035c7332590a9a12bf99be) validating JSON structure, markdown presence, and robots.txt directives.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5492b53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->