### PR TITLE
Fix InsForge RLS for non-UUID auth subjects

### DIFF
--- a/scripts/ops/fix-auth-uid-nonuuid.sql
+++ b/scripts/ops/fix-auth-uid-nonuuid.sql
@@ -1,5 +1,19 @@
--- Remediate InsForge Backend Advisor performance findings.
--- Keep this file outside explicit transactions: CREATE INDEX CONCURRENTLY requires it.
+-- Fix VibeUsage RLS policies for InsForge API-key requests whose JWT sub is
+-- not a UUID.
+--
+-- Root cause:
+--   auth.uid() is InsForge-managed and casts JWT sub directly to uuid. Project
+--   API-key requests can carry sub = 'project-admin-with-api-key', so any RLS
+--   policy that evaluates auth.uid() fails before other permissive policies can
+--   authorize service/device-token paths.
+--
+-- Contract:
+--   - UUID sub values still compare exactly against user_id.
+--   - Missing or non-UUID sub values return null.
+--   - Existing user policies remain default-deny for non-user service/API-key
+--     subjects instead of raising a cast error.
+
+begin;
 
 create or replace function public.vibeusage_auth_uid()
 returns uuid
@@ -32,53 +46,17 @@ $function$;
 
 grant execute on function public.vibeusage_auth_uid() to public;
 
-create index concurrently if not exists idx_vibeusage_tracker_device_tokens_device_id
-  on public.vibeusage_tracker_device_tokens(device_id);
-
-create index concurrently if not exists idx_vibeusage_tracker_events_device_id
-  on public.vibeusage_tracker_events(device_id);
-
-create index concurrently if not exists idx_vibeusage_tracker_events_device_token_id
-  on public.vibeusage_tracker_events(device_token_id);
-
-create index concurrently if not exists idx_vibeusage_user_settings_user_id
-  on public.vibeusage_user_settings(user_id);
-
-create index concurrently if not exists idx_vibeusage_tracker_hourly_device_token_id
-  on public.vibeusage_tracker_hourly(device_token_id);
-
-create index concurrently if not exists idx_vibeusage_tracker_ingest_batches_device_token_id
-  on public.vibeusage_tracker_ingest_batches(device_token_id);
-
-create index concurrently if not exists idx_vibeusage_user_entitlements_user_id
-  on public.vibeusage_user_entitlements(user_id);
-
-create index concurrently if not exists idx_vibeusage_link_codes_user_id
-  on public.vibeusage_link_codes(user_id);
-
-create index concurrently if not exists idx_vibeusage_public_views_user_id
-  on public.vibeusage_public_views(user_id);
-
-create index concurrently if not exists idx_vibeusage_projects_device_id
-  on public.vibeusage_projects(device_id);
-
-create index concurrently if not exists idx_vibeusage_projects_device_token_id
-  on public.vibeusage_projects(device_token_id);
-
-create index concurrently if not exists idx_vibeusage_project_usage_hourly_device_id
-  on public.vibeusage_project_usage_hourly(device_id);
-
-create index concurrently if not exists idx_vibeusage_project_usage_hourly_device_token_id
-  on public.vibeusage_project_usage_hourly(device_token_id);
-
-create index concurrently if not exists idx_vibeusage_tracker_subscriptions_device_id
-  on public.vibeusage_tracker_subscriptions(device_id);
-
-create index concurrently if not exists idx_vibeusage_tracker_subscriptions_device_token_id
-  on public.vibeusage_tracker_subscriptions(device_token_id);
-
 alter policy vibeusage_link_codes_insert_self on public.vibeusage_link_codes
   with check ((select public.vibeusage_auth_uid()) = user_id);
+
+alter policy vibeusage_model_aliases_select on public.vibeusage_model_aliases
+  using ((select public.vibeusage_auth_uid()) is not null);
+
+alter policy vibeusage_pricing_model_aliases_select on public.vibeusage_pricing_model_aliases
+  using ((select public.vibeusage_auth_uid()) is not null);
+
+alter policy vibeusage_pricing_profiles_select on public.vibeusage_pricing_profiles
+  using ((select public.vibeusage_auth_uid()) is not null);
 
 alter policy vibeusage_project_usage_hourly_select on public.vibeusage_project_usage_hourly
   using ((select public.vibeusage_auth_uid()) = user_id);
@@ -98,11 +76,11 @@ alter policy vibeusage_public_views_update on public.vibeusage_public_views
 
 alter policy vibeusage_tracker_device_tokens_insert on public.vibeusage_tracker_device_tokens
   with check (
-    (select public.vibeusage_auth_uid()) = user_id
+    ((select public.vibeusage_auth_uid()) = user_id)
     and exists (
       select 1
       from public.vibeusage_tracker_devices d
-      where d.id = device_id
+      where d.id = vibeusage_tracker_device_tokens.device_id
         and d.user_id = (select public.vibeusage_auth_uid())
     )
   );
@@ -145,3 +123,5 @@ alter policy vibeusage_user_settings_select on public.vibeusage_user_settings
 alter policy vibeusage_user_settings_update on public.vibeusage_user_settings
   using ((select public.vibeusage_auth_uid()) = user_id)
   with check ((select public.vibeusage_auth_uid()) = user_id);
+
+commit;

--- a/scripts/ops/fix-auth-uid-nonuuid.sql
+++ b/scripts/ops/fix-auth-uid-nonuuid.sql
@@ -17,31 +17,34 @@ begin;
 
 create or replace function public.vibeusage_auth_uid()
 returns uuid
-language sql
+language plpgsql
 stable
 set search_path = ''
 as $function$
-  with claims as (
-    select
-      nullif(current_setting('request.jwt.claim.sub', true), '') as legacy_sub,
-      nullif(current_setting('request.jwt.claims', true), '') as claims_json
-  ),
-  subject as (
-    select coalesce(
-      legacy_sub,
-      case
-        when claims_json is null then null
-        else claims_json::jsonb ->> 'sub'
-      end
-    ) as sub
-    from claims
-  )
-  select case
-    when sub ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-      then sub::uuid
-    else null
-  end
-  from subject
+declare
+  raw_claims text;
+  subject text;
+begin
+  raw_claims := nullif(current_setting('request.jwt.claims', true), '');
+  subject := coalesce(
+    nullif(current_setting('request.jwt.claim.sub', true), ''),
+    case
+      when raw_claims is null then null
+      else raw_claims::jsonb ->> 'sub'
+    end
+  );
+
+  if subject is null then
+    return null;
+  end if;
+
+  begin
+    return subject::uuid;
+  exception
+    when invalid_text_representation then
+      return null;
+  end;
+end
 $function$;
 
 grant execute on function public.vibeusage_auth_uid() to public;

--- a/scripts/ops/fix-auth-uid-nonuuid.sql
+++ b/scripts/ops/fix-auth-uid-nonuuid.sql
@@ -50,13 +50,13 @@ alter policy vibeusage_link_codes_insert_self on public.vibeusage_link_codes
   with check ((select public.vibeusage_auth_uid()) = user_id);
 
 alter policy vibeusage_model_aliases_select on public.vibeusage_model_aliases
