### PR TITLE
Fix web auth refresh fallback

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -334,11 +334,12 @@ export default function App() {
   useEffect(() => {
     if (!insforgeLoaded) return;
     if (hasInsforgeSession) return;
+    if (sessionSoftExpired) return;
     clearInsforgePersistentStorage();
     clearAuthStorage();
     clearSessionExpired();
     clearSessionSoftExpired();
-  }, [hasInsforgeSession, insforgeLoaded]);
+  }, [hasInsforgeSession, insforgeLoaded, sessionSoftExpired]);
 
   const signOut = useMemo(() => {
     return async () => {

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -206,6 +206,7 @@ export default function App() {
       return;
     }
     if (!sessionSoftExpired) return;
+    if (insforgeSession?.accessToken) return;
     // Avoid getting stuck on dashboard without a usable session token.
     clearSessionSoftExpired();
   }, [insforgeLoaded, insforgeSession, sessionSoftExpired]);

--- a/dashboard/src/lib/__tests__/auth-storage.test.ts
+++ b/dashboard/src/lib/__tests__/auth-storage.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearSessionSoftExpired,
+  isSessionSoftExpiredForToken,
   loadSessionSoftExpired,
   loadSessionSoftExpiredState,
   markSessionSoftExpired,
@@ -71,6 +72,7 @@ describe("session soft expiry storage", () => {
     markSessionSoftExpired(token);
 
     expect(shouldClearSessionSoftExpiredForToken(token)).toBe(false);
+    expect(isSessionSoftExpiredForToken(token)).toBe(true);
   });
 
   it("clears soft expiry only when a different token arrives", () => {
@@ -88,6 +90,7 @@ describe("session soft expiry storage", () => {
     markSessionSoftExpired(firstToken);
 
     expect(shouldClearSessionSoftExpiredForToken(secondToken)).toBe(true);
+    expect(isSessionSoftExpiredForToken(secondToken)).toBe(false);
   });
 
   it("keeps legacy soft-expired markers clearable after a new token appears", () => {

--- a/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
+++ b/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
@@ -184,7 +184,7 @@ describe("getCurrentInsforgeSession", () => {
     expect(authMocks.refreshSession).toHaveBeenCalledTimes(1);
   });
 
-  it("marks expired restored sessions as soft-expired when refresh fails", async () => {
+  it("marks expired restored sessions as soft-expired when refresh fails transiently", async () => {
     const expiredToken = createJwt({ sub: "u6", expiresInMs: -5 * 60 * 1000 });
     tokenManagerState.session = {
       accessToken: expiredToken,
@@ -201,6 +201,29 @@ describe("getCurrentInsforgeSession", () => {
 
     expect(authMocks.refreshSession).toHaveBeenCalledTimes(1);
     expect(authStorageMocks.markSessionSoftExpired).toHaveBeenCalledWith(expiredToken);
+    expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
+  });
+
+  it("does not mark soft-expired when refresh fails with a permanent auth error", async () => {
+    tokenManagerState.session = {
+      accessToken: createJwt({ sub: "u7", expiresInMs: -5 * 60 * 1000 }),
+      user: { id: "u7" },
+    };
+    authMocks.refreshSession.mockResolvedValueOnce({
+      data: null,
+      error: {
+        statusCode: 401,
+        error: "INVALID_TOKEN",
+        message: "Refresh token revoked",
+      },
+    });
+
+    const mod = await import("../insforge-auth-client");
+
+    await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
+
+    expect(authMocks.refreshSession).toHaveBeenCalledTimes(1);
+    expect(authStorageMocks.markSessionSoftExpired).not.toHaveBeenCalled();
     expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
   });
 

--- a/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
+++ b/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
@@ -207,6 +207,35 @@ describe("getCurrentInsforgeSession", () => {
     expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
   });
 
+  it("keeps soft-expired retry state for generic 400 and 403 refresh errors", async () => {
+    const expiredToken = createJwt({ sub: "u10", expiresInMs: -5 * 60 * 1000 });
+    for (const statusCode of [400, 403]) {
+      vi.resetModules();
+      tokenManagerState.session = {
+        accessToken: expiredToken,
+        user: { id: "u10" },
+      };
+      delete (authClient.tokenManager as Record<string, unknown>).__vibeusage_auth_session_store_v1__;
+      authMocks.refreshSession.mockReset();
+      authMocks.refreshSession.mockResolvedValueOnce({
+        data: null,
+        error: {
+          statusCode,
+          message: "temporary auth gateway failure",
+        },
+      });
+      authStorageMocks.clearSessionSoftExpired.mockReset();
+      authStorageMocks.markSessionSoftExpired.mockReset();
+
+      const mod = await import("../insforge-auth-client");
+
+      await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
+
+      expect(authStorageMocks.clearSessionSoftExpired).not.toHaveBeenCalled();
+      expect(authStorageMocks.markSessionSoftExpired).toHaveBeenCalledWith(expiredToken);
+    }
+  });
+
   it("clears soft-expired state when refresh fails with a permanent auth error", async () => {
     tokenManagerState.session = {
       accessToken: createJwt({ sub: "u7", expiresInMs: -5 * 60 * 1000 }),

--- a/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
+++ b/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
@@ -207,9 +207,9 @@ describe("getCurrentInsforgeSession", () => {
     expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
   });
 
-  it("keeps soft-expired retry state for generic 400 and 403 refresh errors", async () => {
+  it("keeps soft-expired retry state for generic 400, 401, and 403 refresh errors", async () => {
     const expiredToken = createJwt({ sub: "u10", expiresInMs: -5 * 60 * 1000 });
-    for (const statusCode of [400, 403]) {
+    for (const statusCode of [400, 401, 403]) {
       vi.resetModules();
       tokenManagerState.session = {
         accessToken: expiredToken,

--- a/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
+++ b/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
@@ -21,6 +21,10 @@ const authMocks = vi.hoisted(() => ({
   getProfile: vi.fn(),
 }));
 
+const authStorageMocks = vi.hoisted(() => ({
+  markSessionSoftExpired: vi.fn(),
+}));
+
 const authClient = vi.hoisted(() => ({
   tokenManager: {
     getSession: tokenManagerMocks.getSession,
@@ -38,6 +42,8 @@ const authClient = vi.hoisted(() => ({
 vi.mock("../insforge-client", () => ({
   createInsforgeAuthClient: vi.fn(() => authClient),
 }));
+
+vi.mock("../auth-storage", () => authStorageMocks);
 
 function createJwt({
   sub = "u1",
@@ -87,6 +93,7 @@ describe("getCurrentInsforgeSession", () => {
     authMocks.getCurrentUser.mockReset();
     authMocks.refreshSession.mockReset();
     authMocks.getProfile.mockReset();
+    authStorageMocks.markSessionSoftExpired.mockReset();
   });
 
   it("dedupes concurrent user hydration across callers", async () => {
@@ -175,6 +182,26 @@ describe("getCurrentInsforgeSession", () => {
     });
 
     expect(authMocks.refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks expired restored sessions as soft-expired when refresh fails", async () => {
+    const expiredToken = createJwt({ sub: "u6", expiresInMs: -5 * 60 * 1000 });
+    tokenManagerState.session = {
+      accessToken: expiredToken,
+      user: { id: "u6" },
+    };
+    authMocks.refreshSession.mockResolvedValueOnce({
+      data: null,
+      error: { message: "refresh failed" },
+    });
+
+    const mod = await import("../insforge-auth-client");
+
+    await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
+
+    expect(authMocks.refreshSession).toHaveBeenCalledTimes(1);
+    expect(authStorageMocks.markSessionSoftExpired).toHaveBeenCalledWith(expiredToken);
+    expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
   });
 
   it("publishes token-manager changes through the session store", async () => {

--- a/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
+++ b/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
@@ -261,29 +261,37 @@ describe("getCurrentInsforgeSession", () => {
     expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
   });
 
-  it("clears soft-expired state after a generic auth failure repeats for the same token", async () => {
+  it("clears soft-expired state after generic auth failures repeat for the same token", async () => {
     const expiredToken = createJwt({ sub: "u11", expiresInMs: -5 * 60 * 1000 });
-    tokenManagerState.session = {
-      accessToken: expiredToken,
-      user: { id: "u11" },
-    };
-    authStorageMocks.isSessionSoftExpiredForToken.mockReturnValueOnce(true);
-    authMocks.refreshSession.mockResolvedValueOnce({
-      data: null,
-      error: {
-        statusCode: 401,
-        message: "Unauthorized",
-      },
-    });
+    for (const statusCode of [400, 401, 403]) {
+      vi.resetModules();
+      tokenManagerState.session = {
+        accessToken: expiredToken,
+        user: { id: "u11" },
+      };
+      delete (authClient.tokenManager as Record<string, unknown>).__vibeusage_auth_session_store_v1__;
+      authMocks.refreshSession.mockReset();
+      authMocks.refreshSession.mockResolvedValueOnce({
+        data: null,
+        error: {
+          statusCode,
+          message: statusCode === 400 ? "bad request" : "Unauthorized",
+        },
+      });
+      authStorageMocks.isSessionSoftExpiredForToken.mockReset();
+      authStorageMocks.isSessionSoftExpiredForToken.mockReturnValueOnce(true);
+      authStorageMocks.clearSessionSoftExpired.mockReset();
+      authStorageMocks.markSessionSoftExpired.mockReset();
 
-    const mod = await import("../insforge-auth-client");
+      const mod = await import("../insforge-auth-client");
 
-    await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
+      await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
 
-    expect(authStorageMocks.isSessionSoftExpiredForToken).toHaveBeenCalledWith(expiredToken);
-    expect(authStorageMocks.clearSessionSoftExpired).toHaveBeenCalledTimes(1);
-    expect(authStorageMocks.markSessionSoftExpired).not.toHaveBeenCalled();
-    expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
+      expect(authStorageMocks.isSessionSoftExpiredForToken).toHaveBeenCalledWith(expiredToken);
+      expect(authStorageMocks.clearSessionSoftExpired).toHaveBeenCalledTimes(1);
+      expect(authStorageMocks.markSessionSoftExpired).not.toHaveBeenCalled();
+      expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
+    }
   });
 
   it("clears soft-expired state when refresh fails with a permanent auth error", async () => {

--- a/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
+++ b/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
@@ -22,6 +22,7 @@ const authMocks = vi.hoisted(() => ({
 }));
 
 const authStorageMocks = vi.hoisted(() => ({
+  clearSessionSoftExpired: vi.fn(),
   markSessionSoftExpired: vi.fn(),
 }));
 
@@ -93,6 +94,8 @@ describe("getCurrentInsforgeSession", () => {
     authMocks.getCurrentUser.mockReset();
     authMocks.refreshSession.mockReset();
     authMocks.getProfile.mockReset();
+    (authClient.auth as any).refreshSession = authMocks.refreshSession;
+    authStorageMocks.clearSessionSoftExpired.mockReset();
     authStorageMocks.markSessionSoftExpired.mockReset();
   });
 
@@ -204,7 +207,7 @@ describe("getCurrentInsforgeSession", () => {
     expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
   });
 
-  it("does not mark soft-expired when refresh fails with a permanent auth error", async () => {
+  it("clears soft-expired state when refresh fails with a permanent auth error", async () => {
     tokenManagerState.session = {
       accessToken: createJwt({ sub: "u7", expiresInMs: -5 * 60 * 1000 }),
       user: { id: "u7" },
@@ -223,6 +226,24 @@ describe("getCurrentInsforgeSession", () => {
     await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
 
     expect(authMocks.refreshSession).toHaveBeenCalledTimes(1);
+    expect(authStorageMocks.clearSessionSoftExpired).toHaveBeenCalledTimes(1);
+    expect(authStorageMocks.markSessionSoftExpired).not.toHaveBeenCalled();
+    expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
+  });
+
+  it("clears soft-expired state when refresh is unsupported", async () => {
+    tokenManagerState.session = {
+      accessToken: createJwt({ sub: "u8", expiresInMs: -5 * 60 * 1000 }),
+      user: { id: "u8" },
+    };
+    (authClient.auth as any).refreshSession = undefined;
+
+    const mod = await import("../insforge-auth-client");
+
+    await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
+
+    expect(authMocks.refreshSession).not.toHaveBeenCalled();
+    expect(authStorageMocks.clearSessionSoftExpired).toHaveBeenCalledTimes(1);
     expect(authStorageMocks.markSessionSoftExpired).not.toHaveBeenCalled();
     expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
   });

--- a/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
+++ b/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
@@ -23,6 +23,7 @@ const authMocks = vi.hoisted(() => ({
 
 const authStorageMocks = vi.hoisted(() => ({
   clearSessionSoftExpired: vi.fn(),
+  isSessionSoftExpiredForToken: vi.fn(() => false),
   markSessionSoftExpired: vi.fn(),
 }));
 
@@ -96,6 +97,8 @@ describe("getCurrentInsforgeSession", () => {
     authMocks.getProfile.mockReset();
     (authClient.auth as any).refreshSession = authMocks.refreshSession;
     authStorageMocks.clearSessionSoftExpired.mockReset();
+    authStorageMocks.isSessionSoftExpiredForToken.mockReset();
+    authStorageMocks.isSessionSoftExpiredForToken.mockReturnValue(false);
     authStorageMocks.markSessionSoftExpired.mockReset();
   });
 
@@ -234,6 +237,31 @@ describe("getCurrentInsforgeSession", () => {
       expect(authStorageMocks.clearSessionSoftExpired).not.toHaveBeenCalled();
       expect(authStorageMocks.markSessionSoftExpired).toHaveBeenCalledWith(expiredToken);
     }
+  });
+
+  it("clears soft-expired state after a generic auth failure repeats for the same token", async () => {
+    const expiredToken = createJwt({ sub: "u11", expiresInMs: -5 * 60 * 1000 });
+    tokenManagerState.session = {
+      accessToken: expiredToken,
+      user: { id: "u11" },
+    };
+    authStorageMocks.isSessionSoftExpiredForToken.mockReturnValueOnce(true);
+    authMocks.refreshSession.mockResolvedValueOnce({
+      data: null,
+      error: {
+        statusCode: 401,
+        message: "Unauthorized",
+      },
+    });
+
+    const mod = await import("../insforge-auth-client");
+
+    await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
+
+    expect(authStorageMocks.isSessionSoftExpiredForToken).toHaveBeenCalledWith(expiredToken);
+    expect(authStorageMocks.clearSessionSoftExpired).toHaveBeenCalledTimes(1);
+    expect(authStorageMocks.markSessionSoftExpired).not.toHaveBeenCalled();
+    expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
   });
 
   it("clears soft-expired state when refresh fails with a permanent auth error", async () => {

--- a/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
+++ b/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
@@ -248,6 +248,26 @@ describe("getCurrentInsforgeSession", () => {
     expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
   });
 
+  it("clears soft-expired state when refresh returns no session and no error", async () => {
+    tokenManagerState.session = {
+      accessToken: createJwt({ sub: "u9", expiresInMs: -5 * 60 * 1000 }),
+      user: { id: "u9" },
+    };
+    authMocks.refreshSession.mockResolvedValueOnce({
+      data: null,
+      error: null,
+    });
+
+    const mod = await import("../insforge-auth-client");
+
+    await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
+
+    expect(authMocks.refreshSession).toHaveBeenCalledTimes(1);
+    expect(authStorageMocks.clearSessionSoftExpired).toHaveBeenCalledTimes(1);
+    expect(authStorageMocks.markSessionSoftExpired).not.toHaveBeenCalled();
+    expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
+  });
+
   it("publishes token-manager changes through the session store", async () => {
     const mod = await import("../insforge-auth-client");
     const snapshots: any[] = [];

--- a/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
+++ b/dashboard/src/lib/__tests__/insforge-auth-client.test.ts
@@ -239,6 +239,28 @@ describe("getCurrentInsforgeSession", () => {
     }
   });
 
+  it("keeps soft-expired retry state for temporary refresh token service errors", async () => {
+    const expiredToken = createJwt({ sub: "u12", expiresInMs: -5 * 60 * 1000 });
+    tokenManagerState.session = {
+      accessToken: expiredToken,
+      user: { id: "u12" },
+    };
+    authMocks.refreshSession.mockResolvedValueOnce({
+      data: null,
+      error: {
+        message: "temporary refresh token service outage",
+      },
+    });
+
+    const mod = await import("../insforge-auth-client");
+
+    await expect(mod.getCurrentInsforgeSession()).resolves.toBeNull();
+
+    expect(authStorageMocks.clearSessionSoftExpired).not.toHaveBeenCalled();
+    expect(authStorageMocks.markSessionSoftExpired).toHaveBeenCalledWith(expiredToken);
+    expect(tokenManagerMocks.clearSession).not.toHaveBeenCalled();
+  });
+
   it("clears soft-expired state after a generic auth failure repeats for the same token", async () => {
     const expiredToken = createJwt({ sub: "u11", expiresInMs: -5 * 60 * 1000 });
     tokenManagerState.session = {

--- a/dashboard/src/lib/auth-storage.ts
+++ b/dashboard/src/lib/auth-storage.ts
@@ -179,6 +179,14 @@ export function shouldClearSessionSoftExpiredForToken(accessToken: any) {
   return state.tokenFingerprint !== nextFingerprint;
 }
 
+export function isSessionSoftExpiredForToken(accessToken: any) {
+  const state = loadSessionSoftExpiredState();
+  if (!state) return false;
+  const nextFingerprint = buildTokenFingerprint(accessToken);
+  if (!nextFingerprint || !state.tokenFingerprint) return false;
+  return state.tokenFingerprint === nextFingerprint;
+}
+
 export function subscribeAuthStorage(handler: any) {
   if (typeof window === "undefined" || !window.addEventListener) {
     return () => {};

--- a/dashboard/src/lib/insforge-auth-client.ts
+++ b/dashboard/src/lib/insforge-auth-client.ts
@@ -1,4 +1,5 @@
 import { createInsforgeAuthClient } from "./insforge-client";
+import { markSessionSoftExpired } from "./auth-storage";
 import { isLikelyExpiredAccessToken } from "./auth-token";
 
 export const insforgeAuthClient = createInsforgeAuthClient();
@@ -142,6 +143,7 @@ export async function getCurrentInsforgeSession() {
         }
         return await hydrateCurrentUser(refreshedSession);
       }
+      markSessionSoftExpired(snapshot.accessToken);
       return null;
     }
 

--- a/dashboard/src/lib/insforge-auth-client.ts
+++ b/dashboard/src/lib/insforge-auth-client.ts
@@ -1,5 +1,5 @@
 import { createInsforgeAuthClient } from "./insforge-client";
-import { markSessionSoftExpired } from "./auth-storage";
+import { clearSessionSoftExpired, markSessionSoftExpired } from "./auth-storage";
 import { isLikelyExpiredAccessToken } from "./auth-token";
 
 export const insforgeAuthClient = createInsforgeAuthClient();
@@ -172,7 +172,9 @@ export async function getCurrentInsforgeSession() {
         }
         return await hydrateCurrentUser(refreshedSession);
       }
-      if (!isPermanentRefreshFailure(refreshError)) {
+      if (isPermanentRefreshFailure(refreshError)) {
+        clearSessionSoftExpired();
+      } else {
         markSessionSoftExpired(snapshot.accessToken);
       }
       return null;
@@ -199,7 +201,14 @@ async function refreshInsforgeSessionOutcome() {
   refreshSessionInFlight = (async () => {
     const refreshSession = (insforgeAuthClient as any)?.auth?.refreshSession;
     if (typeof refreshSession !== "function") {
-      return { session: null, error: null };
+      return {
+        session: null,
+        error: {
+          statusCode: 400,
+          code: "REFRESH_SESSION_UNSUPPORTED",
+          message: "refreshSession is not available",
+        },
+      };
     }
     const result = await refreshSession.call((insforgeAuthClient as any).auth);
     const snapshot = buildSessionFromTokenManager();

--- a/dashboard/src/lib/insforge-auth-client.ts
+++ b/dashboard/src/lib/insforge-auth-client.ts
@@ -1,5 +1,9 @@
 import { createInsforgeAuthClient } from "./insforge-client";
-import { clearSessionSoftExpired, markSessionSoftExpired } from "./auth-storage";
+import {
+  clearSessionSoftExpired,
+  isSessionSoftExpiredForToken,
+  markSessionSoftExpired,
+} from "./auth-storage";
 import { isLikelyExpiredAccessToken } from "./auth-token";
 
 export const insforgeAuthClient = createInsforgeAuthClient();
@@ -62,7 +66,12 @@ function getErrorText(error: any) {
     .toLowerCase();
 }
 
-function isPermanentRefreshFailure(error: any) {
+function getErrorStatus(error: any) {
+  const status = error?.statusCode ?? error?.status ?? error?.cause?.statusCode ?? error?.cause?.status;
+  return typeof status === "number" && Number.isFinite(status) ? status : null;
+}
+
+function isExplicitPermanentRefreshFailure(error: any) {
   if (!error) return false;
   const code = typeof error?.code === "string" ? error.code : null;
   if (code === "REFRESH_SESSION_EMPTY" || code === "REFRESH_SESSION_UNSUPPORTED") {
@@ -70,6 +79,13 @@ function isPermanentRefreshFailure(error: any) {
   }
   const text = getErrorText(error);
   return /invalid[_ -]?grant|invalid[_ -]?token|refresh[_ -]?token|revoked/.test(text);
+}
+
+function isGenericAuthRefreshFailure(error: any) {
+  if (!error) return false;
+  const status = getErrorStatus(error);
+  if (status === 401 || status === 403) return true;
+  return /unauthorized|forbidden/.test(getErrorText(error));
 }
 
 function ensureSessionStoreInstalled() {
@@ -167,7 +183,11 @@ export async function getCurrentInsforgeSession() {
         }
         return await hydrateCurrentUser(refreshedSession);
       }
-      if (isPermanentRefreshFailure(refreshError)) {
+      const shouldClearSoftExpired =
+        isExplicitPermanentRefreshFailure(refreshError) ||
+        (isGenericAuthRefreshFailure(refreshError) &&
+          isSessionSoftExpiredForToken(snapshot.accessToken));
+      if (shouldClearSoftExpired) {
         clearSessionSoftExpired();
       } else {
         markSessionSoftExpired(snapshot.accessToken);

--- a/dashboard/src/lib/insforge-auth-client.ts
+++ b/dashboard/src/lib/insforge-auth-client.ts
@@ -216,9 +216,20 @@ async function refreshInsforgeSessionOutcome() {
       return { session: snapshot, error: null };
     }
     const normalized = normalizeSessionResult(result);
+    const resultError = result?.error ?? null;
+    if (!resultError && !hasUsableAccessToken(normalized)) {
+      return {
+        session: null,
+        error: {
+          statusCode: 400,
+          code: "REFRESH_SESSION_EMPTY",
+          message: "refreshSession returned no usable session",
+        },
+      };
+    }
     return {
       session: hasUsableAccessToken(normalized) ? normalized : null,
-      error: result?.error ?? null,
+      error: resultError,
     };
   })()
     .catch((error) => ({ session: null, error }))

--- a/dashboard/src/lib/insforge-auth-client.ts
+++ b/dashboard/src/lib/insforge-auth-client.ts
@@ -69,10 +69,14 @@ function getErrorText(error: any) {
 
 function isPermanentRefreshFailure(error: any) {
   if (!error) return false;
+  const code = typeof error?.code === "string" ? error.code : null;
+  if (code === "REFRESH_SESSION_EMPTY" || code === "REFRESH_SESSION_UNSUPPORTED") {
+    return true;
+  }
   const status = getErrorStatus(error);
-  if (status === 400 || status === 401 || status === 403) return true;
+  if (status === 401) return true;
   const text = getErrorText(error);
-  return /invalid[_ -]?grant|invalid[_ -]?token|refresh[_ -]?token|required|revoked|unauthorized|forbidden/.test(
+  return /invalid[_ -]?grant|invalid[_ -]?token|refresh[_ -]?token|revoked|unauthorized|forbidden/.test(
     text,
   );
 }

--- a/dashboard/src/lib/insforge-auth-client.ts
+++ b/dashboard/src/lib/insforge-auth-client.ts
@@ -78,7 +78,7 @@ function isExplicitPermanentRefreshFailure(error: any) {
     return true;
   }
   const text = getErrorText(error);
-  return /invalid[_ -]?grant|invalid[_ -]?token|refresh[_ -]?token|revoked/.test(text);
+  return /invalid[_ -]?grant|invalid[_ -]?token|revoked/.test(text);
 }
 
 function isGenericAuthRefreshFailure(error: any) {

--- a/dashboard/src/lib/insforge-auth-client.ts
+++ b/dashboard/src/lib/insforge-auth-client.ts
@@ -48,11 +48,6 @@ function hasUsableAccessToken(session: any) {
   return Boolean(accessToken && !isLikelyExpiredAccessToken(accessToken));
 }
 
-function getErrorStatus(error: any) {
-  const status = error?.statusCode ?? error?.status ?? error?.cause?.statusCode ?? error?.cause?.status;
-  return typeof status === "number" && Number.isFinite(status) ? status : null;
-}
-
 function getErrorText(error: any) {
   return [
     error?.error,
@@ -73,12 +68,8 @@ function isPermanentRefreshFailure(error: any) {
   if (code === "REFRESH_SESSION_EMPTY" || code === "REFRESH_SESSION_UNSUPPORTED") {
     return true;
   }
-  const status = getErrorStatus(error);
-  if (status === 401) return true;
   const text = getErrorText(error);
-  return /invalid[_ -]?grant|invalid[_ -]?token|refresh[_ -]?token|revoked|unauthorized|forbidden/.test(
-    text,
-  );
+  return /invalid[_ -]?grant|invalid[_ -]?token|refresh[_ -]?token|revoked/.test(text);
 }
 
 function ensureSessionStoreInstalled() {

--- a/dashboard/src/lib/insforge-auth-client.ts
+++ b/dashboard/src/lib/insforge-auth-client.ts
@@ -84,7 +84,7 @@ function isExplicitPermanentRefreshFailure(error: any) {
 function isGenericAuthRefreshFailure(error: any) {
   if (!error) return false;
   const status = getErrorStatus(error);
-  if (status === 401 || status === 403) return true;
+  if (status === 400 || status === 401 || status === 403) return true;
   return /unauthorized|forbidden/.test(getErrorText(error));
 }
 

--- a/dashboard/src/lib/insforge-auth-client.ts
+++ b/dashboard/src/lib/insforge-auth-client.ts
@@ -5,7 +5,7 @@ import { isLikelyExpiredAccessToken } from "./auth-token";
 export const insforgeAuthClient = createInsforgeAuthClient();
 
 let currentSessionInFlight: Promise<any> | null = null;
-let refreshSessionInFlight: Promise<any> | null = null;
+let refreshSessionInFlight: Promise<{ session: any; error: any }> | null = null;
 let currentSessionSnapshot: any = undefined;
 const sessionListeners = new Set<() => void>();
 
@@ -46,6 +46,35 @@ function buildSessionFromTokenManager() {
 function hasUsableAccessToken(session: any) {
   const accessToken = session?.accessToken ?? null;
   return Boolean(accessToken && !isLikelyExpiredAccessToken(accessToken));
+}
+
+function getErrorStatus(error: any) {
+  const status = error?.statusCode ?? error?.status ?? error?.cause?.statusCode ?? error?.cause?.status;
+  return typeof status === "number" && Number.isFinite(status) ? status : null;
+}
+
+function getErrorText(error: any) {
+  return [
+    error?.error,
+    error?.code,
+    error?.message,
+    error?.cause?.error,
+    error?.cause?.code,
+    error?.cause?.message,
+  ]
+    .filter((value) => typeof value === "string" && value.trim())
+    .join(" ")
+    .toLowerCase();
+}
+
+function isPermanentRefreshFailure(error: any) {
+  if (!error) return false;
+  const status = getErrorStatus(error);
+  if (status === 400 || status === 401 || status === 403) return true;
+  const text = getErrorText(error);
+  return /invalid[_ -]?grant|invalid[_ -]?token|refresh[_ -]?token|required|revoked|unauthorized|forbidden/.test(
+    text,
+  );
 }
 
 function ensureSessionStoreInstalled() {
@@ -136,14 +165,16 @@ export async function getCurrentInsforgeSession() {
     }
 
     if (snapshot?.accessToken && isLikelyExpiredAccessToken(snapshot.accessToken)) {
-      const refreshedSession = await refreshInsforgeSession();
+      const { session: refreshedSession, error: refreshError } = await refreshInsforgeSessionOutcome();
       if (hasUsableAccessToken(refreshedSession)) {
         if (refreshedSession?.user) {
           return refreshedSession;
         }
         return await hydrateCurrentUser(refreshedSession);
       }
-      markSessionSoftExpired(snapshot.accessToken);
+      if (!isPermanentRefreshFailure(refreshError)) {
+        markSessionSoftExpired(snapshot.accessToken);
+      }
       return null;
     }
 
@@ -158,22 +189,30 @@ export async function getCurrentInsforgeSession() {
 }
 
 export async function refreshInsforgeSession() {
+  const { session } = await refreshInsforgeSessionOutcome();
+  return session;
+}
+
+async function refreshInsforgeSessionOutcome() {
   ensureSessionStoreInstalled();
   if (refreshSessionInFlight) return refreshSessionInFlight;
   refreshSessionInFlight = (async () => {
     const refreshSession = (insforgeAuthClient as any)?.auth?.refreshSession;
     if (typeof refreshSession !== "function") {
-      return null;
+      return { session: null, error: null };
     }
     const result = await refreshSession.call((insforgeAuthClient as any).auth);
     const snapshot = buildSessionFromTokenManager();
     if (hasUsableAccessToken(snapshot)) {
-      return snapshot;
+      return { session: snapshot, error: null };
     }
     const normalized = normalizeSessionResult(result);
-    return hasUsableAccessToken(normalized) ? normalized : null;
+    return {
+      session: hasUsableAccessToken(normalized) ? normalized : null,
+      error: result?.error ?? null,
+    };
   })()
-    .catch(() => null)
+    .catch((error) => ({ session: null, error }))
     .finally(() => {
       emitSessionSnapshot();
       refreshSessionInFlight = null;

--- a/test/dashboard-session-expired-banner.test.js
+++ b/test/dashboard-session-expired-banner.test.js
@@ -338,3 +338,9 @@ test("App clears soft-expired state after a different token or successful same-t
   assert.match(src, /shouldClearSessionSoftExpiredForToken\(nextToken\)/);
   assert.match(src, /await probeBackend\(\{ baseUrl, accessToken: nextToken \}\)/);
 });
+
+test("App preserves soft-expired state when an expired restored token can still retry", () => {
+  const src = read("dashboard/src/App.jsx");
+  assert.match(src, /if \(insforgeSession\?\.accessToken\) return;/);
+  assert.match(src, /if \(sessionSoftExpired\) return;/);
+});

--- a/test/dashboard-session-expired-banner.test.js
+++ b/test/dashboard-session-expired-banner.test.js
@@ -161,6 +161,7 @@ test("App clears stale InsForge storage after hosted auth resolves signed out", 
   const src = read("dashboard/src/App.jsx");
   assert.match(src, /if \(!insforgeLoaded\) return;/);
   assert.match(src, /if \(hasInsforgeSession\) return;/);
+  assert.match(src, /if \(sessionSoftExpired\) return;/);
   assert.match(src, /clearInsforgePersistentStorage\(\)/);
   assert.match(src, /clearAuthStorage\(\)/);
   assert.match(src, /clearSessionExpired\(\)/);


### PR DESCRIPTION
# What does this PR do?

- Fixes the web dashboard auth recovery path when a restored InsForge session has an expired access token and refresh fails transiently.
- Preserves the persisted InsForge session during soft-expired recovery so a later page refresh, focus, or visibility revalidation can retry instead of forcing a fresh login.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / workflow
- [ ] Risk / contract change

## Changes Made

- Mark expired restored sessions as soft-expired when `refreshSession()` cannot recover immediately.
- Prevent `App.jsx` from clearing persisted InsForge auth storage while the app is in the soft-expired recovery state.
- Add regression coverage for the failed-refresh path and update the existing session-expired guardrail test.

## Affected Modules / Contracts

- **Modules touched:** `dashboard/src/lib/insforge-auth-client.ts`, `dashboard/src/App.jsx`, auth/session tests
- **Dependencies / contracts touched:** Dashboard hosted-auth session restore behavior; no external API response contract changes
- **Repo sitemap evidence:** `not required` - local session recovery behavior only; no module boundary, public interface, or data-flow ownership change

## Validation

### Automated

- `npm --prefix dashboard run test -- src/lib/__tests__/insforge-auth-client.test.ts --run`
- `node --test test/dashboard-session-expired-banner.test.js`
- `npm --prefix dashboard run typecheck`
- `npm --prefix dashboard run build`
- `npm run ci:local`

### Manual / smoke

- Not run. This change is covered by the targeted failed-refresh regression and full local CI gate.

### Uncovered scope

- Live browser OAuth cookie expiry timing was not manually forced against production.

## Risk Flags

- [ ] Public exposure / share links / unauthenticated access
- [x] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Addendum (required if any risk flag is checked)

### Rules / Invariants

- A missing session after InsForge has resolved signed-out state may clear persisted auth storage.
- A soft-expired session is still a recovery state and must not clear persisted InsForge session storage.
- A failed refresh for an expired restored token should not call `tokenManager.clearSession()` from repository code.

### Boundary Matrix (must list at least 3)

- Expired restored token + refresh succeeds: return refreshed session and keep signed-in flow.
- Expired restored token + refresh fails: mark soft-expired, preserve persisted session, show recovery UI.
- No token after auth resolution and not soft-expired: clear stale auth storage and route signed-out.
- Different valid token after soft-expired state: clear soft-expired marker through existing token fingerprint logic.

### Evidence

- Regression test asserts failed refresh marks soft-expired and does not clear token manager session.
- Existing guardrail asserts `App.jsx` preserves auth while soft-expired.
- `npm run ci:local` passes.

## Public Exposure Addendum (required if public exposure is checked)

- **Access rules:** N/A
- **Exposed fields:** N/A
- **Avatar / image policy:** N/A
- **Regression coverage:** N/A

## Reviewer Context (optional)

- **Review focus:** Confirm the soft-expired state is the right boundary for preserving persisted InsForge auth storage after transient refresh failure.
- **Delta since last review:** New branch from current `main`; one auth-session fix commit.
- **Depends on:** None.
- **Known gaps / follow-ups:** No manual production cookie-expiry smoke in this PR.

## Screenshots / Logs (optional)

- Local `ci:local` completed successfully.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix web auth refresh fallback to preserve soft-expired state during transient failures
> - Introduces token-fingerprinted soft-expiry tracking via `isSessionSoftExpiredForToken` in [auth-storage.ts](https://github.com/victorGPT/vibeusage/pull/200/files#diff-3c899082bc2c50d3ef368fc74850159fd02210b0a71e91c272bd210b95df2891), so soft-expired state is tied to a specific access token rather than being a global flag.
> - Refactors `getCurrentInsforgeSession` in [insforge-auth-client.ts](https://github.com/victorGPT/vibeusage/pull/200/files#diff-f9cbf3552b386894364fbc4da858ac89b40c294c97c4588dc390891256e0506f) to distinguish transient failures (marks token soft-expired) from permanent ones (clears soft-expired state), and repeated generic failures for the same token also clear the state.
> - Guards in [App.jsx](https://github.com/victorGPT/vibeusage/pull/200/files#diff-e58ba19e1cbb6e9d590e6b0ad766ebe7661a30f9d476d61cc384e4c25f038452) prevent clearing soft-expired state or persisted auth storage while a session token is present or while `sessionSoftExpired` is still true, avoiding premature sign-out during retryable refresh failures.
> - Behavioral Change: expired sessions that previously caused storage to be wiped on any refresh error will now retain soft-expired state across retries until a permanent or repeated failure is detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1dffd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->