### PR TITLE
Align agent skills discovery schema URL

### DIFF
--- a/dashboard/public/.well-known/agent-skills/index.json
+++ b/dashboard/public/.well-known/agent-skills/index.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://agentskills.io/schemas/agent-skills-index-v0.2.json",
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
   "version": "0.2.0",
   "generated_at": "2026-05-09T09:30:00Z",
   "entries": [

--- a/test/agent-readiness-public-assets.test.js
+++ b/test/agent-readiness-public-assets.test.js
@@ -89,6 +89,7 @@ test("well-known agent discovery files are valid JSON", () => {
   assert.equal(plugin.schema_version, "v1");
   assert.equal(plugin.api.url, "https://www.vibeusage.cc/openapi.json");
   assert.equal(card.name, "VibeUsage");
+  assert.equal(skillsIndex.$schema, "https://schemas.agentskills.io/discovery/0.2.0/schema.json");
   assert.equal(skillsIndex.version, "0.2.0");
   assert.equal(skillsIndex.entries[0].type, "skill-md");
   assert.match(skillsIndex.entries[0].digest, /^sha256:[a-f0-9]{64}$/);


### PR DESCRIPTION
# What does this PR do?

Aligns the Agent Skills discovery index `$schema` URL with the v0.2.0 schema URI expected by orank and locks it with a regression assertion.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI / workflow
- [x] Risk / contract change

## Changes Made

- Updated `/.well-known/agent-skills/index.json` to use `https://schemas.agentskills.io/discovery/0.2.0/schema.json`.
- Added a public asset regression assertion for the exact schema URI.

## Affected Modules / Contracts

- **Modules touched:** public agent discovery assets, agent-readiness regression tests.
- **Dependencies / contracts touched:** `/.well-known/agent-skills/index.json` discovery contract.
- **Repo sitemap evidence:** not required; no module boundary or entrypoint change.

## Validation

### Automated

- `node --test test/agent-readiness-public-assets.test.js` -> pass
- `git diff --check` -> pass
- `node -e '<JSON parse smoke for agent skills index>'` -> pass

### Manual / smoke

- Verified the changed index remains valid JSON.

### Uncovered scope

- This PR only fixes the schema URI; it does not add a live MCP transport or registry listing.

## Risk Flags

- [x] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

- Public discovery metadata must remain static and contain no secrets or user data.
- The Agent Skills index must keep v0.2.0 fields and digest references stable.
- The schema URI must match the external discovery contract expected by agent scanners.

### Boundary Matrix (must list at least 3)

- `/.well-known/agent-skills/index.json`: public static discovery JSON; no authenticated data; validated by parse and exact schema tests.
- `/.well-known/agent-skills/vibeusage-agent-readiness/SKILL.md`: unchanged public skill artifact referenced by digest.
- `test/agent-readiness-public-assets.test.js`: regression coverage for the public discovery contract.

### Evidence

- Targeted node test passed.
- `git diff --check` passed.
- JSON parse smoke passed.

## Public Exposure Addendum (required if public exposure is checked)

- **Access rules:** The changed resource is intentionally public static metadata.
- **Exposed fields:** Schema URL and existing non-secret skill metadata only.
- **Avatar / image policy:** No images or avatars are exposed by this change.
- **Regression coverage:** Exact `$schema` assertion in `test/agent-readiness-public-assets.test.js`.

## Reviewer Context (optional)

- **Review focus:** Confirm the schema URL matches the expected Agent Skills v0.2.0 discovery URI.
- **Delta since last review:** Tiny follow-up to PR #197 based on the latest orank warning.
- **Depends on:** PR #197.
- **Known gaps / follow-ups:** Live MCP server and registry listing remain future work.

## Screenshots / Logs (optional)

- `node --test test/agent-readiness-public-assets.test.js` passed locally.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update agent skills discovery `$schema` URL to version 0.2.0
> Updates the `$schema` field in [index.json](https://github.com/victorGPT/vibeusage/pull/198/files#diff-370788b0b25bb8d77fbe48d369ca408b8ea82e04438df816513830dbcbf87a5f) to `https://schemas.agentskills.io/discovery/0.2.0/schema.json`. The test in [agent-readiness-public-assets.test.js](https://github.com/victorGPT/vibeusage/pull/198/files#diff-1af88d85abf48992c18c55b2af176a8047a10d1312035c7332590a9a12bf99be) is updated to assert the exact schema URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60b83bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->