-  using ((select public.vibeusage_auth_uid()) is not null);
+  using (current_user = 'authenticated');
 
 alter policy vibeusage_pricing_model_aliases_select on public.vibeusage_pricing_model_aliases
-  using ((select public.vibeusage_auth_uid()) is not null);
+  using (current_user = 'authenticated');
 
 alter policy vibeusage_pricing_profiles_select on public.vibeusage_pricing_profiles
-  using ((select public.vibeusage_auth_uid()) is not null);
+  using (current_user = 'authenticated');
 
 alter policy vibeusage_project_usage_hourly_select on public.vibeusage_project_usage_hourly
   using ((select public.vibeusage_auth_uid()) = user_id);

--- a/scripts/ops/insforge-advisor-performance-hardening.sql
+++ b/scripts/ops/insforge-advisor-performance-hardening.sql
@@ -1,0 +1,116 @@
+-- Remediate InsForge Backend Advisor performance findings.
+-- Keep this file outside explicit transactions: CREATE INDEX CONCURRENTLY requires it.
+
+create index concurrently if not exists idx_vibeusage_tracker_device_tokens_device_id
+  on public.vibeusage_tracker_device_tokens(device_id);
+
+create index concurrently if not exists idx_vibeusage_tracker_events_device_id
+  on public.vibeusage_tracker_events(device_id);
+
+create index concurrently if not exists idx_vibeusage_tracker_events_device_token_id
+  on public.vibeusage_tracker_events(device_token_id);
+
+create index concurrently if not exists idx_vibeusage_user_settings_user_id
+  on public.vibeusage_user_settings(user_id);
+
+create index concurrently if not exists idx_vibeusage_tracker_hourly_device_token_id
+  on public.vibeusage_tracker_hourly(device_token_id);
+
+create index concurrently if not exists idx_vibeusage_tracker_ingest_batches_device_token_id
+  on public.vibeusage_tracker_ingest_batches(device_token_id);
+
+create index concurrently if not exists idx_vibeusage_user_entitlements_user_id
+  on public.vibeusage_user_entitlements(user_id);
+
+create index concurrently if not exists idx_vibeusage_link_codes_user_id
+  on public.vibeusage_link_codes(user_id);
+
+create index concurrently if not exists idx_vibeusage_public_views_user_id
+  on public.vibeusage_public_views(user_id);
+
+create index concurrently if not exists idx_vibeusage_projects_device_id
+  on public.vibeusage_projects(device_id);
+
+create index concurrently if not exists idx_vibeusage_projects_device_token_id
+  on public.vibeusage_projects(device_token_id);
+
+create index concurrently if not exists idx_vibeusage_project_usage_hourly_device_id
+  on public.vibeusage_project_usage_hourly(device_id);
+
+create index concurrently if not exists idx_vibeusage_project_usage_hourly_device_token_id
+  on public.vibeusage_project_usage_hourly(device_token_id);
+
+create index concurrently if not exists idx_vibeusage_tracker_subscriptions_device_id
+  on public.vibeusage_tracker_subscriptions(device_id);
+
+create index concurrently if not exists idx_vibeusage_tracker_subscriptions_device_token_id
+  on public.vibeusage_tracker_subscriptions(device_token_id);
+
+alter policy vibeusage_link_codes_insert_self on public.vibeusage_link_codes
+  with check ((select auth.uid()) = user_id);
+
+alter policy vibeusage_project_usage_hourly_select on public.vibeusage_project_usage_hourly
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_projects_select on public.vibeusage_projects
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_public_views_insert on public.vibeusage_public_views
+  with check ((select auth.uid()) = user_id);
+
+alter policy vibeusage_public_views_select on public.vibeusage_public_views
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_public_views_update on public.vibeusage_public_views
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+alter policy vibeusage_tracker_device_tokens_insert on public.vibeusage_tracker_device_tokens
+  with check (
+    (select auth.uid()) = user_id
+    and exists (
+      select 1
+      from public.vibeusage_tracker_devices d
+      where d.id = device_id
+        and d.user_id = (select auth.uid())
+    )
+  );
+
+alter policy vibeusage_tracker_device_tokens_select on public.vibeusage_tracker_device_tokens
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_tracker_device_tokens_update on public.vibeusage_tracker_device_tokens
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+alter policy vibeusage_tracker_devices_insert on public.vibeusage_tracker_devices
+  with check ((select auth.uid()) = user_id);
+
+alter policy vibeusage_tracker_devices_select on public.vibeusage_tracker_devices
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_tracker_devices_update on public.vibeusage_tracker_devices
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+alter policy vibeusage_tracker_events_select on public.vibeusage_tracker_events
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_tracker_hourly_select on public.vibeusage_tracker_hourly
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_tracker_subscriptions_select on public.vibeusage_tracker_subscriptions
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_user_entitlements_select on public.vibeusage_user_entitlements
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_user_settings_insert on public.vibeusage_user_settings
+  with check ((select auth.uid()) = user_id);
+
+alter policy vibeusage_user_settings_select on public.vibeusage_user_settings
+  using ((select auth.uid()) = user_id);
+
+alter policy vibeusage_user_settings_update on public.vibeusage_user_settings
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);

--- a/scripts/ops/insforge-advisor-performance-hardening.sql
+++ b/scripts/ops/insforge-advisor-performance-hardening.sql
@@ -3,31 +3,34 @@
 
 create or replace function public.vibeusage_auth_uid()
 returns uuid
-language sql
+language plpgsql
 stable
 set search_path = ''
 as $function$
-  with claims as (
-    select
-      nullif(current_setting('request.jwt.claim.sub', true), '') as legacy_sub,
-      nullif(current_setting('request.jwt.claims', true), '') as claims_json
-  ),
-  subject as (
-    select coalesce(
-      legacy_sub,
-      case
-        when claims_json is null then null
-        else claims_json::jsonb ->> 'sub'
-      end
-    ) as sub
-    from claims
-  )
-  select case
-    when sub ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-      then sub::uuid
-    else null
-  end
-  from subject
+declare
+  raw_claims text;
+  subject text;
+begin
+  raw_claims := nullif(current_setting('request.jwt.claims', true), '');
+  subject := coalesce(
+    nullif(current_setting('request.jwt.claim.sub', true), ''),
+    case
+      when raw_claims is null then null
+      else raw_claims::jsonb ->> 'sub'
+    end
+  );
+
+  if subject is null then
+    return null;
+  end if;
+
+  begin
+    return subject::uuid;
+  exception
+    when invalid_text_representation then
+      return null;
+  end;
+end
 $function$;
 
 grant execute on function public.vibeusage_auth_uid() to public;

--- a/scripts/ops/insforge-advisor-security-hardening.sql
+++ b/scripts/ops/insforge-advisor-security-hardening.sql
@@ -9,6 +9,37 @@
 
 begin;
 
+create or replace function public.vibeusage_auth_uid()
+returns uuid
+language sql
+stable
+set search_path = ''
+as $function$
+  with claims as (
+    select
+      nullif(current_setting('request.jwt.claim.sub', true), '') as legacy_sub,
+      nullif(current_setting('request.jwt.claims', true), '') as claims_json
+  ),
+  subject as (
+    select coalesce(
+      legacy_sub,
+      case
+        when claims_json is null then null
+        else claims_json::jsonb ->> 'sub'
+      end
+    ) as sub
+    from claims
+  )
+  select case
+    when sub ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      then sub::uuid
+    else null
+  end
+  from subject
+$function$;
+
+grant execute on function public.vibeusage_auth_uid() to public;
+
 do $$
 declare
   table_name text;
@@ -37,7 +68,7 @@ begin
     create policy vibeusage_model_aliases_select on public.vibeusage_model_aliases
       for select
       to authenticated
-      using ((select auth.uid()) is not null);
+      using ((select public.vibeusage_auth_uid()) is not null);
   end if;
 
   if to_regclass('public.vibeusage_pricing_model_aliases') is not null then
@@ -45,7 +76,7 @@ begin
     create policy vibeusage_pricing_model_aliases_select on public.vibeusage_pricing_model_aliases
       for select
       to authenticated
-      using ((select auth.uid()) is not null);
+      using ((select public.vibeusage_auth_uid()) is not null);
   end if;
 
   if to_regclass('public.vibeusage_pricing_profiles') is not null then
@@ -53,7 +84,7 @@ begin
     create policy vibeusage_pricing_profiles_select on public.vibeusage_pricing_profiles
       for select
       to authenticated
-      using ((select auth.uid()) is not null);
+      using ((select public.vibeusage_auth_uid()) is not null);
   end if;
 end $$;
 

--- a/scripts/ops/insforge-advisor-security-hardening.sql
+++ b/scripts/ops/insforge-advisor-security-hardening.sql
@@ -11,31 +11,34 @@ begin;
 
 create or replace function public.vibeusage_auth_uid()
 returns uuid
-language sql
+language plpgsql
 stable
 set search_path = ''
 as $function$
-  with claims as (
-    select
-      nullif(current_setting('request.jwt.claim.sub', true), '') as legacy_sub,
-      nullif(current_setting('request.jwt.claims', true), '') as claims_json
-  ),
-  subject as (
-    select coalesce(
-      legacy_sub,
-      case
-        when claims_json is null then null
-        else claims_json::jsonb ->> 'sub'
-      end
-    ) as sub
-    from claims
-  )
-  select case
-    when sub ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-      then sub::uuid
-    else null
-  end
-  from subject
+declare
+  raw_claims text;
+  subject text;
+begin
+  raw_claims := nullif(current_setting('request.jwt.claims', true), '');
+  subject := coalesce(
+    nullif(current_setting('request.jwt.claim.sub', true), ''),
+    case
+      when raw_claims is null then null
+      else raw_claims::jsonb ->> 'sub'
+    end
+  );
+
+  if subject is null then
+    return null;
+  end if;
+
+  begin
+    return subject::uuid;
+  exception
+    when invalid_text_representation then
+      return null;
+  end;
+end
 $function$;
 
 grant execute on function public.vibeusage_auth_uid() to public;

--- a/scripts/ops/insforge-advisor-security-hardening.sql
+++ b/scripts/ops/insforge-advisor-security-hardening.sql
@@ -5,7 +5,7 @@
 -- - NFT and legacy public tables become default-deny through RLS.
 -- - Pricing/model metadata remains readable only by authenticated users.
 -- - project_admin remains a privileged DB role, but policies no longer use literal true.
--- - SECURITY DEFINER functions stay privileged where required by ingest/link/leaderboard flows.
+-- - Legacy SECURITY DEFINER functions are removed from direct anon/auth execution.
 
 begin;
 
@@ -112,14 +112,17 @@ do $$
 begin
   if to_regprocedure('public.vibeusage_device_token_allows_event_insert(uuid,uuid,uuid)') is not null then
     revoke execute on function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) from public;
-    grant execute on function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) to anon, authenticated, project_admin;
     alter function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) set search_path = '';
+    alter function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) security invoker;
+    grant execute on function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) to anon, authenticated, project_admin;
   end if;
 
   if to_regprocedure('public.vibeusage_leaderboard_system_earliest_day()') is not null then
     revoke execute on function public.vibeusage_leaderboard_system_earliest_day() from public;
-    grant execute on function public.vibeusage_leaderboard_system_earliest_day() to authenticated, project_admin;
+    revoke execute on function public.vibeusage_leaderboard_system_earliest_day() from anon, authenticated;
     alter function public.vibeusage_leaderboard_system_earliest_day() set search_path = '';
+    alter function public.vibeusage_leaderboard_system_earliest_day() security invoker;
+    grant execute on function public.vibeusage_leaderboard_system_earliest_day() to project_admin;
   end if;
 
   if to_regprocedure('public.vibeusage_purge_events(timestamp with time zone,boolean)') is not null then
@@ -130,20 +133,26 @@ begin
 
   if to_regprocedure('public.vibeusage_exchange_link_code(text,text,text,text,text)') is not null then
     revoke execute on function public.vibeusage_exchange_link_code(text, text, text, text, text) from public;
-    grant execute on function public.vibeusage_exchange_link_code(text, text, text, text, text) to anon, authenticated, project_admin;
+    revoke execute on function public.vibeusage_exchange_link_code(text, text, text, text, text) from anon, authenticated;
     alter function public.vibeusage_exchange_link_code(text, text, text, text, text) set search_path = '';
+    alter function public.vibeusage_exchange_link_code(text, text, text, text, text) security invoker;
+    grant execute on function public.vibeusage_exchange_link_code(text, text, text, text, text) to project_admin;
   end if;
 
   if to_regprocedure('public.vibeusage_leaderboard_period(text,text,integer)') is not null then
     revoke execute on function public.vibeusage_leaderboard_period(text, text, integer) from public;
-    grant execute on function public.vibeusage_leaderboard_period(text, text, integer) to authenticated, project_admin;
+    revoke execute on function public.vibeusage_leaderboard_period(text, text, integer) from anon, authenticated;
     alter function public.vibeusage_leaderboard_period(text, text, integer) set search_path = '';
+    alter function public.vibeusage_leaderboard_period(text, text, integer) security invoker;
+    grant execute on function public.vibeusage_leaderboard_period(text, text, integer) to project_admin;
   end if;
 
   if to_regprocedure('public.vibeusage_leaderboard_me(text,text)') is not null then
     revoke execute on function public.vibeusage_leaderboard_me(text, text) from public;
-    grant execute on function public.vibeusage_leaderboard_me(text, text) to authenticated, project_admin;
+    revoke execute on function public.vibeusage_leaderboard_me(text, text) from anon, authenticated;
     alter function public.vibeusage_leaderboard_me(text, text) set search_path = '';
+    alter function public.vibeusage_leaderboard_me(text, text) security invoker;
+    grant execute on function public.vibeusage_leaderboard_me(text, text) to project_admin;
   end if;
 end $$;
 

--- a/scripts/ops/insforge-advisor-security-hardening.sql
+++ b/scripts/ops/insforge-advisor-security-hardening.sql
@@ -147,7 +147,7 @@ begin
   if to_regprocedure('public.vibeusage_device_token_allows_event_insert(uuid,uuid,uuid)') is not null then
     revoke execute on function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) from public;
     alter function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) set search_path = '';
-    alter function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) security invoker;
+    alter function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) security definer;
     grant execute on function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) to anon, authenticated, project_admin;
   end if;
 

--- a/scripts/ops/insforge-advisor-security-hardening.sql
+++ b/scripts/ops/insforge-advisor-security-hardening.sql
@@ -68,7 +68,7 @@ begin
     create policy vibeusage_model_aliases_select on public.vibeusage_model_aliases
       for select
       to authenticated
-      using ((select public.vibeusage_auth_uid()) is not null);
+      using (current_user = 'authenticated');
   end if;
 
   if to_regclass('public.vibeusage_pricing_model_aliases') is not null then
@@ -76,7 +76,7 @@ begin
     create policy vibeusage_pricing_model_aliases_select on public.vibeusage_pricing_model_aliases
       for select
       to authenticated
-      using ((select public.vibeusage_auth_uid()) is not null);
+      using (current_user = 'authenticated');
   end if;
 
   if to_regclass('public.vibeusage_pricing_profiles') is not null then
@@ -84,7 +84,7 @@ begin
     create policy vibeusage_pricing_profiles_select on public.vibeusage_pricing_profiles
       for select
       to authenticated
-      using ((select public.vibeusage_auth_uid()) is not null);
+      using (current_user = 'authenticated');
   end if;
 end $$;
 
@@ -158,8 +158,10 @@ begin
 
   if to_regprocedure('public.vibeusage_purge_events(timestamp with time zone,boolean)') is not null then
     revoke execute on function public.vibeusage_purge_events(timestamp with time zone, boolean) from public;
+    revoke execute on function public.vibeusage_purge_events(timestamp with time zone, boolean) from anon, authenticated;
     grant execute on function public.vibeusage_purge_events(timestamp with time zone, boolean) to project_admin;
     alter function public.vibeusage_purge_events(timestamp with time zone, boolean) set search_path = '';
+    alter function public.vibeusage_purge_events(timestamp with time zone, boolean) security invoker;
   end if;
 
   if to_regprocedure('public.vibeusage_exchange_link_code(text,text,text,text,text)') is not null then

--- a/scripts/ops/insforge-advisor-security-hardening.sql
+++ b/scripts/ops/insforge-advisor-security-hardening.sql
@@ -1,0 +1,196 @@
+-- Remediate InsForge Backend Advisor RLS and SECURITY DEFINER findings.
+-- Run against the InsForge Postgres database after reviewing the access notes below.
+--
+-- Access boundaries:
+-- - NFT and legacy public tables become default-deny through RLS.
+-- - Pricing/model metadata remains readable only by authenticated users.
+-- - project_admin remains a privileged DB role, but policies no longer use literal true.
+-- - SECURITY DEFINER functions stay privileged where required by ingest/link/leaderboard flows.
+
+begin;
+
+do $$
+declare
+  table_name text;
+begin
+  foreach table_name in array array[
+    'nft_siwe_nonces',
+    'nft_wallet_bindings',
+    'nft_wallet_binding_audit',
+    'nft_issuances',
+    'nft_allowlist_roots',
+    'vibeusage_user_totals',
+    'posts'
+  ]
+  loop
+    if to_regclass(format('public.%I', table_name)) is not null then
+      execute format('alter table public.%I enable row level security', table_name);
+      execute format('alter table public.%I force row level security', table_name);
+    end if;
+  end loop;
+end $$;
+
+do $$
+begin
+  if to_regclass('public.vibeusage_model_aliases') is not null then
+    drop policy if exists vibeusage_model_aliases_select on public.vibeusage_model_aliases;
+    create policy vibeusage_model_aliases_select on public.vibeusage_model_aliases
+      for select
+      to authenticated
+      using ((select auth.uid()) is not null);
+  end if;
+
+  if to_regclass('public.vibeusage_pricing_model_aliases') is not null then
+    drop policy if exists vibeusage_pricing_model_aliases_select on public.vibeusage_pricing_model_aliases;
+    create policy vibeusage_pricing_model_aliases_select on public.vibeusage_pricing_model_aliases
+      for select
+      to authenticated
+      using ((select auth.uid()) is not null);
+  end if;
+
+  if to_regclass('public.vibeusage_pricing_profiles') is not null then
+    drop policy if exists vibeusage_pricing_profiles_select on public.vibeusage_pricing_profiles;
+    create policy vibeusage_pricing_profiles_select on public.vibeusage_pricing_profiles
+      for select
+      to authenticated
+      using ((select auth.uid()) is not null);
+  end if;
+end $$;
+
+do $$
+declare
+  table_name text;
+begin
+  foreach table_name in array array[
+    'nft_siwe_nonces',
+    'nft_wallet_bindings',
+    'nft_wallet_binding_audit',
+    'nft_issuances',
+    'nft_allowlist_roots',
+    'vibeusage_user_totals',
+    'posts',
+    'vibeusage_projects',
+    'vibeusage_public_views',
+    'vibeusage_tracker_device_tokens',
+    'vibeusage_tracker_devices',
+    'vibeusage_tracker_events',
+    'vibeusage_tracker_hourly',
+    'vibeusage_tracker_ingest_batches',
+    'vibeusage_leaderboard_snapshots',
+    'vibeusage_link_codes',
+    'vibeusage_model_aliases',
+    'vibeusage_tracker_subscriptions',
+    'vibeusage_pricing_model_aliases',
+    'vibeusage_user_entitlements',
+    'vibeusage_pricing_profiles',
+    'vibeusage_user_settings'
+  ]
+  loop
+    if to_regclass(format('public.%I', table_name)) is not null then
+      execute format('drop policy if exists project_admin_policy on public.%I', table_name);
+      execute format(
+        'create policy project_admin_policy on public.%I for all to project_admin using (current_user = %L) with check (current_user = %L)',
+        table_name,
+        'project_admin',
+        'project_admin'
+      );
+    end if;
+  end loop;
+
+  if to_regclass('public.vibeusage_project_usage_hourly') is not null then
+    drop policy if exists project_admin_usage_policy on public.vibeusage_project_usage_hourly;
+    drop policy if exists project_admin_policy on public.vibeusage_project_usage_hourly;
+    create policy project_admin_policy on public.vibeusage_project_usage_hourly
+      for all
+      to project_admin
+      using (current_user = 'project_admin')
+      with check (current_user = 'project_admin');
+  end if;
+end $$;
+
+do $$
+begin
+  if to_regprocedure('public.vibeusage_device_token_allows_event_insert(uuid,uuid,uuid)') is not null then
+    revoke execute on function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) from public;
+    grant execute on function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) to anon, authenticated, project_admin;
+    alter function public.vibeusage_device_token_allows_event_insert(uuid, uuid, uuid) set search_path = '';
+  end if;
+
+  if to_regprocedure('public.vibeusage_leaderboard_system_earliest_day()') is not null then
+    revoke execute on function public.vibeusage_leaderboard_system_earliest_day() from public;
+    grant execute on function public.vibeusage_leaderboard_system_earliest_day() to authenticated, project_admin;
+    alter function public.vibeusage_leaderboard_system_earliest_day() set search_path = '';
+  end if;
+
+  if to_regprocedure('public.vibeusage_purge_events(timestamp with time zone,boolean)') is not null then
+    revoke execute on function public.vibeusage_purge_events(timestamp with time zone, boolean) from public;
+    grant execute on function public.vibeusage_purge_events(timestamp with time zone, boolean) to project_admin;
+    alter function public.vibeusage_purge_events(timestamp with time zone, boolean) set search_path = '';
+  end if;
+
+  if to_regprocedure('public.vibeusage_exchange_link_code(text,text,text,text,text)') is not null then
+    revoke execute on function public.vibeusage_exchange_link_code(text, text, text, text, text) from public;
+    grant execute on function public.vibeusage_exchange_link_code(text, text, text, text, text) to anon, authenticated, project_admin;
+    alter function public.vibeusage_exchange_link_code(text, text, text, text, text) set search_path = '';
+  end if;
+
+  if to_regprocedure('public.vibeusage_leaderboard_period(text,text,integer)') is not null then
+    revoke execute on function public.vibeusage_leaderboard_period(text, text, integer) from public;
+    grant execute on function public.vibeusage_leaderboard_period(text, text, integer) to authenticated, project_admin;
+    alter function public.vibeusage_leaderboard_period(text, text, integer) set search_path = '';
+  end if;
+
+  if to_regprocedure('public.vibeusage_leaderboard_me(text,text)') is not null then
+    revoke execute on function public.vibeusage_leaderboard_me(text, text) from public;
+    grant execute on function public.vibeusage_leaderboard_me(text, text) to authenticated, project_admin;
+    alter function public.vibeusage_leaderboard_me(text, text) set search_path = '';
+  end if;
+end $$;
+
+commit;
+
+-- Verification queries:
+--
+-- select c.relname, c.relrowsecurity, c.relforcerowsecurity
+-- from pg_class c
+-- join pg_namespace n on n.oid = c.relnamespace
+-- where n.nspname = 'public'
+--   and c.relname in (
+--     'nft_siwe_nonces',
+--     'nft_wallet_bindings',
+--     'nft_wallet_binding_audit',
+--     'nft_issuances',
+--     'nft_allowlist_roots',
+--     'vibeusage_user_totals',
+--     'posts'
+--   )
+-- order by c.relname;
+--
+-- select schemaname, tablename, policyname, roles, cmd, qual, with_check
+-- from pg_policies
+-- where schemaname = 'public'
+--   and (
+--     policyname in (
+--       'vibeusage_model_aliases_select',
+--       'vibeusage_pricing_model_aliases_select',
+--       'vibeusage_pricing_profiles_select',
+--       'project_admin_policy',
+--       'project_admin_usage_policy'
+--     )
+--     or tablename like 'vibeusage_%'
+--   )
+-- order by tablename, policyname;
+--
+-- select n.nspname, p.proname, pg_get_function_arguments(p.oid) as arguments, p.prosecdef, p.proconfig
+-- from pg_proc p
+-- join pg_namespace n on n.oid = p.pronamespace
+-- where n.nspname = 'public'
+--   and p.proname in (
+--     'vibeusage_device_token_allows_event_insert',
+--     'vibeusage_leaderboard_system_earliest_day',
+--     'vibeusage_purge_events',
+--     'vibeusage_exchange_link_code',
+--     'vibeusage_leaderboard_period',
+--     'vibeusage_leaderboard_me'
+--   )
+-- order by p.proname;

--- a/scripts/ops/vibeusage-tracker-subscriptions.sql
+++ b/scripts/ops/vibeusage-tracker-subscriptions.sql
@@ -29,31 +29,34 @@ create index if not exists vibeusage_tracker_subscriptions_updated_at_idx
 
 create or replace function public.vibeusage_auth_uid()
 returns uuid
-language sql
+language plpgsql
 stable
 set search_path = ''
 as $function$
-  with claims as (
-    select
-      nullif(current_setting('request.jwt.claim.sub', true), '') as legacy_sub,
-      nullif(current_setting('request.jwt.claims', true), '') as claims_json
-  ),
-  subject as (
-    select coalesce(
-      legacy_sub,
-      case
-        when claims_json is null then null
-        else claims_json::jsonb ->> 'sub'
-      end
-    ) as sub
-    from claims
-  )
-  select case
-    when sub ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-      then sub::uuid
-    else null
-  end
-  from subject
+declare
+  raw_claims text;
+  subject text;
+begin
+  raw_claims := nullif(current_setting('request.jwt.claims', true), '');
+  subject := coalesce(
+    nullif(current_setting('request.jwt.claim.sub', true), ''),
+    case
+      when raw_claims is null then null
+      else raw_claims::jsonb ->> 'sub'
+    end
+  );
+
+  if subject is null then
+    return null;
+  end if;
+
+  begin
+    return subject::uuid;
+  exception
+    when invalid_text_representation then
+      return null;
+  end;
+end
 $function$;
 
 grant execute on function public.vibeusage_auth_uid() to public;

--- a/scripts/ops/vibeusage-tracker-subscriptions.sql
+++ b/scripts/ops/vibeusage-tracker-subscriptions.sql
@@ -27,6 +27,37 @@ create index if not exists vibeusage_tracker_subscriptions_user_id_idx
 create index if not exists vibeusage_tracker_subscriptions_updated_at_idx
   on public.vibeusage_tracker_subscriptions(updated_at desc);
 
+create or replace function public.vibeusage_auth_uid()
+returns uuid
+language sql
+stable
+set search_path = ''
+as $function$
+  with claims as (
+    select
+      nullif(current_setting('request.jwt.claim.sub', true), '') as legacy_sub,
+      nullif(current_setting('request.jwt.claims', true), '') as claims_json
+  ),
+  subject as (
+    select coalesce(
+      legacy_sub,
+      case
+        when claims_json is null then null
+        else claims_json::jsonb ->> 'sub'
+      end
+    ) as sub
+    from claims
+  )
+  select case
+    when sub ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      then sub::uuid
+    else null
+  end
+  from subject
+$function$;
+
+grant execute on function public.vibeusage_auth_uid() to public;
+
 alter table public.vibeusage_tracker_subscriptions enable row level security;
 
 drop policy if exists project_admin_policy on public.vibeusage_tracker_subscriptions;
@@ -41,4 +72,4 @@ drop policy if exists vibeusage_tracker_subscriptions_select on public.vibeusage
 create policy vibeusage_tracker_subscriptions_select on public.vibeusage_tracker_subscriptions
   for select
   to public
-  using (auth.uid() = user_id);
+  using ((select public.vibeusage_auth_uid()) = user_id);

--- a/test/insforge-advisor-performance-hardening.test.js
+++ b/test/insforge-advisor-performance-hardening.test.js
@@ -40,7 +40,7 @@ test("advisor performance hardening adds concurrent FK indexes", () => {
   assert.doesNotMatch(sql, /\bcommit\b/i);
 });
 
-test("advisor performance hardening wraps auth.uid in RLS policies", () => {
+test("advisor performance hardening uses safe auth uid in RLS policies", () => {
   const sql = readSql();
   for (const policyName of [
     "vibeusage_link_codes_insert_self",
@@ -54,7 +54,8 @@ test("advisor performance hardening wraps auth.uid in RLS policies", () => {
   ]) {
     assert.match(sql, new RegExp(`alter policy ${policyName}`));
   }
-  assert.match(sql, /\(select auth\.uid\(\)\) = user_id/);
-  assert.doesNotMatch(sql, /auth\.uid\(\) = user_id/);
-  assert.match(sql, /d\.user_id = \(select auth\.uid\(\)\)/);
+  assert.match(sql, /create or replace function public\.vibeusage_auth_uid\(\)/);
+  assert.match(sql, /\(select public\.vibeusage_auth_uid\(\)\) = user_id/);
+  assert.doesNotMatch(sql, /\(select auth\.uid\(\)\) = user_id/);
+  assert.match(sql, /d\.user_id = \(select public\.vibeusage_auth_uid\(\)\)/);
 });

--- a/test/insforge-advisor-performance-hardening.test.js
+++ b/test/insforge-advisor-performance-hardening.test.js
@@ -36,8 +36,8 @@ test("advisor performance hardening adds concurrent FK indexes", () => {
   ]) {
     assert.match(sql, new RegExp(`create index concurrently if not exists ${indexName}`));
   }
-  assert.doesNotMatch(sql, /\bbegin\b/i);
-  assert.doesNotMatch(sql, /\bcommit\b/i);
+  assert.doesNotMatch(sql, /^begin;$/im);
+  assert.doesNotMatch(sql, /^commit;$/im);
 });
 
 test("advisor performance hardening uses safe auth uid in RLS policies", () => {

--- a/test/insforge-advisor-performance-hardening.test.js
+++ b/test/insforge-advisor-performance-hardening.test.js
@@ -1,0 +1,60 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sqlPath = path.join(
+  __dirname,
+  "..",
+  "scripts",
+  "ops",
+  "insforge-advisor-performance-hardening.sql",
+);
+
+function readSql() {
+  return fs.readFileSync(sqlPath, "utf8");
+}
+
+test("advisor performance hardening adds concurrent FK indexes", () => {
+  const sql = readSql();
+  for (const indexName of [
+    "idx_vibeusage_tracker_device_tokens_device_id",
+    "idx_vibeusage_tracker_events_device_id",
+    "idx_vibeusage_tracker_events_device_token_id",
+    "idx_vibeusage_user_settings_user_id",
+    "idx_vibeusage_tracker_hourly_device_token_id",
+    "idx_vibeusage_tracker_ingest_batches_device_token_id",
+    "idx_vibeusage_user_entitlements_user_id",
+    "idx_vibeusage_link_codes_user_id",
+    "idx_vibeusage_public_views_user_id",
+    "idx_vibeusage_projects_device_id",
+    "idx_vibeusage_projects_device_token_id",
+    "idx_vibeusage_project_usage_hourly_device_id",
+    "idx_vibeusage_project_usage_hourly_device_token_id",
+    "idx_vibeusage_tracker_subscriptions_device_id",
+    "idx_vibeusage_tracker_subscriptions_device_token_id",
+  ]) {
+    assert.match(sql, new RegExp(`create index concurrently if not exists ${indexName}`));
+  }
+  assert.doesNotMatch(sql, /\bbegin\b/i);
+  assert.doesNotMatch(sql, /\bcommit\b/i);
+});
+
+test("advisor performance hardening wraps auth.uid in RLS policies", () => {
+  const sql = readSql();
+  for (const policyName of [
+    "vibeusage_link_codes_insert_self",
+    "vibeusage_project_usage_hourly_select",
+    "vibeusage_projects_select",
+    "vibeusage_public_views_update",
+    "vibeusage_tracker_device_tokens_insert",
+    "vibeusage_tracker_devices_update",
+    "vibeusage_tracker_hourly_select",
+    "vibeusage_user_settings_update",
+  ]) {
+    assert.match(sql, new RegExp(`alter policy ${policyName}`));
+  }
+  assert.match(sql, /\(select auth\.uid\(\)\) = user_id/);
+  assert.doesNotMatch(sql, /auth\.uid\(\) = user_id/);
+  assert.match(sql, /d\.user_id = \(select auth\.uid\(\)\)/);
+});

--- a/test/insforge-advisor-security-hardening.test.js
+++ b/test/insforge-advisor-security-hardening.test.js
@@ -43,11 +43,9 @@ test("advisor hardening removes anonymous metadata reads", () => {
   }
   assert.doesNotMatch(sql, /for select\s+to public\s+using\s*\(true\)/i);
   assert.match(sql, /create or replace function public\.vibeusage_auth_uid\(\)/);
-  assert.match(
-    sql,
-    /to authenticated\s+using \(\(select public\.vibeusage_auth_uid\(\)\) is not null\)/i,
-  );
+  assert.match(sql, /to authenticated\s+using \(current_user = 'authenticated'\)/i);
   assert.doesNotMatch(sql, /\(select auth\.uid\(\)\) is not null/i);
+  assert.doesNotMatch(sql, /vibeusage_model_aliases_select[\s\S]*public\.vibeusage_auth_uid\(\)/i);
 });
 
 test("advisor hardening keeps project_admin explicit instead of literal true", () => {
@@ -84,6 +82,8 @@ test("advisor hardening locks SECURITY DEFINER execution grants", () => {
   assert.match(sql, /set search_path = ''/);
   assert.match(sql, /alter function public\.vibeusage_device_token_allows_event_insert\(uuid, uuid, uuid\) security invoker/);
   assert.match(sql, /revoke execute on function public\.vibeusage_leaderboard_me\(text, text\) from anon, authenticated/);
+  assert.match(sql, /revoke execute on function public\.vibeusage_purge_events\(timestamp with time zone, boolean\) from anon, authenticated/);
+  assert.match(sql, /alter function public\.vibeusage_purge_events\(timestamp with time zone, boolean\) security invoker/);
   assert.match(sql, /grant execute on function public\.vibeusage_purge_events\(timestamp with time zone, boolean\) to project_admin/);
   assert.doesNotMatch(sql, /grant execute on function public\.vibeusage_leaderboard_me\(text, text\) to authenticated/);
 });

--- a/test/insforge-advisor-security-hardening.test.js
+++ b/test/insforge-advisor-security-hardening.test.js
@@ -80,7 +80,9 @@ test("advisor hardening locks SECURITY DEFINER execution grants", () => {
     assert.match(sql, new RegExp(`alter function public\\.${functionName}`));
   }
   assert.match(sql, /set search_path = ''/);
-  assert.match(sql, /alter function public\.vibeusage_device_token_allows_event_insert\(uuid, uuid, uuid\) security invoker/);
+  assert.match(sql, /alter function public\.vibeusage_device_token_allows_event_insert\(uuid, uuid, uuid\) security definer/);
+  assert.doesNotMatch(sql, /revoke execute on function public\.vibeusage_device_token_allows_event_insert\(uuid, uuid, uuid\) from anon, authenticated/);
+  assert.match(sql, /grant execute on function public\.vibeusage_device_token_allows_event_insert\(uuid, uuid, uuid\) to anon, authenticated, project_admin/);
   assert.match(sql, /revoke execute on function public\.vibeusage_leaderboard_me\(text, text\) from anon, authenticated/);
   assert.match(sql, /revoke execute on function public\.vibeusage_purge_events\(timestamp with time zone, boolean\) from anon, authenticated/);
   assert.match(sql, /alter function public\.vibeusage_purge_events\(timestamp with time zone, boolean\) security invoker/);

--- a/test/insforge-advisor-security-hardening.test.js
+++ b/test/insforge-advisor-security-hardening.test.js
@@ -42,7 +42,12 @@ test("advisor hardening removes anonymous metadata reads", () => {
     assert.match(sql, new RegExp(`create policy ${policyName}`));
   }
   assert.doesNotMatch(sql, /for select\s+to public\s+using\s*\(true\)/i);
-  assert.match(sql, /to authenticated\s+using \(\(select auth\.uid\(\)\) is not null\)/i);
+  assert.match(sql, /create or replace function public\.vibeusage_auth_uid\(\)/);
+  assert.match(
+    sql,
+    /to authenticated\s+using \(\(select public\.vibeusage_auth_uid\(\)\) is not null\)/i,
+  );
+  assert.doesNotMatch(sql, /\(select auth\.uid\(\)\) is not null/i);
 });
 
 test("advisor hardening keeps project_admin explicit instead of literal true", () => {

--- a/test/insforge-advisor-security-hardening.test.js
+++ b/test/insforge-advisor-security-hardening.test.js
@@ -77,5 +77,8 @@ test("advisor hardening locks SECURITY DEFINER execution grants", () => {
     assert.match(sql, new RegExp(`alter function public\\.${functionName}`));
   }
   assert.match(sql, /set search_path = ''/);
+  assert.match(sql, /alter function public\.vibeusage_device_token_allows_event_insert\(uuid, uuid, uuid\) security invoker/);
+  assert.match(sql, /revoke execute on function public\.vibeusage_leaderboard_me\(text, text\) from anon, authenticated/);
   assert.match(sql, /grant execute on function public\.vibeusage_purge_events\(timestamp with time zone, boolean\) to project_admin/);
+  assert.doesNotMatch(sql, /grant execute on function public\.vibeusage_leaderboard_me\(text, text\) to authenticated/);
 });

--- a/test/insforge-advisor-security-hardening.test.js
+++ b/test/insforge-advisor-security-hardening.test.js
@@ -1,0 +1,81 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sqlPath = path.join(
+  __dirname,
+  "..",
+  "scripts",
+  "ops",
+  "insforge-advisor-security-hardening.sql",
+);
+
+function readSql() {
+  return fs.readFileSync(sqlPath, "utf8");
+}
+
+test("advisor hardening enables forced RLS for reported public tables", () => {
+  const sql = readSql();
+  for (const tableName of [
+    "nft_siwe_nonces",
+    "nft_wallet_bindings",
+    "nft_wallet_binding_audit",
+    "nft_issuances",
+    "nft_allowlist_roots",
+    "vibeusage_user_totals",
+    "posts",
+  ]) {
+    assert.match(sql, new RegExp(`'${tableName}'`));
+  }
+  assert.match(sql, /enable row level security/);
+  assert.match(sql, /force row level security/);
+});
+
+test("advisor hardening removes anonymous metadata reads", () => {
+  const sql = readSql();
+  for (const policyName of [
+    "vibeusage_model_aliases_select",
+    "vibeusage_pricing_model_aliases_select",
+    "vibeusage_pricing_profiles_select",
+  ]) {
+    assert.match(sql, new RegExp(`create policy ${policyName}`));
+  }
+  assert.doesNotMatch(sql, /for select\s+to public\s+using\s*\(true\)/i);
+  assert.match(sql, /to authenticated\s+using \(\(select auth\.uid\(\)\) is not null\)/i);
+});
+
+test("advisor hardening keeps project_admin explicit instead of literal true", () => {
+  const sql = readSql();
+  for (const tableName of [
+    "nft_siwe_nonces",
+    "nft_wallet_bindings",
+    "nft_wallet_binding_audit",
+    "nft_issuances",
+    "nft_allowlist_roots",
+    "vibeusage_user_totals",
+    "posts",
+  ]) {
+    assert.match(sql, new RegExp(`'${tableName}'`));
+  }
+  assert.match(sql, /create policy project_admin_policy/);
+  assert.match(sql, /current_user = 'project_admin'/);
+  assert.doesNotMatch(sql, /to project_admin using \(true\) with check \(true\)/i);
+});
+
+test("advisor hardening locks SECURITY DEFINER execution grants", () => {
+  const sql = readSql();
+  for (const functionName of [
+    "vibeusage_device_token_allows_event_insert",
+    "vibeusage_leaderboard_system_earliest_day",
+    "vibeusage_purge_events",
+    "vibeusage_exchange_link_code",
+    "vibeusage_leaderboard_period",
+    "vibeusage_leaderboard_me",
+  ]) {
+    assert.match(sql, new RegExp(`revoke execute on function public\\.${functionName}`));
+    assert.match(sql, new RegExp(`alter function public\\.${functionName}`));
+  }
+  assert.match(sql, /set search_path = ''/);
+  assert.match(sql, /grant execute on function public\.vibeusage_purge_events\(timestamp with time zone, boolean\) to project_admin/);
+});

--- a/test/insforge-auth-uid-nonuuid.test.js
+++ b/test/insforge-auth-uid-nonuuid.test.js
@@ -9,7 +9,9 @@ test("auth uid nonuuid fix installs safe helper and rewires RLS policies", () =>
   const sql = fs.readFileSync(sqlPath, "utf8");
   assert.match(sql, /create or replace function public\.vibeusage_auth_uid\(\)/);
   assert.match(sql, /project-admin-with-api-key/);
-  assert.match(sql, /when sub ~\*/);
+  assert.match(sql, /language plpgsql/);
+  assert.match(sql, /return subject::uuid/);
+  assert.match(sql, /when invalid_text_representation then/);
   assert.match(sql, /alter policy vibeusage_tracker_device_tokens_select/);
   assert.match(sql, /alter policy vibeusage_model_aliases_select on public\.vibeusage_model_aliases\s+using \(current_user = 'authenticated'\)/);
   assert.match(sql, /\(select public\.vibeusage_auth_uid\(\)\) = user_id/);

--- a/test/insforge-auth-uid-nonuuid.test.js
+++ b/test/insforge-auth-uid-nonuuid.test.js
@@ -1,0 +1,16 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sqlPath = path.join(__dirname, "..", "scripts", "ops", "fix-auth-uid-nonuuid.sql");
+
+test("auth uid nonuuid fix installs safe helper and rewires RLS policies", () => {
+  const sql = fs.readFileSync(sqlPath, "utf8");
+  assert.match(sql, /create or replace function public\.vibeusage_auth_uid\(\)/);
+  assert.match(sql, /project-admin-with-api-key/);
+  assert.match(sql, /when sub ~\*/);
+  assert.match(sql, /alter policy vibeusage_tracker_device_tokens_select/);
+  assert.match(sql, /\(select public\.vibeusage_auth_uid\(\)\) = user_id/);
+  assert.doesNotMatch(sql, /\(select auth\.uid\(\)\) = user_id/);
+});

--- a/test/insforge-auth-uid-nonuuid.test.js
+++ b/test/insforge-auth-uid-nonuuid.test.js
@@ -11,6 +11,7 @@ test("auth uid nonuuid fix installs safe helper and rewires RLS policies", () =>
   assert.match(sql, /project-admin-with-api-key/);
   assert.match(sql, /when sub ~\*/);
   assert.match(sql, /alter policy vibeusage_tracker_device_tokens_select/);
+  assert.match(sql, /alter policy vibeusage_model_aliases_select on public\.vibeusage_model_aliases\s+using \(current_user = 'authenticated'\)/);
   assert.match(sql, /\(select public\.vibeusage_auth_uid\(\)\) = user_id/);
   assert.doesNotMatch(sql, /\(select auth\.uid\(\)\) = user_id/);
 });


### PR DESCRIPTION
# What does this PR do?

Fixes VibeUsage tracker ingest failures when InsForge API-key requests carry a non-UUID JWT subject such as `project-admin-with-api-key`.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [x] Risk / contract change

## Changes Made

- Add `public.vibeusage_auth_uid()` as a safe replacement for direct `auth.uid()` usage in VibeUsage RLS policies.
- Rewire tracker, project usage, metadata, subscription, entitlement, public view, and settings policies to use the safe helper.
- Add a standalone hotfix SQL script for the live non-UUID subject failure.
- Add regression tests covering the helper installation and policy rewiring.

## Affected Modules / Contracts

- **Modules touched:** `scripts/ops`, `test`
- **Dependencies / contracts touched:** InsForge/PostgREST RLS policy evaluation for project API-key and user JWT subjects
- **Repo sitemap evidence:** `not required` - no module boundary, entrypoint, or data-flow ownership change

## Validation

### Automated

- `node --test --test-concurrency=1 test/insforge-auth-uid-nonuuid.test.js test/insforge-advisor-performance-hardening.test.js test/insforge-advisor-security-hardening.test.js` - passed, 7/7
- `rg -n "\\(select auth\\.uid\\(\\)\\)|using \\(auth\\.uid\\(\\)|with check \\(auth\\.uid\\(\\)" scripts/ops test || true` - no matches
- `node --test --test-concurrency=1 test/init-local-runtime-reinstall.test.js` - passed on rerun
- `npm run ci:local` - full run reached 844/845 tests, then failed once in `test/init-local-runtime-reinstall.test.js` with temporary directory cleanup `ENOTEMPTY`; the failing test passed when rerun alone

### Manual / smoke

- `node bin/tracker.js sync --drain` - passed after live fix, uploaded pending usage rows
- `node bin/tracker.js status` - queue returned to `0 bytes pending`, `Backoff until: never`

### Uncovered scope

- Did not change InsForge-managed `auth.uid()` because `auth` schema writes are protected.
- Did not push directly to `main`.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [x] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

- UUID JWT subjects must still compare exactly against `user_id`.
- Missing or non-UUID subjects must return `null`, not throw a cast error.
- Existing user-scoped policies remain default-deny for non-user service/API-key subjects unless another explicit policy authorizes the request.

### Boundary Matrix (must list at least 3)

- User JWT with UUID `sub` -> `public.vibeusage_auth_uid()` returns UUID -> user RLS policies can match `user_id`.
- Project API-key request with `sub=project-admin-with-api-key` -> helper returns `null` -> user RLS policies do not throw and do not grant user access.
- Missing subject claims -> helper returns `null` -> policies remain default-deny.
- Device-token ingest lookup -> token-hash policy can be evaluated without being preempted by `auth.uid()` UUID cast failure.

### Evidence

- Live root cause reproduced as `invalid input syntax for type uuid: "project-admin-with-api-key"` during `vibeusage_tracker_device_tokens` token-hash lookup.
- Live hotfix verified by successful `node bin/tracker.js sync --drain` upload and empty queue status.
- Regression tests assert the safe helper exists and direct `(select auth.uid()) = user_id` policy forms are absent from touched ops SQL.

## Public Exposure Addendum (required if public exposure is checked)

- **Access rules:** N/A
- **Exposed fields:** N/A
- **Avatar / image policy:** N/A
- **Regression coverage:** N/A

## Reviewer Context (optional)

- **Review focus:** RLS policy semantics around non-UUID InsForge API-key subjects.
- **Delta since last review:** Adds safe helper and rewires direct `auth.uid()` policy comparisons introduced by advisor hardening.
- **Depends on:** Current live InsForge behavior where project API-key requests can use a non-UUID subject.
- **Known gaps / follow-ups:** Consider adding a deploy-time catalog validation that flags direct `auth.uid()` usage in public RLS policies.

## Screenshots / Logs (optional)

- `Sync finished: Uploaded: 2 inserted, 0 skipped`
- `Status: Queue: 0 bytes pending; Backoff until: never`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix InsForge RLS policies to handle non-UUID JWT auth subjects without errors
> - Introduces `public.vibeusage_auth_uid()`, a stable PL/pgSQL helper that safely extracts a UUID from the JWT `sub` claim, returning `null` for missing or non-UUID subjects instead of raising a cast error.
> - Rewrites RLS policies across all `vibeusage_*` tables to use `(select public.vibeusage_auth_uid()) = user_id` instead of `auth.uid()`, making policy evaluation null-safe.
> - Restricts SELECT on `vibeusage_model_aliases`, `vibeusage_pricing_model_aliases`, and `vibeusage_pricing_profiles` to the `authenticated` role.
> - Tightens function security by revoking broad `EXECUTE` grants, setting empty `search_path`, and scoping grants to specific roles (e.g. `anon`, `authenticated`, `project_admin`).
> - Behavioral Change: requests with non-UUID or missing JWT subjects now receive an access denied response rather than a database cast error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55795c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->